### PR TITLE
Add script for automatic deployment on cron job

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,6 @@ PATH_OMS_LOGO_PRINT=oms-logo-print/docker/
 
 
 # To enable services, add them to the array, like
-ENABLED_SERVICES=oms-global:oms-core:oms-serviceregistry:oms-events-frontend:oms-events:alastair:oms-logo-print
+#ENABLED_SERVICES=oms-global:oms-core:oms-serviceregistry:oms-events-frontend:oms-events:alastair:oms-logo-print
+#Warning! the above is commented out because it becomes memory-heavy with the constraint of 1GB of Vagrant. Until we will know that our future server can have 2GB memory, the cap stays at 1GB. 
+ENABLED_SERVICES=oms-global:oms-core:oms-logo-print

--- a/README.md
+++ b/README.md
@@ -54,3 +54,27 @@ For container-specific usage guides see the container's repository.
 
 ## Licence
 Apache License 2.0, see LICENSE.txt for more information.
+
+## Ports registered on traefik
+| Port | What | Container |
+|---|---|---|
+| 80,443 | standard entrypoint | traefik |
+| 5432 | not registered | postgres |
+
+## Deployment script
+The types of deployment:
+-local (docker/vagrant), with default silly Passwords
+-local (docker/vagrant), with hardened passwords
+-remote, with a zero-downtime upgrade
+-remote, with a complete wipe (major overhauls)
+
+a script is provided for you (deploy.sh), in which you can specify the target (deploy.sh --target=local)
+
+### TESTS to perform for the deploy script
+OK fresh install (problema di permission denied per modificare .env -solved with sudo)
+- refresh
+- nuke (problema di permission denied per rimuovere node modules e vendor php -solved with sudo) 
+- through provision script
+
+
+- base docker compose is needed because it is the "base" to get the relative path of all the future docker compose files

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,36 +1,98 @@
 #!/bin/bash
 
