### PR TITLE
feat(logstash): write to different indexes based on tags

### DIFF
--- a/oms-monitor/docker/logstash/pipeline/logstash.conf
+++ b/oms-monitor/docker/logstash/pipeline/logstash.conf
@@ -99,9 +99,28 @@ filter {
 }
 
 output {
-  elasticsearch {
-    hosts => "${ELASTIC_HOST}"
-    user => "${ELASTIC_USER}"
-    password => "${ELASTIC_PASSWORD}"
+  if "access-log" in [tags] {
+    elasticsearch {
+      hosts => "${ELASTIC_HOST}"
+      user => "${ELASTIC_USER}"
+      password => "${ELASTIC_PASSWORD}"
+      index => "access-log-%{+YYYY.MM.dd}"
+    }
+  }
+  else if "bunyan-log" in [tags] {
+    elasticsearch {
+      hosts => "${ELASTIC_HOST}"
+      user => "${ELASTIC_USER}"
+      password => "${ELASTIC_PASSWORD}"
+      index => "bunyan-log-%{+YYYY.MM.dd}"
+    }
+  }
+  else {
+    elasticsearch {
+      hosts => "${ELASTIC_HOST}"
+      user => "${ELASTIC_USER}"
+      password => "${ELASTIC_PASSWORD}"
+      index => "other-log-%{+YYYY.MM.dd}"
+    }
   }
 }


### PR DESCRIPTION
part 4 (should be the last one) of logstash pipeline improvements.

1) write images with tag `access-log`(traefik/nginx logs) to `access-log-${timestamp}`
2) write images with tag `bunyan-log` (app/logs) to `access-log-${timestamp}`
3) write other logs (mostly other services are these messages that couldn't be parsed with json parser) to `other-log-${timestamp}`

b1.barnab.eu uses this new schema right now, works okay.
only thing I don't know about is how to get rid of this copy-paste of host/username/password, but it may be not possible, so let's leave it like this.