### PR TITLE
feat(events): add cc and reply-to to SPC safe person email

### DIFF
--- a/events/lib/events.js
+++ b/events/lib/events.js
@@ -192,6 +192,8 @@ exports.addEvent = async (req, res) => {
         // Sending SPC information email to organizers.
         await mailer.sendMail({
             to: event.organizers.map((organizer) => organizer.notification_email),
+            cc: 'safe.person@aegee.eu',
+            reply_to: 'safe.person@aegee.eu',
             subject: 'MyAEGEE: Tips on make your event a safer space',
             template: 'events_spc_info.html',
             parameters: {

--- a/events/lib/mailer.js
+++ b/events/lib/mailer.js
@@ -11,6 +11,7 @@ module.exports.sendMail = async (options) => {
         body: {
             from: options.from,
             to: options.to,
+            cc: options.cc,
             subject: options.subject,
             template: options.template,
             parameters: options.parameters,


### PR DESCRIPTION
## Summary

- CC and reply-to `safe.person@aegee.eu` on the SPC information email sent to organizers when an event is created, so replies go directly to the Safe Person Committee and they receive a copy of each notification.
- Forward the `cc` field from the events mailer client to the central mailer service (`reply_to` was already forwarded; `cc` was missing).

## Changes

- **`events/lib/mailer.js`** — Pass `cc` field through to the central mailer HTTP request body
- **`events/lib/events.js`** — Add `cc` and `reply_to` set to `safe.person@aegee.eu` on the SPC email in `addEvent`

## Notes

The central Elixir mailer already supports `cc`, `bcc`, and `reply_to` headers (see `mailer/lib/omsmailer/page.ex`). The `network` service already uses both `cc` and `reply_to` for antenna criteria emails, so this pattern is proven.