-# Move this file 1 level above the oms-docker installation!
+# MANUAL INTERVENTION NEEDED:
+#   This file MUST be 1 level above the oms-docker installation!
+
+#This script assumes that it is run on a production server. It is meant to be safe for cron updates
+# NOTE: to change passwords through the script, one must do a HARD reset (a new install or a nuke is what takes the password script to run). The script will error if passwords are not set properly
+
+#STEP 1 check if we have to make a new setup (first time/nuke) or an update (default: assumes non-destructive update, rolls back to the first time - never nukes unless specified)
+#STEP 2 run password script (if new deployment)
+#STEP 3 application will be deployed
+
+#read params to understand (default:non-destructive)
+fresh="false"
+nuke="false"
+error="false"
+if [ $# -eq 1 ]; then
+  if [ "$1" == "--fresh" ]; then
+    fresh="true"
+  else
+    if [ "$1" == "--nuke" ]; then
+      fresh="true"
+      nuke="true"
+    else
+      error="true"
+    fi
+  fi
+else
+  if [ ! $# -eq 0 ]; then
+    error="true"
+  fi
+fi
+
+if [ "$error" == "true" ]; then
+  echo -e "usage: deploy.sh [--fresh|--nuke]"
+  exit 8
+fi
+
+EDITOR=$(env | grep EDITOR | grep -oe '[^=]*$');
+if [ -z "$EDITOR" ]; then
+  export EDITOR="nano"
+fi
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-echo -e "###\n### Deploying OMS...\n###"
-if [ $(grep ADMIN_PASSWORD $DIR/oms-core.env) == "ADMIN_PASSWORD=admin" ]; then
-  echo "ERROR: Please do not use the default ADMIN_PASSWORD in ./oms-core.env"
-  exit 9
-fi
-bash $DIR/oms-docker/oms.sh down -v
-rm -Rf oms-docker
-docker stop $(docker ps -aq)
-docker rm -f $(docker ps -aq)
-docker rmi -f $(docker images -a)
-echo -e "\nFinished cleanup\n"
-
-git clone --recursive --branch master https://github.com/AEGEE/oms-docker.git
-cp $DIR/oms-core.env $DIR/oms-docker/oms-core/.env.example
-echo -e "\nFinished setting up files\n"
-
-if [[ -f "$DIR/oms-docker/oms-core/storage/key" ]]; then
-    echo -e "WARNING: The application key is already set, security compromised!"
-    echo -e "WARNING: The application key is already set, security compromised!"
-    echo -e "WARNING: The application key is already set, security compromised!"
-    echo -e "WARNING: The application key is already set, security compromised!"
-    echo -e "WARNING: The application key is already set, security compromised!"
-    echo -e "WARNING: The application key is already set, security compromised!"
-    echo -e "WARNING: The application key is already set, security compromised!"
+#DEBUG echo
+echo 'the directory is ${DIR} and bash source is ${BASH_SOURCE[0]} and the wtf is $( dirname "${BASH_SOURCE[0]}" )'
+#assuming i am in /opt/MyAEGEE
+if [ "$fresh" == "true" ]; then
+  echo -e "\n[Deployment] Nuking installation (removing .env = $nuke )\n"
+  bash $DIR/oms-docker/oms.sh down -v
+  cp $DIR/oms-docker/.env .env
+  rm -Rf $DIR/oms-docker
+  if [ "$nuke" == "true" ]; then
+    echo -e "\n[Deployment] Removing .env\n"
+    rm .env
+  fi
 fi
 
-bash $DIR/oms-docker/oms.sh up -d
-echo -e "\nInitializing..."
-echo -e "This might take a while"
-sleep 5
-echo -e "Use 'bash ./oms-docker/oms.sh logs -f' to show the log"
+if [ -f oms-docker/.env ]; then
+  echo -e "\n[Deployment] Updating installation\n"
+  cd oms-docker/
+  git pull
+  git submodule init
+  git submodule update
+  echo -e "\n[Deployment] Update performed, restarting containers\n"
+  mv ../.env $DIR/oms-docker/.env 
+  bash $DIR/oms-docker/oms.sh up -d
+else
+  echo -e "\n[Deployment] New installation\n"
+  echo -e "\n[Deployment] Cloning repo (output suppressed)\n"
+  git clone --recursive --branch feat-autodeploy https://github.com/AEGEE/oms-docker.git 1>/dev/null 2>&1
+  cp $DIR/oms-docker/.env.example $DIR/oms-docker/.env
+  #Ask if one wants to tweak the .env before starting it up
+  echo "Do you wish to edit .env file? (write the number)"
+  select yn in "Yes" "No"; do
+    case $yn in
+        Yes ) cp oms-docker/.env.example oms-docker/.env; sudo $EDITOR oms-docker/.env; break;;
+        No ) break;;
+    esac
+  done
+  echo -e "\n[Deployment] Setting passwords\n"
+  bash $DIR/oms-docker/password-setter.sh
+  if [[ -f "$DIR/oms-docker/oms-core/storage/key" ]]; then
+    echo -e "WARNING: The application key is already set, security compromised!"
+    echo -e "WARNING: The application key is already set, security compromised!"
+    echo -e "WARNING: The application key is already set, security compromised!"
+    echo -e "WARNING: The application key is already set, security compromised!"
+    echo -e "WARNING: The application key is already set, security compromised!"
+    echo -e "WARNING: The application key is already set, security compromised!"
+    echo -e "WARNING: The application key is already set, security compromised!"
+  fi
+  echo -e "\n[Deployment] Deploying (This could take a while)\n"
+  cd $DIR/oms-docker
+  bash oms.sh up -d
+  sleep 5
+  echo -e "\n[Deployment] Showing logs, feel free to cancel with ctrl+c (server keeps running anyway)\n"
+  bash $DIR/oms-docker/oms.sh logs -f
+fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,10 +3,11 @@
 # MANUAL INTERVENTION NEEDED:
 #   This file MUST be 1 level above the oms-docker installation!
 
