### PR TITLE
fix(docker): add curl to Alpine-based Node.js images for healthchecks

### DIFF
--- a/core/docker/core/Dockerfile
+++ b/core/docker/core/Dockerfile
@@ -1,7 +1,9 @@
 # Multi-platform support (linux/amd64, linux/arm64)
 FROM --platform=$BUILDPLATFORM node:22-alpine
 
-RUN mkdir -p /usr/app/src \
+# hadolint ignore=DL3018
+RUN apk add --no-cache curl \
+ && mkdir -p /usr/app/src \
  && mkdir -p /usr/app/media \
  && mkdir -p /usr/app/scripts
 

--- a/discounts/docker/discounts/Dockerfile
+++ b/discounts/docker/discounts/Dockerfile
@@ -1,7 +1,9 @@
 # Multi-platform support (linux/amd64, linux/arm64)
 FROM --platform=$BUILDPLATFORM node:22-alpine
 
-RUN mkdir -p /usr/app/src \
+# hadolint ignore=DL3018
+RUN apk add --no-cache curl \
+ && mkdir -p /usr/app/src \
  && mkdir -p /usr/app/media \
  && mkdir -p /usr/app/scripts
 

--- a/events/docker/events/Dockerfile
+++ b/events/docker/events/Dockerfile
@@ -1,7 +1,9 @@
 # Multi-platform support (linux/amd64, linux/arm64)
 FROM --platform=$BUILDPLATFORM node:22-alpine
 
-RUN mkdir -p /usr/app/src \
+# hadolint ignore=DL3018
+RUN apk add --no-cache curl \
+ && mkdir -p /usr/app/src \
  && mkdir -p /usr/app/media \
  && mkdir -p /usr/app/scripts
 

--- a/knowledge/docker/knowledge/Dockerfile
+++ b/knowledge/docker/knowledge/Dockerfile
@@ -1,7 +1,9 @@
 # Multi-platform support (linux/amd64, linux/arm64)
 FROM --platform=$BUILDPLATFORM node:22-alpine
 
-RUN mkdir -p /usr/app/src \
+# hadolint ignore=DL3018
+RUN apk add --no-cache curl \
+ && mkdir -p /usr/app/src \
  && mkdir -p /usr/app/media \
  && mkdir -p /usr/app/scripts
 

--- a/network/docker/network/Dockerfile
+++ b/network/docker/network/Dockerfile
@@ -1,7 +1,9 @@
 # Multi-platform support (linux/amd64, linux/arm64)
 FROM --platform=$BUILDPLATFORM node:22-alpine
 
-RUN mkdir -p /usr/app/src \
+# hadolint ignore=DL3018
+RUN apk add --no-cache curl \
+ && mkdir -p /usr/app/src \
  && mkdir -p /usr/app/media \
  && mkdir -p /usr/app/scripts
 

--- a/statutory/docker/statutory/Dockerfile
+++ b/statutory/docker/statutory/Dockerfile
@@ -1,7 +1,9 @@
 # Multi-platform support (linux/amd64, linux/arm64)
 FROM --platform=$BUILDPLATFORM node:22-alpine
 
-RUN mkdir -p /usr/app/src \
+# hadolint ignore=DL3018
+RUN apk add --no-cache curl \
+ && mkdir -p /usr/app/src \
  && mkdir -p /usr/app/media \
  && mkdir -p /usr/app/scripts
 

--- a/summeruniversity/docker/summeruniversity/Dockerfile
+++ b/summeruniversity/docker/summeruniversity/Dockerfile
@@ -1,7 +1,9 @@
 # Multi-platform support (linux/amd64, linux/arm64)
 FROM --platform=$BUILDPLATFORM node:22-alpine
 
-RUN mkdir -p /usr/app/src \
+# hadolint ignore=DL3018
+RUN apk add --no-cache curl \
+ && mkdir -p /usr/app/src \
  && mkdir -p /usr/app/media/headimages \
  && mkdir -p /usr/app/scripts
 


### PR DESCRIPTION
## Summary

- Adds `apk add --no-cache curl` to all 7 Node.js service Dockerfiles (core, events, discounts, statutory, summeruniversity, knowledge, network)
- Fixes containers being marked unhealthy after the switch from `node:22` (Debian) to `node:22-alpine` in #1770

## Root Cause

The Alpine base image does not include `curl`, but the docker-compose healthcheck probes use `curl -f http://localhost:8084/healthcheck`. Without curl:

1. Every healthcheck probe fails (command not found)
2. Docker marks the container as **unhealthy**
3. Traefik removes unhealthy containers from its backend pool
4. API requests return **404** from Traefik (no backend available)
5. No requests reach the containers, so container logs appear empty

Services like `mailer` were unaffected because its Dockerfile already installs curl via `apk add`. The `discounts` service on production still worked because it was running an image built before the Alpine switch.