### PR TITLE
feat: add visualiser of documentation of our API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,8 @@ SUBDOMAIN_WIKI=wiki.
 SUBDOMAIN_SURVEY=survey.
 SUBDOMAIN_UPMONITOR=ciao.
 SUBDOMAIN_STATPING=ping.
+SUBDOMAIN_APIDOCS=apidocs.
+SUBDOMAIN_REDISADMIN=redis.
 
 # Paths in the filesystem
 PATH_OMS_GLOBAL=oms-global/docker/

--- a/oms-dev/docker/docker-compose.yml
+++ b/oms-dev/docker/docker-compose.yml
@@ -62,13 +62,13 @@ services:
     image: swaggerapi/swagger-ui:v3.28.0
     environment:
       #API_URL: http://events/api-docs.json
-      URLS: "[{url: \"http://core/api-docs.json\", \
+      URLS: "[{url: \"http://${SUBDOMAIN_FRONTEND}${BASE_URL}/api/core/api-docs.json\", \
               name: \"core\"}, \
-              {url: \"http://events/api-docs.json\", \
+              {url: \"http://${SUBDOMAIN_FRONTEND}${BASE_URL}/api/events/api-docs.json\", \
               name: \"events\"}, \
-              {url: \"http://statutory/api-docs.json\", \
+              {url: \"http://${SUBDOMAIN_FRONTEND}${BASE_URL}/api/statutory/api-docs.json\", \
               name: \"statutory\"}, \
-              {url: \"http://discounts/api-docs.json\", \
+              {url: \"http://${SUBDOMAIN_FRONTEND}${BASE_URL}/api/discounts/api-docs.json\", \
               name: \"discounts\"}, \
               ]"
     labels:

--- a/oms-dev/docker/docker-compose.yml
+++ b/oms-dev/docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
 ### pg Admin Container #######################################
   pgadmin:
-    image: fenglc/pgadmin4:2.0
+    image: dpage/pgadmin4:4.23
     restart: on-failure
     expose:
       - "5050"
@@ -37,8 +37,9 @@ services:
       - "traefik.frontend.priority=20"
       - "traefik.frontend.auth.basic.users=admin:${PW_TRAEFIK}"
     environment:
-      DEFAULT_USER: "myaegee-admins@${EMAIL_DOMAIN}"
-      DEFAULT_PASSWORD: "${PW_PGADMIN}"
+      PGADMIN_DEFAULT_EMAIL: "myaegee-admins@${EMAIL_DOMAIN}"
+      PGADMIN_DEFAULT_PASSWORD: "${PW_PGADMIN}"
+      PGADMIN_LISTEN_PORT: 5050
 
 ### redis Admin Container #######################################
   redisadmin:

--- a/oms-dev/docker/docker-compose.yml
+++ b/oms-dev/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
 ### DB admin (UIs) Containers #######################################
 
-### pgAdmin Container #######################################
+### pg Admin Container #######################################
   pgadmin:
     image: fenglc/pgadmin4:2.0
     restart: on-failure
@@ -40,6 +40,7 @@ services:
       DEFAULT_USER: "myaegee-admins@${EMAIL_DOMAIN}"
       DEFAULT_PASSWORD: "${PW_PGADMIN}"
 
+### redis Admin Container #######################################
   redisadmin:
     image: erikdubbelboer/phpredisadmin:v1.11.4
     environment:
@@ -57,16 +58,25 @@ services:
 
 
 ### show api docs Container #######################################
-  # swagger:
-  #   image: swaggerapi/swagger-ui
-  #   environment:
-  #     API_URL: http://oms-events/api-docs.json
-  #   labels:
-  #     - traefik.enable=true
-  #     - traefik.backend=swagger
-  #     - traefik.port=8080
-  #     - traefik.frontend.rule=Host:${SUBDOMAIN_APIDOCS}${BASE_URL}
-  #     - traefik.frontend.priority=20
+  swagger:
+    image: swaggerapi/swagger-ui:v3.28.0
+    environment:
+      #API_URL: http://events/api-docs.json
+      URLS: "[{url: \"http://core/api-docs.json\", \
+              name: \"core\"}, \
+              {url: \"http://events/api-docs.json\", \
+              name: \"events\"}, \
+              {url: \"http://statutory/api-docs.json\", \
+              name: \"statutory\"}, \
+              {url: \"http://discounts/api-docs.json\", \
+              name: \"discounts\"}, \
+              ]"
+    labels:
+      - traefik.enable=true
+      - traefik.backend=swagger
+      - traefik.port=8080
+      - traefik.frontend.rule=Host:${SUBDOMAIN_APIDOCS}${BASE_URL}
+      - traefik.frontend.priority=20
 
 
 networks:

--- a/oms-dev/docker/docker-compose.yml
+++ b/oms-dev/docker/docker-compose.yml
@@ -43,11 +43,11 @@ services:
 ### redis Admin Container #######################################
   redisadmin:
     image: erikdubbelboer/phpredisadmin:v1.11.4
-    environment:
-      ADMIN_USER: admin
-      ADMIN_PASS: ${PW_TRAEFIK}
-      REDIS_1_HOST: redis-oms-gsuite-wrapper
-      REDIS_1_PORT: 6379
+    # environment:
+      # ADMIN_USER: admin
+      # ADMIN_PASS: ${PW_TRAEFIK}
+      # REDIS_1_HOST: redis-oms-gsuite-wrapper
+      # REDIS_1_PORT: 6379
     labels:
       - "traefik.enable=true"
       - "traefik.backend=redisadmin"


### PR DESCRIPTION
One will be able to go to apiadmin.appserver.test and pick on the top-right corner one of our service, and have the docs presented.

Requires use of [swaggerJSDoc](https://github.com/Surnet/swagger-jsdoc) (not a priority)

Imho better than apiary, because the code is auto-generated and in the same place (I used it at work)