+folderName="oms-docker" #could also be MyAEGEE or whatever e.g. /opt/MyAEGEE
+
 #This script assumes that it is run on a production server. It is meant to be safe for cron updates
 # NOTE: to change passwords through the script, one must do a HARD reset (a new install or a nuke is what takes the password script to run). The script will error if passwords are not set properly
 
-#TODO: who is the user launching it? check sudos
 
 #STEP 1 check if we have to make a new setup (first time/nuke) or an update (default: assumes non-destructive update, rolls back to the first time - never nukes unless specified)
 #STEP 2 run password script (if new deployment)
@@ -47,23 +48,28 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 #DEBUG echo
 echo -e "\n the directory is ${DIR} and bash source is ${BASH_SOURCE[0]} and the wtf is $( dirname '${BASH_SOURCE[0]}' )"
 
-#assuming i am in /opt/MyAEGEE
+#FRESH/NUKE: nuke installation (bring it down and up again without volumes)
+# nuke is just removing .env and using the repo one
 if [ "$fresh" == "true" ]; then
   echo -e "\n[Deployment] Nuking installation (removing .env = $nuke )\n"
   bash $DIR/oms-docker/oms.sh down -v 
   #ONLY FOR DEv
   bash $DIR/oms-docker/oms.sh down -v --remove-orphans
   #END ONLY FOR DEV
-  sudo cp $DIR/oms-docker/.env $DIR/.env #NOTE check how many times/why i copy .env outside the folder
-  sudo rm -Rf $DIR/oms-docker/
-  sudo mkdir $DIR/oms-docker/
-  sudo chown grasshopper:grasshopper $DIR/oms-docker/
+  cp $DIR/oms-docker/.env $DIR/.env #NOTE check how many times/why i copy .env outside the folder
+  rm -Rf $DIR/oms-docker/
+  mkdir $DIR/oms-docker/
+  #DEV only for me to mess around
+  chown -R grasshopper:grasshopper $DIR/oms-docker/
+  #END DEV for me to mess around
   if [ "$nuke" == "true" ]; then
     echo -e "\n[Deployment] Removing .env\n"
-    sudo rm .env
+    rm .env
   fi
 fi
 
+#BRINGING IT UP: if there is a .env file it's an update
+# otherwise it's a fresh setup
 if [ -f ./oms-docker/.env ]; then
   echo -e "\n[Deployment] Updating installation\n"
   
@@ -77,7 +83,7 @@ if [ -f ./oms-docker/.env ]; then
   rsync -hrPt --include=.git --exclude=node_modules/ --delete /opt/masterRepo/ /opt/oms-docker
    
   echo -e "\n[Deployment] Update performed, restarting containers\n"
-  sudo mv /opt/.env $DIR/oms-docker/.env #NOTE useless basically (but see above anyway)
+  mv /opt/.env $DIR/oms-docker/.env #NOTE useless basically (but see above anyway)
   bash $DIR/oms-docker/oms.sh up -d
 else
   echo -e "\n[Deployment] New installation\n"
@@ -87,17 +93,23 @@ else
   #DEVELOPMENT: a copy from filesystem (from an up-to-date, manually edited repo)
   rsync -hrPt --include=.git --exclude=node_modules/ --delete /opt/masterRepo/ /opt/oms-docker
   
-  sudo chown -R grasshopper:grasshopper /opt/oms-docker #NOTE user?
+  #DEV only for me to mess around
+  chown -R grasshopper:grasshopper /opt/oms-docker #NOTE user?
+  #END DEV only for me to mess around
+
   cp $DIR/oms-docker/.env.example $DIR/oms-docker/.env
-  sudo cp $DIR/oms-docker/.env $DIR/.env
-  #Ask if one wants to tweak the .env before starting it up
-  echo "Do you wish to edit .env file? (write the number)"
-  select yn in "Yes" "No"; do
-    case $yn in
-        Yes ) $EDITOR oms-docker/.env; break;;
-        No ) break;;
-    esac
-  done
+  cp $DIR/oms-docker/.env $DIR/.env
+  
+  if [ ! $RUN_BY_CRON ]; then
+    #Ask if one wants to tweak the .env before starting it up
+    echo "Do you wish to edit .env file? (write the number)"
+    select yn in "Yes" "No"; do
+      case $yn in
+          Yes ) $EDITOR oms-docker/.env; break;;
+          No ) break;;
+      esac
+    done
+  fi
   echo -e "\n[Deployment] Setting passwords\n"
   bash $DIR/oms-docker/password-setter.sh
   if [[ -f "$DIR/oms-docker/oms-core/storage/key" ]]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # MANUAL INTERVENTION NEEDED:
