### PR TITLE
fix: fix typo in start.sh usage

### DIFF
--- a/helper.sh
+++ b/helper.sh
@@ -189,6 +189,10 @@ function retry {
 }
 
 # TODO: ignore this when using --no-vagrant in start.sh
+if [[ ! $HOSTNAME =~ ^appserver ]]; then
+  echo "You're on $HOSTNAME, (the HOST) but you should be on 'appserver' (the GUEST). Exiting..."
+  exit 1
+fi
 
 # HUMAN INTERVENTION NEEDED: register in .env your services
 ## Export all environment variables from .env to this script in case we need them some time

--- a/helper.sh
+++ b/helper.sh
@@ -188,10 +188,7 @@ function retry {
   done
 }
 
-if [[ ! $HOSTNAME =~ ^appserver ]]; then
-  echo "You're on $HOSTNAME, (the HOST) but you should be on 'appserver' (the GUEST). Exiting..."
-  exit 1
-fi
+# TODO: ignore this when using --no-vagrant in start.sh
 
 # HUMAN INTERVENTION NEEDED: register in .env your services
 ## Export all environment variables from .env to this script in case we need them some time

--- a/start.sh
+++ b/start.sh
@@ -12,8 +12,8 @@ while [ "$#" -gt 0 ]; do
         --fast) fast=true; shift ;;
         --reset) reset=true; shift ;;
 
-        -*) echo "Usage: start.sh [--novagrant] [--reset] [--fast]"; exit 1;;
-        *) echo "Usage: start.sh [--novagrant] [--reset] [--fast]"; exit 1;;
+        -*) echo "Usage: start.sh [--no-vagrant] [--reset] [--fast]"; exit 1;;
+        *) echo "Usage: start.sh [--no-vagrant] [--reset] [--fast]"; exit 1;;
     esac
 done
 


### PR DESCRIPTION
@linuxbandit not sure how to deal with the TODO since I think we'll need to pass the no-vagrant from start.sh to helper.sh. Or is there some kind of global thing we can set? I'm not really knowledgeable about shell things