### PR TITLE
fix(logstash): refactor logstash access logs

### DIFF
--- a/oms-monitor/docker/logstash/pipeline/logstash.conf
+++ b/oms-monitor/docker/logstash/pipeline/logstash.conf
@@ -20,26 +20,25 @@ filter {
   #     whitelist_names => [ "timestamp", "msg", "message", "loglevel", "docker", "stream", "tags", "statuscode", "method", "type" ]
   # }
 
-  ## From filebeat: traefik logs in nginx format
-  if [docker][image] =~ "traefik" {
-    #  mutate{ add_field => { "traefik_log_type" => "nginx_log" } }
+  ## From logstash: traefik/nginx logs in nginx format
+  if [docker][image] =~ "traefik" or [docker][image] =~ "nginx" or [docker][image] =~ "frontend"{
     grok {
-      match => { "message" => ["%{IPORHOST:[traefik][access][remote_ip]} - %{DATA:[traefik][access][user_name]} \[%{HTTPDATE:[traefik][access][time]}\] \"%{WORD:[traefik][access][method]} %{DATA:[traefik][access][url]} HTTP/%{NUMBER:[traefik][access][http_version]}\" %{NUMBER:[traefik][access][response_code]} %{NUMBER:[traefik][access][body_sent][bytes]} \"%{DATA:[traefik][access][referrer]}\" \"%{DATA:[traefik][access][agent]}\""] }
-      remove_field => [ "message", "[traefik][access][time]" ]
-      add_tag => ["traefik-access-log"]
+      match => { "message" => ["%{IPORHOST:[remote_ip]} - %{DATA:[user_name]} \[%{HTTPDATE:[time]}\] \"%{WORD:[method]} %{DATA:[url]} HTTP/%{NUMBER:[http_version]}\" %{NUMBER:[response_code]} %{NUMBER:[body_sent][bytes]} \"%{DATA:[referrer]}\" \"%{DATA:[agent]}\""] }
+      remove_field => [ "message", "[time]" ]
+      add_tag => ["access-log"]
     }
     useragent {
-      source => "[traefik][access][agent]"
-      target => "[traefik][access][user_agent]"
-      remove_field => "[traefik][access][agent]"
+      source => "[agent]"
+      target => "[user_agent]"
+      remove_field => "[agent]"
     }
     geoip {
-      source => "[traefik][access][remote_ip]"
-      target => "[traefik][access][geoip]"
+      source => "[remote_ip]"
+      target => "[geoip]"
     }
     translate {
-      field => "[traefik][access][response_code]"
-      destination => "[traefik][access][x_http_response]"
+      field => "[response_code]"
+      destination => "[x_http_response]"
       dictionary => {
         "200" => "200 OK"
         "201" => "201 Created"
@@ -74,32 +73,6 @@ filter {
   ## From applications: not logging requests to healthchecks or metrics.
   if [url] =~ "/healthcheck" or [url] =~ "/metrics" {
     drop {}
-  }
-
-  ## From logspout: nginx containers
-  ## Taken from https://www.elastic.co/guide/en/logstash/current/logstash-config-for-filebeat-modules.html#parsing-nginx
-  if [docker][image] =~ "nginx" or [docker][image] =~ "frontend" {
-    grok {
-      match => { "message" => ["%{IPORHOST:[nginx][access][remote_ip]} - %{DATA:[nginx][access][user_name]} \[%{HTTPDATE:[nginx][access][time]}\] \"%{WORD:[nginx][access][method]} %{DATA:[nginx][access][url]} HTTP/%{NUMBER:[nginx][access][http_version]}\" %{NUMBER:[nginx][access][response_code]} %{NUMBER:[nginx][access][body_sent][bytes]} \"%{DATA:[nginx][access][referrer]}\" \"%{DATA:[nginx][access][agent]}\""] }
-      remove_field => "message"
-      add_tag => ["nginx-access-log"]
-    }
-    mutate {
-      add_field => { "read_timestamp" => "%{@timestamp}" }
-    }
-    date {
-      match => [ "[nginx][access][time]", "dd/MMM/YYYY:H:m:s Z" ]
-      remove_field => "[nginx][access][time]"
-    }
-    useragent {
-      source => "[nginx][access][agent]"
-      target => "[nginx][access][user_agent]"
-      remove_field => "[nginx][access][agent]"
-    }
-    geoip {
-      source => "[nginx][access][remote_ip]"
-      # target => "[nginx][access][geoip]"
-    }
   }
 
   if [docker][image] =~ "portainer"{

--- a/oms-monitor/docker/logstash/pipeline/logstash.conf
+++ b/oms-monitor/docker/logstash/pipeline/logstash.conf
@@ -21,7 +21,7 @@ filter {
   # }
 
   ## From logstash: traefik/nginx logs in nginx format
-  if [docker][image] =~ "traefik" or [docker][image] =~ "nginx" or [docker][image] =~ "frontend"{
+  if [docker][image] =~ "traefik" or [docker][image] =~ "nginx" or [docker][image] =~ "frontend" {
     grok {
       match => { "message" => ["%{IPORHOST:[remote_ip]} - %{DATA:[user_name]} \[%{HTTPDATE:[time]}\] \"%{WORD:[method]} %{DATA:[url]} HTTP/%{NUMBER:[http_version]}\" %{NUMBER:[response_code]} %{NUMBER:[body_sent][bytes]} \"%{DATA:[referrer]}\" \"%{DATA:[agent]}\""] }
       remove_field => [ "message", "[time]" ]


### PR DESCRIPTION
part 3 of logstash improvements:

1) removed nginx access logs parsing
2) updated traefik access logs parsing so it'd accept nginx logs as well (they both write in the same format)
3) removed `[traefik][access]` and `[nginx][access]` prefixes for all fields
4) tag these as `access-log`