### PR TITLE
Forward MongoDB port to the host machine

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -103,6 +103,8 @@ services:
 
     mongodb:
         build: ./mongo
+        ports:
+            - "27017:27017"
         volumes:
             - mongodb:/data/db
 


### PR DESCRIPTION
To have the ability to use 'localhost:27017' instead of '172.18.0.2:27017' (or something like that) to connect to MongoDB.