-#   This file MUST be 1 level above the oms-docker installation!
+#   This file MUST be 1 level above the (folderName) installation!
 
-folderName="MyAEGEE" #could also be MyAEGEE or whatever e.g. /opt/MyAEGEE
+folderName="MyAEGEE" #could be oms-docker, but also be MyAEGEE or whatever e.g. /opt/MyAEGEE
 OMS_GITBRANCH="dev"
 
 #This script assumes that it is run on a production server. It is meant to be safe for cron updates
@@ -61,9 +61,9 @@ if [ "$fresh" == "true" ]; then
   bash $DIR/$folderName/oms.sh down -v 
   if [ $RUN_BY_CRON ]; then
     #ONLY FOR Test server
-    bash $DIR/oms-docker/oms.sh down -v --remove-orphans
+    bash $DIR/$folderName/oms.sh down -v --remove-orphans
   fi
-  cp $DIR/oms-docker/.env $DIR/.env 
+  cp $DIR/$folderName/.env $DIR/.env 
   if [ "$nuke" == "true" ]; then
     echo -e "\n[Deployment] Removing .env (nuking)\n"
     rm $DIR/.env
@@ -72,16 +72,16 @@ fi
 
 #BRINGING IT UP: if there is a .env file it's an update
 # otherwise it's a fresh setup
-if [ -f $DIR/oms-docker/.env ]; then
+if [ -f $DIR/$folderName/.env ]; then
   echo -e "\n[Deployment] Updating installation\n"
   
-  cd $DIR/oms-docker/
+  cd $DIR/$folderName/
   git pull
   git submodule init
   git submodule update
    
   echo -e "\n[Deployment] Update performed, restarting containers\n"
-  bash $DIR/oms-docker/oms.sh up -d
+  bash $DIR/$folderName/oms.sh up -d
 else
   echo -e "\n[Deployment] New installation\n"
   echo -e "\n[Deployment] Cloning repo (normal output suppressed)\n"
@@ -100,15 +100,15 @@ else
     echo "Do you wish to edit .env file? (write the number)"
     select yn in "Yes" "No"; do
       case $yn in
-          Yes ) $EDITOR oms-docker/.env; break;;
+          Yes ) $EDITOR $folderName/.env; break;;
           No ) break;;
       esac
     done
   fi
   echo -e "\n[Deployment] Setting passwords\n"
-  bash $DIR/oms-docker/password-setter.sh
+  bash $DIR/$folderName/password-setter.sh
   echo -e "\n[Deployment] Deploying (This could take a while)\n"
-  bash $DIR/oms-docker/oms.sh up -d
+  bash $DIR/$folderName/oms.sh up -d
   sleep 10
   if [ ! $RUN_BY_CRON ]; then
     echo -e "\n[Deployment] Showing logs, feel free to cancel with ctrl+c (server keeps running anyway)\n"

--- a/deploy.sh
+++ b/deploy.sh
@@ -50,12 +50,17 @@ echo -e "\n the directory is ${DIR} and bash source is ${BASH_SOURCE[0]} and the
 #assuming i am in /opt/MyAEGEE
 if [ "$fresh" == "true" ]; then
   echo -e "\n[Deployment] Nuking installation (removing .env = $nuke )\n"
