### PR TITLE
Update vagrantfile to current status of docker composer

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,20 +22,12 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder "./oms-core",              "/home/vagrant/oms-docker/oms-core"
   config.vm.synced_folder "./oms-events",              "/home/vagrant/oms-docker/oms-events"
   config.vm.synced_folder "./oms-events-frontend",              "/home/vagrant/oms-docker/oms-events-frontend"
-  config.vm.synced_folder "./oms-serviceregistry",              "/home/vagrant/oms-docker/oms-serviceregistry"
-  config.vm.synced_folder "./oms-applications",              "/home/vagrant/oms-docker/oms-applications"
-  config.vm.synced_folder "./oms-applications-frontend",              "/home/vagrant/oms-docker/oms-applications-frontend"
   config.vm.synced_folder "./docker",              "/home/vagrant/oms-docker/docker"
 
   config.vm.provision "docker" do |d|
-    d.pull_images "laradock/php-fpm:7.0--1.2"
-    d.pull_images "laradock/workspace:1.2"
     d.pull_images "tianon/true"
     d.pull_images "postgres:latest"
-    d.pull_images "fenglc/pgadmin4"
-    d.pull_images "node:7"
-    d.pull_images "nginx:alpine"
-    d.pull_images "mongo:latest"
+    d.pull_images "fenglc/pgadmin4:1.6"
     #d.build_image "/vagrant/app"
   end
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -5,15 +5,10 @@ default:
 start:  
 	export COMPOSE_PROJECT_NAME=myaegee && sudo docker-compose up -d
   
-bootstrap: start monitor
-
-monitor:
-	sudo docker-compose logs -f omscore-bootstrap && sudo docker-compose logs -f omsevents-bootstrap
-
 stop:  
 	sudo docker-compose down
   
-restart: stop bootstrap
+restart: stop start
 
 nuke:  
 	sudo docker-compose down -v

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -80,7 +80,7 @@ services:
 ### pgAdmin Container #######################################
 
     pgadmin:
-        image: fenglc/pgadmin4
+        image: fenglc/pgadmin4:1.6
         ports:
             - "8081:5050"
         links:

--- a/vagrant-post-script/orchestrate_docker.sh
+++ b/vagrant-post-script/orchestrate_docker.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd oms-docker/docker
-make bootstrap
+make start


### PR DESCRIPTION
The vagrant vm is set to the new status of docker-compose file (no folders for services which aren't there)

to test,
 1. `git clone --recursive <repo>`
 2. `cd oms-docker`
 3. `vagrant up`