### PR TITLE
fix: bootstrap procedure when not using start.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,3 @@ secrets/*
 
 # exception to the rule
 !secrets/.gitkeep
-
-.firstbootstrap
-

--- a/vagrant-post-script/orchestrate_docker.sh
+++ b/vagrant-post-script/orchestrate_docker.sh
@@ -2,11 +2,12 @@
 
 cd /vagrant/ || exit 1
 
-if [[ -f .firstbootstrap ]]; then
+if [[ -f .env ]]; then
   dos2unix .env
   make start
 else
-  touch .firstbootstrap
+  cp .env.example .env
+
   #git reset --hard HEAD
   #./helper.sh --bumpmodules
   make bootstrap


### PR DESCRIPTION
although it is very discouraged, it could happen of people
launching the command `vagrant up` before any initialisation