### PR TITLE
Add basic MTA on a container (MEMB-299)

### DIFF
--- a/oms-global/docker/docker-compose.yml
+++ b/oms-global/docker/docker-compose.yml
@@ -32,8 +32,8 @@ services:
         restart: always
         expose:
           - 25
-    #   volumes:
-    #      - ./$PATH_OMS_GLOBAL/postfix/main.cf:/etc/postfix/main.cf
+        volumes:
+          - ./$PATH_OMS_GLOBAL/postfix/main.cf:/etc/postfix/main.cf
 
     portal:
         build:

--- a/oms-global/docker/docker-compose.yml
+++ b/oms-global/docker/docker-compose.yml
@@ -1,6 +1,4 @@
 version: "3.2"
-#TODO make sure all services always have the appropriate
-#       restart: on-failure
 #TODO: maybe add also the web interfaces for postgre, mongo, whichever?
 services:
 
@@ -28,6 +26,14 @@ services:
           - traefik.frontend.rule=HostRegexp:{domain:traefik.[a-z0-9.]+}
           - traefik.frontend.priority=20
           - traefik.frontend.auth.basic=admin:$$2y$$05$$xyGGmUIFoXSDXjBQ10gc7uIjinlWrIZxCmjZ6OGDwoqWk605lCPxi
+
+    postfix:
+        image: catatnight/postfix:latest #no fixed version
+        restart: always
+        expose:
+          - 25
+    #   volumes:
+    #      - ./$PATH_OMS_GLOBAL/postfix/main.cf:/etc/postfix/main.cf
 
     portal:
         build:

--- a/oms-global/docker/postfix/main.cf
+++ b/oms-global/docker/postfix/main.cf
@@ -1,0 +1,42 @@
+# See /usr/share/postfix/main.cf.dist for a commented, more complete version
+
+smtpd_banner = $myhostname ESMTP $mail_name (Ubuntu)
+biff = no
+
+# appending .domain is the MUA's job
+append_dot_mydomain = no
+
+readme_directory = no
+
+# TLS parameters
+smtpd_use_tls=yes
+smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
+smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+
+myhostname = my.aegee.eu
+myorigin = aegee.org 
+alias_maps = hash:/etc/aliases
+smtp_generic_maps = hash:/etc/postfix/generic
+alias_database = hash:/etc/aliases
+mydestination = $mydomain, $myhostname, localhost.$mydomain, localhost
+
+
+
+
+relayhost = [mail.aegee.org]:587
+mynetworks = 127.0.0.0/8
+mailbox_size_limit = 0
+recipient_delimiter = +
+inet_interfaces = loopback-only
+
+
+
+
+# Queue
+bounce_queue_lifetime = 20h
+maximal_queue_lifetime = 10h
+maximal_backoff_time = 15m
+minimal_backoff_time = 5m
+queue_run_delay = 5m


### PR DESCRIPTION
The MTA was supposed to be native, but for a starter we all agreed to
have it in a container. This is by no means complete as it needs testing
by the app etc, but the most basic settings are there