### PR TITLE
fix(statutory): configure Express to parse query string arrays properly

### DIFF
--- a/statutory/lib/server.js
+++ b/statutory/lib/server.js
@@ -41,6 +41,7 @@ const QuestionLinesRouter = router({ mergeParams: true });
 const QuestionsRouter = router({ mergeParams: true });
 
 const server = express();
+server.set('query parser', 'extended');
 server.use(bodyParser.json());
 server.use(boolParser());
 server.use(morgan);


### PR DESCRIPTION
## Summary
Fixes the failing `statutory-test` job by configuring Express to properly parse query string arrays.

## Root Cause
The `export-all.test.js` tests were failing with 400 (Bad Request) instead of 200 (OK) responses because:

1. The tests pass an array of field names via the `select` query parameter: `?select=field1&select=field2&select=field3`
2. Express's default simple query parser doesn't handle repeated query parameters as arrays
3. The application code at `statutory/lib/applications.js:819` strictly requires `req.query.select` to be an array
4. When it wasn't an array, the code returned a 400 error: "Filters are not provided or are invalid."

## Solution
Added one line to configure Express to use the 'extended' query parser (which uses the `qs` library):

```javascript
server.set('query parser', 'extended');
```

This ensures repeated query parameters are properly parsed as arrays.

## Testing
This fix resolves all 6 failing test cases in `export-all.test.js`:
- ✅ should return nothing if no applications
- ✅ should return nothing if only cancelled applications
- ✅ should return something if there are not cancelled applications
- ✅ should filter out selected fields on /incoming
- ✅ should use the default filter if the passed filter is not provided
- ✅ should use the filter if provided

## Note
The `export-candidates.test.js` tests don't fail because `positions.js` handles this more defensively - if `select` isn't an array, it uses a default value rather than throwing an error.

Resolves: #1501 (statutory-test failures)