### PR TITLE
ci: add pylint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - checkout
       - run: pip install pylint
-      - run: pylint .
+      - run: pylint scripts/notify.py
   shellcheck:
     docker:
       - image: cimg/base:2021.10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,13 @@ jobs:
       - checkout
       - run: pip install yamllint
       - run: yamllint -d .yamllint.yml .
+  pylint:
+    docker:
+      - image: cimg/python:3.10.0
+    steps:
+      - checkout
+      - run: pip install pylint
+      - run: pylint .
   shellcheck:
     docker:
       - image: cimg/base:2021.10
@@ -26,6 +33,9 @@ workflows:
   lint-shell:
     jobs:
       - shellcheck
+  lint-python:
+    jobs:
+      - pylint
   lint-dockerfile:
     jobs:
       - docker/hadolint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - checkout
       - run: pip install pylint
-      - run: pylint scripts/notify.py
+      - run: pylint --recursive=y scripts
   shellcheck:
     docker:
       - image: cimg/base:2021.10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,8 @@ jobs:
     steps:
       - checkout
       - run: pip install pylint
-      - run: pylint --recursive=y scripts
+      # FIXME: enable W0511 and E0401 as well
+      - run: pylint scripts --disable C0114,C0116,W0511,E0401
   shellcheck:
     docker:
       - image: cimg/base:2021.10


### PR DESCRIPTION
This PR adds `pylint` as an initial Python linter. More can be added in the future as well, I'm not very familiar with python linters.

There are a few rules that I've disabled;
[C0114 missing-module-docstring](https://pylint.pycqa.org/en/latest/user_guide/messages/convention/missing-module-docstring.html)
[C0116 missing-function-docstring](https://pylint.pycqa.org/en/latest/user_guide/messages/convention/missing-function-docstring.html)
[W0511 fixme](https://pylint.pycqa.org/en/latest/user_guide/messages/warning/fixme.html)
[E0401 import-error](https://pylint.pycqa.org/en/latest/user_guide/messages/error/import-error.html)

We for sure should fix E0401, W0511 can be enabled in due time. C0114 and C0116 can be disabled if it's up to me.