### PR TITLE
feat(provisioning): allow --start-ing a single container

### DIFF
--- a/helper.sh
+++ b/helper.sh
@@ -226,7 +226,7 @@ if ( $build ); then
 fi
 
 if ( $start ); then
-    compose_wrapper config > current-config.yml && compose_wrapper up -d
+    compose_wrapper config > current-config.yml && compose_wrapper up -d $arguments
     exit $?
 fi
 


### PR DESCRIPTION
so I can do

```
./helper.sh --start oms-frontend
```

instead of

```
./helper.sh --docker -- up -d oms-frontend
```