-  bash $DIR/oms-docker/oms.sh down -v
-  cp $DIR/oms-docker/.env .env
-  rm -Rf $DIR/oms-docker
+  bash $DIR/oms-docker/oms.sh down -v 
+  #ONLY FOR DEv
+  bash $DIR/oms-docker/oms.sh down -v --remove-orphans
+  #END ONLY FOR DEV
+  sudo cp $DIR/oms-docker/.env $DIR/.env #NOTE check how many times/why i copy .env outside the folder
+  sudo rm -Rf $DIR/oms-docker/
+  sudo mkdir $DIR/oms-docker/
+  sudo chown grasshopper:grasshopper $DIR/oms-docker/
   if [ "$nuke" == "true" ]; then
     echo -e "\n[Deployment] Removing .env\n"
-    rm .env
+    sudo rm .env
   fi
 fi
 
@@ -72,7 +77,7 @@ if [ -f ./oms-docker/.env ]; then
   rsync -hrPt --include=.git --exclude=node_modules/ --delete /opt/masterRepo/ /opt/oms-docker
    
   echo -e "\n[Deployment] Update performed, restarting containers\n"
-  mv ../.env $DIR/oms-docker/.env 
+  sudo mv /opt/.env $DIR/oms-docker/.env #NOTE useless basically (but see above anyway)
   bash $DIR/oms-docker/oms.sh up -d
 else
   echo -e "\n[Deployment] New installation\n"
@@ -80,11 +85,11 @@ else
   #PRODUCTION: a git clone
   #git clone --recursive --branch feat-autodeploy https://github.com/AEGEE/oms-docker.git 1>/dev/null
   #DEVELOPMENT: a copy from filesystem (from an up-to-date, manually edited repo)
-  sudo cp -R /opt/masterRepo /opt/oms-docker
+  rsync -hrPt --include=.git --exclude=node_modules/ --delete /opt/masterRepo/ /opt/oms-docker
   
   sudo chown -R grasshopper:grasshopper /opt/oms-docker #NOTE user?
   cp $DIR/oms-docker/.env.example $DIR/oms-docker/.env
-  cp $DIR/oms-docker/.env $DIR/.env
+  sudo cp $DIR/oms-docker/.env $DIR/.env
   #Ask if one wants to tweak the .env before starting it up
   echo "Do you wish to edit .env file? (write the number)"
   select yn in "Yes" "No"; do

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,6 +6,8 @@
 #This script assumes that it is run on a production server. It is meant to be safe for cron updates
 # NOTE: to change passwords through the script, one must do a HARD reset (a new install or a nuke is what takes the password script to run). The script will error if passwords are not set properly
 
+#TODO: who is the user launching it? check sudos
+
 #STEP 1 check if we have to make a new setup (first time/nuke) or an update (default: assumes non-destructive update, rolls back to the first time - never nukes unless specified)
 #STEP 2 run password script (if new deployment)
 #STEP 3 application will be deployed
@@ -38,12 +40,13 @@ fi
 
 EDITOR=$(env | grep EDITOR | grep -oe '[^=]*$');
 if [ -z "$EDITOR" ]; then
-  export EDITOR="nano"
+  export EDITOR="vim";
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 #DEBUG echo
-echo 'the directory is ${DIR} and bash source is ${BASH_SOURCE[0]} and the wtf is $( dirname "${BASH_SOURCE[0]}" )'
+echo -e "\n the directory is ${DIR} and bash source is ${BASH_SOURCE[0]} and the wtf is $( dirname '${BASH_SOURCE[0]}' )"
+
 #assuming i am in /opt/MyAEGEE
 if [ "$fresh" == "true" ]; then
   echo -e "\n[Deployment] Nuking installation (removing .env = $nuke )\n"
@@ -56,25 +59,37 @@ if [ "$fresh" == "true" ]; then
   fi
 fi
 
-if [ -f oms-docker/.env ]; then
+if [ -f ./oms-docker/.env ]; then
   echo -e "\n[Deployment] Updating installation\n"
