### PR TITLE
Enabling oms-statutory by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,8 @@ PATH_OMS_LOGO_PRINT=oms-logo-print/docker/
 PATH_OMS_CORE_ELIXIR=oms-core-elixir/docker/
 PATH_OMS_REGISTRY=oms-serviceregistry/docker/
 PATH_OMS_EVENTS=oms-events/docker/
+PATH_OMS_STATUTORY=oms-statutory/docker
 PATH_OMS_FRONTEND=oms-frontend/docker/
 
 # To enable services, add them to the array, like
-ENABLED_SERVICES=oms-global:oms-core-elixir:oms-serviceregistry:oms-events:oms-frontend:oms-logo-print
+ENABLED_SERVICES=oms-global:oms-core-elixir:oms-serviceregistry:oms-events:oms-statutory:oms-frontend:oms-logo-print


### PR DESCRIPTION
Forgot that oms-statutory should be enabled by default, here it is.