### PR TITLE
fix(logstash): tagging logspout inputs

### DIFF
--- a/oms-monitor/docker/logstash/pipeline/logstash.conf
+++ b/oms-monitor/docker/logstash/pipeline/logstash.conf
@@ -26,7 +26,7 @@ filter {
     grok {
       match => { "message" => ["%{IPORHOST:[traefik][access][remote_ip]} - %{DATA:[traefik][access][user_name]} \[%{HTTPDATE:[traefik][access][time]}\] \"%{WORD:[traefik][access][method]} %{DATA:[traefik][access][url]} HTTP/%{NUMBER:[traefik][access][http_version]}\" %{NUMBER:[traefik][access][response_code]} %{NUMBER:[traefik][access][body_sent][bytes]} \"%{DATA:[traefik][access][referrer]}\" \"%{DATA:[traefik][access][agent]}\""] }
       remove_field => [ "message", "[traefik][access][time]" ]
-      add_tag => ["traefik_access_log"]
+      add_tag => ["traefik-access-log"]
     }
     useragent {
       source => "[traefik][access][agent]"
@@ -82,7 +82,7 @@ filter {
     grok {
       match => { "message" => ["%{IPORHOST:[nginx][access][remote_ip]} - %{DATA:[nginx][access][user_name]} \[%{HTTPDATE:[nginx][access][time]}\] \"%{WORD:[nginx][access][method]} %{DATA:[nginx][access][url]} HTTP/%{NUMBER:[nginx][access][http_version]}\" %{NUMBER:[nginx][access][response_code]} %{NUMBER:[nginx][access][body_sent][bytes]} \"%{DATA:[nginx][access][referrer]}\" \"%{DATA:[nginx][access][agent]}\""] }
       remove_field => "message"
-      add_tag => ["nginx_access_log"]
+      add_tag => ["nginx_access-log"]
     }
     mutate {
       add_field => { "read_timestamp" => "%{@timestamp}" }
@@ -112,7 +112,7 @@ filter {
   # From logspout: apps bunyan logs.
   # The : at the end of each container is because we have "oms-statutory-static" and "oms-events-static".
   if [docker][image] =~ "oms-events:" or [docker][image] =~ "oms-statutory:" or [docker][image] =~ "oms-discounts:" {
-    mutate { add_tag => ["bunyan_log"] }
+    mutate { add_tag => ["bunyan-log"] }
   }
 
 

--- a/oms-monitor/docker/logstash/pipeline/logstash.conf
+++ b/oms-monitor/docker/logstash/pipeline/logstash.conf
@@ -82,7 +82,7 @@ filter {
     grok {
       match => { "message" => ["%{IPORHOST:[nginx][access][remote_ip]} - %{DATA:[nginx][access][user_name]} \[%{HTTPDATE:[nginx][access][time]}\] \"%{WORD:[nginx][access][method]} %{DATA:[nginx][access][url]} HTTP/%{NUMBER:[nginx][access][http_version]}\" %{NUMBER:[nginx][access][response_code]} %{NUMBER:[nginx][access][body_sent][bytes]} \"%{DATA:[nginx][access][referrer]}\" \"%{DATA:[nginx][access][agent]}\""] }
       remove_field => "message"
-      add_tag => ["nginx_access-log"]
+      add_tag => ["nginx-access-log"]
     }
     mutate {
       add_field => { "read_timestamp" => "%{@timestamp}" }

--- a/oms-monitor/docker/logstash/pipeline/logstash.conf
+++ b/oms-monitor/docker/logstash/pipeline/logstash.conf
@@ -21,11 +21,12 @@ filter {
   # }
 
   ## From filebeat: traefik logs in nginx format
-  if "traefik_log" in [tags] { #WORKS!!!
+  if [docker][image] =~ "traefik" {
     #  mutate{ add_field => { "traefik_log_type" => "nginx_log" } }
     grok {
       match => { "message" => ["%{IPORHOST:[traefik][access][remote_ip]} - %{DATA:[traefik][access][user_name]} \[%{HTTPDATE:[traefik][access][time]}\] \"%{WORD:[traefik][access][method]} %{DATA:[traefik][access][url]} HTTP/%{NUMBER:[traefik][access][http_version]}\" %{NUMBER:[traefik][access][response_code]} %{NUMBER:[traefik][access][body_sent][bytes]} \"%{DATA:[traefik][access][referrer]}\" \"%{DATA:[traefik][access][agent]}\""] }
       remove_field => [ "message", "[traefik][access][time]" ]
+      add_tag => ["traefik_access_log"]
     }
     useragent {
       source => "[traefik][access][agent]"
@@ -81,6 +82,7 @@ filter {
     grok {
       match => { "message" => ["%{IPORHOST:[nginx][access][remote_ip]} - %{DATA:[nginx][access][user_name]} \[%{HTTPDATE:[nginx][access][time]}\] \"%{WORD:[nginx][access][method]} %{DATA:[nginx][access][url]} HTTP/%{NUMBER:[nginx][access][http_version]}\" %{NUMBER:[nginx][access][response_code]} %{NUMBER:[nginx][access][body_sent][bytes]} \"%{DATA:[nginx][access][referrer]}\" \"%{DATA:[nginx][access][agent]}\""] }
       remove_field => "message"
+      add_tag => ["nginx_access_log"]
     }
     mutate {
       add_field => { "read_timestamp" => "%{@timestamp}" }
@@ -105,6 +107,12 @@ filter {
         mapping => { "message" => "%{} %{} %{msg}" }
         remove_field => "message"
     }
+  }
+
+  # From logspout: apps bunyan logs.
+  # The : at the end of each container is because we have "oms-statutory-static" and "oms-events-static".
+  if [docker][image] =~ "oms-events:" or [docker][image] =~ "oms-statutory:" or [docker][image] =~ "oms-discounts:" {
+    mutate { add_tag => ["bunyan_log"] }
   }
 
 


### PR DESCRIPTION
1) since we write traefik logs to stdout we need to check not for tags, but for container name
2) tagging all traefik logs with `"traefik-access-log"`
3) tagging all nginx logs with `"nginx-access-log"`
4) tagging all bunyan logs with `"bunyan-log"`

Will do in another PR to make it small:
1) combine 2) and 3) together as "access-log" and parse it with one block instead of two
2) write "access-log" to index with pattern `"access-log-*"`
3) write "bunyan-log" to index with pattern` "bunyan-log-*"`
4) write anything that isn't these two (mostly, traefik/nginx debug messages, core/mailer logs and whatever couldn't be parsed with json) to `"other-log-*"`
5) once the new core and mailer is there, write it to `"bunyan-log-*"`
6) most of the log messages are in either access-log or bunyan-log indices, whatever's not is either a parsing error or debug messages

Will merge after https://github.com/AEGEE/oms-docker/pull/141 to make changes as small as possible.