-  cd oms-docker/
-  git pull
-  git submodule init
-  git submodule update
+  
+  #cd oms-docker/
+  pwd #REMOVEE
+  #PROD: git pull
+  #git pull
+  #git submodule init
+  #git submodule update
+  #DEV: rsync from /opt/masterRepo
+  rsync -hrPt --include=.git --exclude=node_modules/ --delete /opt/masterRepo/ /opt/oms-docker
+   
   echo -e "\n[Deployment] Update performed, restarting containers\n"
   mv ../.env $DIR/oms-docker/.env 
   bash $DIR/oms-docker/oms.sh up -d
 else
   echo -e "\n[Deployment] New installation\n"
-  echo -e "\n[Deployment] Cloning repo (output suppressed)\n"
-  git clone --recursive --branch feat-autodeploy https://github.com/AEGEE/oms-docker.git 1>/dev/null 2>&1
+  echo -e "\n[Deployment] Cloning repo (normal output suppressed)\n"
+  #PRODUCTION: a git clone
+  #git clone --recursive --branch feat-autodeploy https://github.com/AEGEE/oms-docker.git 1>/dev/null
+  #DEVELOPMENT: a copy from filesystem (from an up-to-date, manually edited repo)
+  sudo cp -R /opt/masterRepo /opt/oms-docker
+  
+  sudo chown -R grasshopper:grasshopper /opt/oms-docker #NOTE user?
   cp $DIR/oms-docker/.env.example $DIR/oms-docker/.env
+  cp $DIR/oms-docker/.env $DIR/.env
   #Ask if one wants to tweak the .env before starting it up
   echo "Do you wish to edit .env file? (write the number)"
   select yn in "Yes" "No"; do
     case $yn in
-        Yes ) cp oms-docker/.env.example oms-docker/.env; sudo $EDITOR oms-docker/.env; break;;
+        Yes ) $EDITOR oms-docker/.env; break;;
         No ) break;;
     esac
   done

--- a/oms.sh
+++ b/oms.sh
@@ -10,7 +10,7 @@ if ! [[ -f "$DIR/.env" ]]; then
     cp $DIR/.env.example $DIR/.env
 fi
 
-docker network inspect OMS &>/dev/null || (echo -e "[OMS] Creating OMS docker network" && docker network create OMS)
+sudo docker network inspect OMS &>/dev/null || (echo -e "[OMS] Creating OMS docker network" && sudo docker network create OMS)
 
 
 # HUMAN INTERVENTION NEEDED: register in .env your services
