### PR TITLE
fix(logstash): not log metrics or requests. Fixes MEMB-841

### DIFF
--- a/oms-monitor/docker/logstash/pipeline/logstash.conf
+++ b/oms-monitor/docker/logstash/pipeline/logstash.conf
@@ -70,6 +70,11 @@ filter {
     }
   }
 
+  ## From applications: not logging requests to healthchecks or metrics.
+  if [url] =~ "/healthcheck" or [url] =~ "/metrics" {
+    drop {}
+  }
+
   ## From logspout: nginx containers
   ## Taken from https://www.elastic.co/guide/en/logstash/current/logstash-config-for-filebeat-modules.html#parsing-nginx
   if [docker][image] =~ "nginx" or [docker][image] =~ "frontend" {


### PR DESCRIPTION
Skipping documents like these: https://d24bd47456c847298cfa27a3ca7325e6.europe-west1.gcp.cloud.es.io:9243/app/kibana#/discover/doc/f8712270-69c1-11ea-bd28-a132feb0b499/logstash-2020.04.25-000001?id=gg9lR3IBGtPPGMg54lWx&_g=()

Probably need to exclude nginx/traefik metrics, will do later in other PR.
This is on prod right now, I've tested it there and it works as expected.