### PR TITLE
feat: add option to fast bootstrap, and to reset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,9 @@ SHORTENER_DOMAIN=aeg.ee
 
 EMAIL_DOMAIN=
 
-
-# To enable services, add them to the array, like
-ENABLED_SERVICES=gateways:frontend:core:statutory:events:discounts:mailer
+# To enable services, add them (i.e. the name of enclosing folder) to the array, like
+#ENABLED_SERVICES=gateways:frontend:core:statutory:events:dev-tools:discounts:mailer
+ENABLED_SERVICES=gateways:frontend:core:statutory:events
 
 MYAEGEE_ENV=development
 

--- a/start.sh
+++ b/start.sh
@@ -4,12 +4,16 @@
 
 #check how to bootstrap
 novagrant=false
+fast=false
+reset=false
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --no-vagrant) novagrant=true; shift ;;
+        --fast) fast=true; shift ;;
+        --reset) reset=true; shift ;;
 
-        -*) echo "Usage: start.sh [--novagrant]"; exit 1;;
-        *) echo "Usage: start.sh [--novagrant]"; exit 1;;
+        -*) echo "Usage: start.sh [--novagrant] [--reset] [--fast]"; exit 1;;
+        *) echo "Usage: start.sh [--novagrant] [--reset] [--fast]"; exit 1;;
     esac
 done
 
@@ -23,6 +27,21 @@ check_etc_hosts () {
 }
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if ( $reset ); then
+  echo
+  echo
+  echo "CAREFUL! you are deleting your .env"
+  echo "here it is, in case you forgot to save some tokens/configs"
+  echo
+  echo
+  sed '/AEGEE_LOGO_B64/d' "${DIR}/.env"
+  rm "${DIR}/.env"
+  echo
+  echo "MORE CAREFUL! you are deleting your development machine"
+  echo
+  vagrant destroy
+fi
+
 if [ ! -f "${DIR}"/.env ]; then #check if it exists, if not take the example
     cp "${DIR}"/.env.example "${DIR}"/.env
 fi
@@ -34,6 +53,9 @@ if ( $novagrant ); then
 else
   check_etc_hosts "192.168.168.168" "appserver.test"
   sed -i 's/localhost/appserver/' .env
+  if ( $fast ); then
+    sed -i 's/development/production/' .env
+  fi
   vagrant up
 fi
 


### PR DESCRIPTION
@HassanCehef I can't find you as assignee

edit: nvm added the group everybody on the repo


The idea of this PR is 
1) give a 'fast lane' to people who would (like me) like to work on the infrastructure. They would need a working installation, but not in dev mode. Also by limiting the services enabled on startup (e.g. the `mailer` which is useless as it doesn't have a dev mode through sendgrid), building time would be reduced even in cases of dev mode (with a build)
2) give a chance to nuke vagrant, similarly to `helper.sh --nuke` but on the vagrant level instead of the docker level