@@ -22,7 +22,7 @@ service_string=$(printenv ENABLED_SERVICES)
 ## Split services into array
 services=(${service_string//:/ })
 
-command="docker-compose -f $DIR/base-docker-compose.yml"
+command="sudo docker-compose -f $DIR/base-docker-compose.yml"
 for s in "${services[@]}"; do
     if [[ -f "$DIR/${s}/docker/docker-compose.yml" ]]; then
         command="${command} -f $DIR/${s}/docker/docker-compose.yml"

--- a/oms.sh
+++ b/oms.sh
@@ -27,7 +27,7 @@ for s in "${services[@]}"; do
     if [[ -f "$DIR/${s}/docker/docker-compose.yml" ]]; then
         command="${command} -f $DIR/${s}/docker/docker-compose.yml"
     else
-        echo -e "[OMS] WARNING: No docker file found for ${s}"
+        echo -e "[OMS] WARNING: No docker file found for ${s} (full path $DIR/${s}/docker/docker-compose.yml)"
     fi
 done
 

--- a/oms.sh
+++ b/oms.sh
@@ -10,11 +10,11 @@ if ! [[ -f "$DIR/.env" ]]; then
     cp $DIR/.env.example $DIR/.env
 fi
 
-sudo docker network inspect OMS &>/dev/null || (echo -e "[OMS] Creating OMS docker network" && sudo docker network create OMS)
+docker network inspect OMS &>/dev/null || (echo -e "[OMS] Creating OMS docker network" && docker network create OMS)
 
 # HUMAN INTERVENTION NEEDED: register in .env your services
 ## Export all environment variables from .env to this script in case we need them some time
-export $(cat .env | grep -v ^# | xargs)
+export $(cat $DIR/.env | grep -v ^# | xargs)
 
 ## Create secrets
 echo -e "[OMS] Creating random secrets if not existing"
@@ -43,7 +43,7 @@ service_string=$(printenv ENABLED_SERVICES)
 ## Split services into array
 services=(${service_string//:/ })
 
-command="sudo docker-compose -f $DIR/base-docker-compose.yml"
+command="docker-compose -f $DIR/base-docker-compose.yml"
 for s in "${services[@]}"; do
     if [[ -f "$DIR/${s}/docker/docker-compose.yml" ]]; then
         command="${command} -f $DIR/${s}/docker/docker-compose.yml"

--- a/password-setter.sh
+++ b/password-setter.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#quit silently if no file to change
+if [ ! -f oms-docker/.env ]; then
+  #echo "[Password setter] no .env file, quitting"
+  exit 0
+fi
+
+#check if we should NOT be strict (default: strict, to enforce secure policy)
+strict="true"
+if [ $# -eq 2 ]; then
+  if [ "$1" == "--loose" ]; then
+    $strict="false"
+  fi
+else
+  echo -e "Usage: password-setter.sh [--loose], assuming strict"
+fi
+#strict mode requires all passwords to be set and exits complaining
+#loose mode just exits (?)
+
+#Passwords set until now:
+OMSCORE_PW="superAdmin"
+OMSCORE_PW_LOCATION="oms-core/.env"
+#PW_POSTGRES=superAdmin #oms-core/docker/docker-compose.yml BUT you can put it in the above file and make the composer take it from there
+#PW_PGADMIN=superAdmin #set in the container probably
+#PW_MONGO=superAdmin #?
+#PW_MONGOADMIN=superAdmin #oms-global/docker/mongoui/app.json
+#PW_MEDIAWIKI=superAdmin
+#PW_LIMESURVEY=superAdmin
+#PW_MONITORING=superAdmin
+
+passwords=($OMSCORE_PW)
+locations=($OMSCORE_PW_LOCATION)
+
+COUNTER=0
+while [  $COUNTER -lt ${#passwords[@]} ]; do
+ currPw=${passwords[$COUNTER]}
+ currServ=${locations[$COUNTER]}
+ sed -i s/adminpass/$currPw/ "$currServ"
+ let COUNTER=COUNTER+1
+done
+
+
+
+#others:
+#bugsnagKey in configFile.json of oms-events/docker
+#oauth keys in .env of oms-core

--- a/provisioning.sh
+++ b/provisioning.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+#usage: provision.sh will call deploy.sh (but it is safer to deploy manually! so this is just for when I have a brand new server and want to bootstrap it from remote) which will update the git repo on the host, call a password setter, and run it
+
+#which server (URL) we want to deploy to (fraktis, amazon, digitalocean, azure)
+REMOTE_HOST=fraktis.aegee.org
+REMOTE_PORT=22302
+REMOTE_USER=
+#a private key to auth passwordless to this server
+REMOTE_HOST_KEY_PATH=~/.ssh/id_rsa
+#the path we want to deploy the application to
+DEPLOY_PATH=/opt/MyAEGEE
+
+#TODO: copy deploy.sh on a remote machine and call it, it will do everything by itself
+
+#IF REMOTE
+scp -i $(REMOTE_HOST_KEY_PATH) -p $(REMOTE_PORT) $(REMOTE_USER)@$(REMOTE_HOST) $(DEPLOY_PATH)/deploy.sh
+
+ssh -i $(REMOTE_HOST_KEY_PATH) -p $(REMOTE_PORT) $(REMOTE_USER)@$(REMOTE_HOST):$(DEPLOY_PATH) ./deploy.sh
+
+#IF LOCAL


### PR DESCRIPTION
While in the future an approach hook-based will work better (since
state-of-the-art) for now this will do. The deploy script is meant to be
run with privileges (to access the docker daemon) and to be scheduled as
a cron job: there will be a check if updates of upstream and a pull
with update of submodules, and a restart of the services (docker-compose
will take care of restarting only the changed containers).
There are also other options to 'refresh' the installation by deleting
the .env file, or to nuke it and re-downloading it from scratch.