### PR TITLE
fix(summeruniversity): add backend permission check for SU event creation

### DIFF
--- a/summeruniversity/lib/events.js
+++ b/summeruniversity/lib/events.js
@@ -157,6 +157,10 @@ exports.listApprovableEvents = async (req, res) => {
 };
 
 exports.addEvent = async (req, res) => {
+    if (!req.permissions.create_summeruniversity) {
+        return errors.makeForbiddenError(res, 'You are not allowed to create summer university events.');
+    }
+
     // Make sure the user doesn't insert malicious stuff
     const data = req.body;
     delete data.id;

--- a/summeruniversity/lib/helpers.js
+++ b/summeruniversity/lib/helpers.js
@@ -201,6 +201,7 @@ exports.getPermissions = (user, corePermissions, approvePermissions) => {
         permissions.manage_summeruniversity[type] = hasPermission(corePermissions, 'manage_summeruniversity:' + type);
     }
 
+    permissions.create_summeruniversity = hasPermission(corePermissions, 'create:summeruniversity');
     permissions.apply_general = hasPermission(corePermissions, 'apply:summeruniversity');
 
     permissions.set_board_comment = {};


### PR DESCRIPTION
## Summary

- **Adds a server-side permission check** for the `create:summeruniversity` permission on the `POST /` (create event) endpoint in the summer university service
- Previously, this permission was only enforced on the frontend (UI visibility), meaning any authenticated user could bypass it by sending a direct API request

## Changes

- **`summeruniversity/lib/helpers.js`**: Added `create_summeruniversity` to the permissions object computed in `getPermissions()`, checking for the `create:summeruniversity` core permission
- **`summeruniversity/lib/events.js`**: Added a guard at the top of `addEvent()` that returns a 403 Forbidden error if the user lacks the `create_summeruniversity` permission

## Notes

- The `create:summeruniversity` permission already exists in the core seed data (assigned to the SUCT circle)
- Follows the same pattern used by other permission checks in the service (e.g., `see_summeruniversity`, `edit_summeruniversity`, `delete_summeruniversity`)
- No frontend changes needed — the frontend already checks this permission correctly