### PR TITLE
(fix) The secrets definition were missing for mailer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .vagrant
 .env
 *.log
-
+*.swp
 
 secrets/*
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: "apt-get install dos2unix -qq -y; cd /vagrant && dos2unix *.sh; dos2unix vagrant-post-script/*.sh"
 
   #nice-to-have prompt and completion
-  config.vm.provision "shell", inline: "cat vagrant-post-script/bashrc > /home/vagrant/.bashrc"
+  config.vm.provision "shell", inline: "cat /vagrant/vagrant-post-script/bashrc > /home/vagrant/.bashrc"
     
   #install docker and docker-composer the easy way
   config.vm.provision "shell", path: "vagrant-post-script/install_docker.sh"

--- a/base-docker-compose.yml
+++ b/base-docker-compose.yml
@@ -68,3 +68,7 @@ secrets:
         file: secrets/cert.pem
     https_key:
         file: secrets/key.pem
+    mail_user:
+        file: secrets/sendgrid_key
+    mail_password:
+        file: secrets/sendgrid_key

--- a/oms-global/docker/traefik/Dockerfile.dev
+++ b/oms-global/docker/traefik/Dockerfile.dev
@@ -1,3 +1,3 @@
 FROM traefik:v1.7.4-alpine
 
-COPY ./traefik.toml /etc/traefik/traefik.toml
+COPY ./traefik.toml.dev /etc/traefik/traefik.toml

--- a/oms-global/docker/traefik/traefik.toml.dev
+++ b/oms-global/docker/traefik/traefik.toml.dev
@@ -1,0 +1,83 @@
+################################################################
+# Global configuration
+################################################################
+logLevel = "INFO"
+
+defaultEntryPoints = ["http"]
+
+[entryPoints]
+  [entryPoints.http]
+  address = ":80"
+
+################################################################
+# Web configuration backend
+################################################################
+[web]
+address = ":8080"
+
+################################################################
+# Docker configuration backend
+################################################################
+
+# Enable Docker configuration backend
+#
+# Optional
+#
+[docker]
+
+# Docker server endpoint. Can be a tcp or a unix socket endpoint.
+#
+# Required
+#
+endpoint = "unix:///var/run/docker.sock"
+
+# Default domain used.
+# Can be overridden by setting the "traefik.domain" label on a container.
+#
+# Required
+#
+domain = "appserver.dev"
+
+
+# Enable watch docker changes
+#
+# Optional
+#
+watch = true
+
+# Override default configuration template. For advanced users :)
+#
+# Optional
+#
+# filename = "docker.tmpl"
+
+# Expose containers by default in traefik
+# If set to false, containers that don't have `traefik.enable=true` will be ignored
+#
+# Optional
+# Default: true
+#
+exposedbydefault = false
+
+# Use the IP address from the binded port instead of the inner network one. For specific use-case :)
+
+#
+# Optional
+# Default: false
+#
+usebindportip = true
+# Use Swarm Mode services as data provider
+#
+# Optional
+# Default: false
+#
+swarmmode = false
+
+
+# Enable docker TLS connection
+#
+#  [docker.tls]
+#  ca = "/etc/ssl/ca.crt"
+#  cert = "/etc/ssl/docker.crt"
+#  key = "/etc/ssl/docker.key"
+#  insecureskipverify = true


### PR DESCRIPTION
Also fixing a missing / in Vagrantfile
Remove HTTPS definition for a home-dev server, just to be safe. Browsers at time don't allow you to override the security and to not care...