### PR TITLE
feat(core): add body_id filter to /members_search endpoint

### DIFF
--- a/core/middlewares/members.js
+++ b/core/middlewares/members.js
@@ -2,7 +2,7 @@ const moment = require('moment');
 const _ = require('lodash');
 const request = require('request-promise-native');
 
-const { User, Body, MailChange, MailConfirmation } = require('../models');
+const { User, Body, BodyMembership, MailChange, MailConfirmation } = require('../models');
 const config = require('../config');
 const constants = require('../lib/constants');
 const helpers = require('../lib/helpers');
@@ -33,11 +33,30 @@ exports.searchAllUsers = async (req, res) => {
         return errors.makeForbiddenError(res, 'Permission global:search:member is required, but not present.');
     }
 
+    const where = helpers.filterBy(req.query.query, constants.FIELDS_TO_QUERY.MEMBER);
+
+    // Optional body_id filter: comma-separated list of body IDs.
+    // When provided, only returns users who are members of at least one of the specified bodies.
+    const include = [];
+    if (req.query.body_id) {
+        const bodyIds = req.query.body_id.split(',').map((id) => parseInt(id, 10)).filter((id) => !Number.isNaN(id));
+        if (bodyIds.length > 0) {
+            include.push({
+                model: BodyMembership,
+                where: { body_id: { [Sequelize.Op.in]: bodyIds } },
+                attributes: [],
+                required: true
+            });
+        }
+    }
+
     const result = await User.findAndCountAll({
-        where: helpers.filterBy(req.query.query, constants.FIELDS_TO_QUERY.MEMBER),
+        where,
         ...helpers.getPagination(req.query),
         attributes: ['id', 'first_name', 'last_name', 'username', 'email', 'gsuite_id'],
-        order: helpers.getSorting(req.query)
+        include,
+        order: helpers.getSorting(req.query),
+        ...(include.length > 0 && { distinct: true })
     });
 
     return res.json({

--- a/core/test/api/users-searching.test.js
+++ b/core/test/api/users-searching.test.js
@@ -233,4 +233,133 @@ describe('Users list', () => {
         expect(res.body.data.length).toEqual(1);
         expect(res.body.data[0]).toEqual(expectedOutput);
     });
+
+    test('should filter by body_id', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
+
+        const body = await generator.createBody();
+        const memberInBody = await generator.createUser();
+        await generator.createBodyMembership(body, memberInBody);
+
+        const memberNotInBody = await generator.createUser();
+
+        const res = await request({
+            uri: '/members_search?body_id=' + body.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+
+        const returnedIds = res.body.data.map((u) => u.id);
+        expect(returnedIds).toContain(memberInBody.id);
+        expect(returnedIds).not.toContain(memberNotInBody.id);
+        expect(returnedIds).not.toContain(user.id);
+    });
+
+    test('should filter by multiple body_ids', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
+
+        const body1 = await generator.createBody();
+        const body2 = await generator.createBody();
+        const memberInBody1 = await generator.createUser();
+        const memberInBody2 = await generator.createUser();
+        await generator.createBodyMembership(body1, memberInBody1);
+        await generator.createBodyMembership(body2, memberInBody2);
+
+        const memberNotInAnyBody = await generator.createUser();
+
+        const res = await request({
+            uri: '/members_search?body_id=' + body1.id + ',' + body2.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+
+        const returnedIds = res.body.data.map((u) => u.id);
+        expect(returnedIds).toContain(memberInBody1.id);
+        expect(returnedIds).toContain(memberInBody2.id);
+        expect(returnedIds).not.toContain(memberNotInAnyBody.id);
+    });
+
+    test('should not duplicate users in multiple bodies when filtering by body_id', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
+
+        const body1 = await generator.createBody();
+        const body2 = await generator.createBody();
+        const memberInBothBodies = await generator.createUser();
+        await generator.createBodyMembership(body1, memberInBothBodies);
+        await generator.createBodyMembership(body2, memberInBothBodies);
+
+        const res = await request({
+            uri: '/members_search?body_id=' + body1.id + ',' + body2.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+
+        const matchingUsers = res.body.data.filter((u) => u.id === memberInBothBodies.id);
+        expect(matchingUsers.length).toEqual(1);
+        expect(res.body.meta.count).toEqual(1);
+    });
+
+    test('should combine body_id filter with query search', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
+
+        const body = await generator.createBody();
+        const matchingMember = await generator.createUser({ first_name: 'TestSearchName' });
+        const nonMatchingMember = await generator.createUser({ first_name: 'OtherName' });
+        await generator.createBodyMembership(body, matchingMember);
+        await generator.createBodyMembership(body, nonMatchingMember);
+
+        const res = await request({
+            uri: '/members_search?body_id=' + body.id + '&query=TestSearchName',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+
+        expect(res.body.data.length).toEqual(1);
+        expect(res.body.data[0].id).toEqual(matchingMember.id);
+    });
+
+    test('should ignore invalid body_id values', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
+
+        const res = await request({
+            uri: '/members_search?body_id=invalid,nonsense',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        // With all invalid IDs filtered out, it should behave like no body_id filter (return all)
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body.data.length).toEqual(1);
+        expect(res.body.data[0].id).toEqual(user.id);
+    });
 });

--- a/frontend/src/views/summeruniversity/Edit.vue
+++ b/frontend/src/views/summeruniversity/Edit.vue
@@ -873,26 +873,14 @@ export default {
       if (this.token) this.token.cancel()
       this.token = this.axios.CancelToken.source()
 
-      // Fetch all of the members of the selected organising bodies.
-      const endpoints = this.event.organizing_bodies.map(body => this.services['core'] + '/bodies/' + body.body_id + '/members')
+      // Search members using the lightweight endpoint, scoped to the organising bodies.
+      const bodyIds = this.event.organizing_bodies.map(body => body.body_id).join(',')
 
-      // Ignoring the requests that failed (because of 403 most likely)
-      // since the user does not always has the permissions to see
-      // the members of the body.
-      const fetchEndpoint = (endpoint) => this.axios.get(endpoint, {
+      this.axios.get(this.services['core'] + '/members_search', {
         cancelToken: this.token.token,
-        params: { query }
-      }).then(res => res.data.data).catch(() => [])
-
-      // Merging all of the responses into one array.
-      // Then filtering out duplicate users.
-      // .map is there because the /bodies/:id/members returns users, not members.
-      Promise.all(endpoints.map(fetchEndpoint)).then((responses) => {
-        this.autoComplete.members.values = responses
-          .reduce((acc, val) => acc.concat(val), [])
-          .map(value => (value.user))
-          .filter((elt, index, array) => array.findIndex(e => e.id === elt.id) === index)
-
+        params: { query, body_id: bodyIds }
+      }).then((res) => {
+        this.autoComplete.members.values = res.data.data
         this.autoComplete.members.loading = false
       }).catch((err) => {
         if (this.axios.isCancel(err)) {

--- a/frontend/src/views/summeruniversity/EditSecond.vue
+++ b/frontend/src/views/summeruniversity/EditSecond.vue
@@ -555,26 +555,14 @@ export default {
       if (this.token) this.token.cancel()
       this.token = this.axios.CancelToken.source()
 
-      // Fetch all of the members of the selected organising bodies.
-      const endpoints = this.event.organizing_bodies.map(body => this.services['core'] + '/bodies/' + body.body_id + '/members')
+      // Search members using the lightweight endpoint, scoped to the organising bodies.
+      const bodyIds = this.event.organizing_bodies.map(body => body.body_id).join(',')
 
-      // Ignoring the requests that failed (because of 403 most likely)
-      // since the user does not always has the permissions to see
-      // the members of the body.
-      const fetchEndpoint = (endpoint) => this.axios.get(endpoint, {
+      this.axios.get(this.services['core'] + '/members_search', {
         cancelToken: this.token.token,
-        params: { query }
-      }).then(res => res.data.data).catch(() => [])
-
-      // Merging all of the responses into one array.
-      // Then filtering out duplicate users.
-      // .map is there because the /bodies/:id/members returns users, not members.
-      Promise.all(endpoints.map(fetchEndpoint)).then((responses) => {
-        this.autoComplete.members.values = responses
-          .reduce((acc, val) => acc.concat(val), [])
-          .map(value => (value.user))
-          .filter((elt, index, array) => array.findIndex(e => e.id === elt.id) === index)
-
+        params: { query, body_id: bodyIds }
+      }).then((res) => {
+        this.autoComplete.members.values = res.data.data
         this.autoComplete.members.loading = false
       }).catch((err) => {
         if (this.axios.isCancel(err)) {


### PR DESCRIPTION
## Summary

- Add optional `body_id` query parameter (comma-separated list of IDs) to the existing `GET /members_search` endpoint, enabling results to be scoped to members of specific bodies
- Update SU `Edit.vue` and `EditSecond.vue` to use `/members_search?body_id=...` instead of making N separate `/bodies/:id/members` requests for organizer autocomplete
- Add 5 tests covering single body, multiple bodies, deduplication, combined query+body_id, and invalid body_id handling

## Motivation

The organizer autocomplete in the Summer University edit pages was calling `GET /bodies/:id/members` for each organizing body. This endpoint returns **full user profiles** (address, phone, date of birth, gender, etc.) when the frontend only needs `id`, `first_name`, and `last_name`. 

The new approach:
- **Reduces data exposure**: returns only 6 fields (`id`, `first_name`, `last_name`, `username`, `email`, `gsuite_id`)
- **Reduces network overhead**: single request instead of N parallel requests (one per organizing body)
- **Server-side deduplication**: users in multiple organizing bodies appear once (via `distinct: true`)
- **Backward compatible**: `body_id` is optional, so existing consumers of `/members_search` are unaffected

## Files Changed

| File | Change |
|------|--------|
| `core/middlewares/members.js` | Add `BodyMembership` import; add `body_id` filter logic with Sequelize `include` JOIN |
| `core/test/api/users-searching.test.js` | Add 5 new test cases for body_id filtering |
| `frontend/src/views/summeruniversity/Edit.vue` | Replace multi-request `fetchMembers` with single `/members_search` call |
| `frontend/src/views/summeruniversity/EditSecond.vue` | Same frontend change as Edit.vue |

## Testing

All 14 tests pass (9 existing + 5 new):
```
PASS test/api/users-searching.test.js (1.818s)
Tests: 14 passed, 14 total
```