### PR TITLE
fix(ci): remove @semantic-release/git to prevent monorepo race conditions

### DIFF
--- a/core/.releaserc.json
+++ b/core/.releaserc.json
@@ -50,13 +50,6 @@
         "releasedLabels": ["released-core"],
         "addReleases": "bottom"
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): core@${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
-      }
     ]
   ]
 }

--- a/discounts/.releaserc.json
+++ b/discounts/.releaserc.json
@@ -50,13 +50,6 @@
         "releasedLabels": ["released-discounts"],
         "addReleases": "bottom"
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): discounts@${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
-      }
     ]
   ]
 }

--- a/events/.releaserc.json
+++ b/events/.releaserc.json
@@ -50,13 +50,6 @@
         "releasedLabels": ["released-events"],
         "addReleases": "bottom"
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): events@${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
-      }
     ]
   ]
 }

--- a/frontend/.releaserc.json
+++ b/frontend/.releaserc.json
@@ -50,13 +50,6 @@
         "releasedLabels": ["released-frontend"],
         "addReleases": "bottom"
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): frontend@${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
-      }
     ]
   ]
 }

--- a/gsuite-wrapper/.releaserc.json
+++ b/gsuite-wrapper/.releaserc.json
@@ -50,13 +50,6 @@
         "releasedLabels": ["released-gsuite-wrapper"],
         "addReleases": "bottom"
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): gsuite-wrapper@${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
-      }
     ]
   ]
 }

--- a/knowledge/.releaserc.json
+++ b/knowledge/.releaserc.json
@@ -50,13 +50,6 @@
         "releasedLabels": ["released-knowledge"],
         "addReleases": "bottom"
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): knowledge@${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
-      }
     ]
   ]
 }

--- a/mailer/.releaserc.json
+++ b/mailer/.releaserc.json
@@ -50,13 +50,6 @@
         "releasedLabels": ["released-mailer"],
         "addReleases": "bottom"
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): mailer@${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
-      }
     ]
   ]
 }

--- a/network/.releaserc.json
+++ b/network/.releaserc.json
@@ -50,13 +50,6 @@
         "releasedLabels": ["released-network"],
         "addReleases": "bottom"
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): network@${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
-      }
     ]
   ]
 }

--- a/statutory/.releaserc.json
+++ b/statutory/.releaserc.json
@@ -50,13 +50,6 @@
         "releasedLabels": ["released-statutory"],
         "addReleases": "bottom"
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): statutory@${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
-      }
     ]
   ]
 }

--- a/summeruniversity/.releaserc.json
+++ b/summeruniversity/.releaserc.json
@@ -50,13 +50,6 @@
         "releasedLabels": ["released-summeruniversity"],
         "addReleases": "bottom"
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): summeruniversity@${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
-      }
     ]
   ]
 }


### PR DESCRIPTION
## Summary

Fixes the semantic-release race condition during concurrent monorepo deployments by removing the `@semantic-release/git` plugin from all package release configurations.

## Problem

Multiple packages running `semantic-release` in parallel were attempting to push version bump commits to the `stable` branch simultaneously, causing conflicts:

```
! [rejected]          HEAD -> stable (fetch first)
error: failed to push some refs
hint: Updates were rejected because the remote contains work that you do not
hint: have locally.
```

## Solution

Removed `@semantic-release/git` plugin from all 10 package `.releaserc.json` files:
- core
- events  
- frontend
- discounts
- knowledge
- network
- statutory
- summeruniversity
- mailer
- gsuite-wrapper

## Impact

**What still works:**
- ✅ GitHub Releases with release notes
- ✅ Git tags (e.g., `events@1.8.1`)
- ✅ Release labels on issues/PRs
- ✅ Parallel releases without conflicts

**What changes:**
- ❌ No more automatic `package.json` version bumps
- ❌ No more automatic `CHANGELOG.md` commits
- ℹ️ GitHub Releases become the source of truth for versions

This is the recommended approach for monorepos using semantic-release, as it eliminates git conflicts while maintaining full release tracking via GitHub Releases.

## Testing

This change will be validated in the next CI deployment run. The releases should complete successfully without push conflicts.