### PR TITLE
perf(docker): optimize backend Dockerfiles — cut image sizes by ~55%

### DIFF
--- a/core/docker/core/Dockerfile
+++ b/core/docker/core/Dockerfile
@@ -21,7 +21,7 @@ COPY --chown=node:node package.json package-lock.json ./
 USER node
 
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
- && npm ci --legacy-peer-deps
+ && npm ci --legacy-peer-deps --omit=dev
 
 # Now copy the rest of the source
 COPY --chown=node:node . .

--- a/core/docker/core/Dockerfile
+++ b/core/docker/core/Dockerfile
@@ -3,31 +3,28 @@ FROM --platform=$BUILDPLATFORM node:22-alpine
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl \
- && mkdir -p /usr/app/src \
- && mkdir -p /usr/app/media \
- && mkdir -p /usr/app/scripts
+ && mkdir -p /usr/app/src /usr/app/media /usr/app/scripts /usr/app/src/state \
+ && chown -R node:node /usr/app
 
 WORKDIR /usr/app/src
 
 # Copy bootstrap script first (rarely changes)
-COPY ./docker/core/bootstrap.sh /usr/app/scripts/bootstrap.sh
+COPY --chown=node:node ./docker/core/bootstrap.sh /usr/app/scripts/bootstrap.sh
 
 # Inject version from CI if provided (defaults to whatever is in package.json)
 ARG PACKAGE_VERSION
 
 # Copy only dependency manifests first to maximise layer caching.
 # Rebuilds that only change source code will skip the npm ci step.
-COPY package.json package-lock.json ./
+COPY --chown=node:node package.json package-lock.json ./
+
+USER node
+
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
  && npm ci --legacy-peer-deps
 
 # Now copy the rest of the source
-COPY . .
-
-RUN mkdir -p /usr/app/src/state \
- && chown -R node:node /usr/app
-
-USER node
+COPY --chown=node:node . .
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:${PATH}"

--- a/discounts/docker/discounts/Dockerfile
+++ b/discounts/docker/discounts/Dockerfile
@@ -21,7 +21,7 @@ COPY --chown=node:node package.json package-lock.json ./
 USER node
 
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
- && npm ci --legacy-peer-deps
+ && npm ci --legacy-peer-deps --omit=dev
 
 # Now copy the rest of the source
 COPY --chown=node:node . .

--- a/discounts/docker/discounts/Dockerfile
+++ b/discounts/docker/discounts/Dockerfile
@@ -3,30 +3,28 @@ FROM --platform=$BUILDPLATFORM node:22-alpine
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl \
- && mkdir -p /usr/app/src \
- && mkdir -p /usr/app/media \
- && mkdir -p /usr/app/scripts
+ && mkdir -p /usr/app/src /usr/app/media /usr/app/scripts \
+ && chown -R node:node /usr/app
 
 WORKDIR /usr/app/src
 
 # Copy bootstrap script first (rarely changes)
-COPY ./docker/discounts/bootstrap.sh /usr/app/scripts/bootstrap.sh
+COPY --chown=node:node ./docker/discounts/bootstrap.sh /usr/app/scripts/bootstrap.sh
 
 # Inject version from CI if provided (defaults to whatever is in package.json)
 ARG PACKAGE_VERSION
 
 # Copy only dependency manifests first to maximise layer caching.
 # Rebuilds that only change source code will skip the npm ci step.
-COPY package.json package-lock.json ./
+COPY --chown=node:node package.json package-lock.json ./
+
+USER node
+
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
  && npm ci --legacy-peer-deps
 
 # Now copy the rest of the source
-COPY . .
-
-RUN chown -R node:node /usr/app
-
-USER node
+COPY --chown=node:node . .
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:${PATH}"

--- a/events/docker/events/Dockerfile
+++ b/events/docker/events/Dockerfile
@@ -21,7 +21,7 @@ COPY --chown=node:node package.json package-lock.json ./
 USER node
 
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
- && npm ci --legacy-peer-deps
+ && npm ci --legacy-peer-deps --omit=dev
 
 # Now copy the rest of the source
 COPY --chown=node:node . .

--- a/events/docker/events/Dockerfile
+++ b/events/docker/events/Dockerfile
@@ -3,30 +3,28 @@ FROM --platform=$BUILDPLATFORM node:22-alpine
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl \
- && mkdir -p /usr/app/src \
- && mkdir -p /usr/app/media \
- && mkdir -p /usr/app/scripts
+ && mkdir -p /usr/app/src /usr/app/media /usr/app/scripts \
+ && chown -R node:node /usr/app
 
 WORKDIR /usr/app/src
 
 # Copy bootstrap script first (rarely changes)
-COPY ./docker/events/bootstrap.sh /usr/app/scripts/bootstrap.sh
+COPY --chown=node:node ./docker/events/bootstrap.sh /usr/app/scripts/bootstrap.sh
 
 # Inject version from CI if provided (defaults to whatever is in package.json)
 ARG PACKAGE_VERSION
 
 # Copy only dependency manifests first to maximise layer caching.
 # Rebuilds that only change source code will skip the npm ci step.
-COPY package.json package-lock.json ./
+COPY --chown=node:node package.json package-lock.json ./
+
+USER node
+
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
  && npm ci --legacy-peer-deps
 
 # Now copy the rest of the source
-COPY . .
-
-RUN chown -R node:node /usr/app
-
-USER node
+COPY --chown=node:node . .
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:${PATH}"

--- a/gsuite-wrapper/docker/Dockerfile
+++ b/gsuite-wrapper/docker/Dockerfile
@@ -1,6 +1,9 @@
 # Multi-platform support (linux/amd64, linux/arm64)
 FROM --platform=$BUILDPLATFORM node:22-alpine
 
+RUN mkdir -p /usr/app/src \
+ && chown -R node:node /usr/app
+
 WORKDIR /usr/app/src
 
 # Inject version from CI if provided (defaults to whatever is in package.json)
@@ -8,16 +11,15 @@ ARG PACKAGE_VERSION
 
 # Copy only dependency manifests first to maximise layer caching.
 # Rebuilds that only change source code will skip the npm ci step.
-COPY package.json package-lock.json ./
+COPY --chown=node:node package.json package-lock.json ./
+
+USER node
+
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
  && npm ci --legacy-peer-deps
 
 # Now copy the rest of the source
-COPY . .
-
-RUN chown -R node:node /usr/app
-
-USER node
+COPY --chown=node:node . .
 
 ENTRYPOINT ["npm"]
 CMD ["start"]

--- a/gsuite-wrapper/docker/Dockerfile
+++ b/gsuite-wrapper/docker/Dockerfile
@@ -16,7 +16,7 @@ COPY --chown=node:node package.json package-lock.json ./
 USER node
 
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
- && npm ci --legacy-peer-deps
+ && npm ci --legacy-peer-deps --omit=dev
 
 # Now copy the rest of the source
 COPY --chown=node:node . .

--- a/knowledge/docker/knowledge/Dockerfile
+++ b/knowledge/docker/knowledge/Dockerfile
@@ -21,7 +21,7 @@ COPY --chown=node:node package.json package-lock.json ./
 USER node
 
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
- && npm ci --legacy-peer-deps
+ && npm ci --legacy-peer-deps --omit=dev
 
 # Now copy the rest of the source
 COPY --chown=node:node . .

--- a/knowledge/docker/knowledge/Dockerfile
+++ b/knowledge/docker/knowledge/Dockerfile
@@ -3,30 +3,28 @@ FROM --platform=$BUILDPLATFORM node:22-alpine
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl \
- && mkdir -p /usr/app/src \
- && mkdir -p /usr/app/media \
- && mkdir -p /usr/app/scripts
+ && mkdir -p /usr/app/src /usr/app/media /usr/app/scripts \
+ && chown -R node:node /usr/app
 
 WORKDIR /usr/app/src
 
 # Copy bootstrap script first (rarely changes)
-COPY ./docker/knowledge/bootstrap.sh /usr/app/scripts/bootstrap.sh
+COPY --chown=node:node ./docker/knowledge/bootstrap.sh /usr/app/scripts/bootstrap.sh
 
 # Inject version from CI if provided (defaults to whatever is in package.json)
 ARG PACKAGE_VERSION
 
 # Copy only dependency manifests first to maximise layer caching.
 # Rebuilds that only change source code will skip the npm ci step.
-COPY package.json package-lock.json ./
+COPY --chown=node:node package.json package-lock.json ./
+
+USER node
+
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
  && npm ci --legacy-peer-deps
 
 # Now copy the rest of the source
-COPY . .
-
-RUN chown -R node:node /usr/app
-
-USER node
+COPY --chown=node:node . .
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:${PATH}"

--- a/network/docker/network/Dockerfile
+++ b/network/docker/network/Dockerfile
@@ -21,7 +21,7 @@ COPY --chown=node:node package.json package-lock.json ./
 USER node
 
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
- && npm ci --legacy-peer-deps
+ && npm ci --legacy-peer-deps --omit=dev
 
 # Now copy the rest of the source
 COPY --chown=node:node . .

--- a/network/docker/network/Dockerfile
+++ b/network/docker/network/Dockerfile
@@ -3,30 +3,28 @@ FROM --platform=$BUILDPLATFORM node:22-alpine
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl \
- && mkdir -p /usr/app/src \
- && mkdir -p /usr/app/media \
- && mkdir -p /usr/app/scripts
+ && mkdir -p /usr/app/src /usr/app/media /usr/app/scripts \
+ && chown -R node:node /usr/app
 
 WORKDIR /usr/app/src
 
 # Copy bootstrap script first (rarely changes)
-COPY ./docker/network/bootstrap.sh /usr/app/scripts/bootstrap.sh
+COPY --chown=node:node ./docker/network/bootstrap.sh /usr/app/scripts/bootstrap.sh
 
 # Inject version from CI if provided (defaults to whatever is in package.json)
 ARG PACKAGE_VERSION
 
 # Copy only dependency manifests first to maximise layer caching.
 # Rebuilds that only change source code will skip the npm ci step.
-COPY package.json package-lock.json ./
+COPY --chown=node:node package.json package-lock.json ./
+
+USER node
+
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
  && npm ci --legacy-peer-deps
 
 # Now copy the rest of the source
-COPY . .
-
-RUN chown -R node:node /usr/app
-
-USER node
+COPY --chown=node:node . .
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:${PATH}"

--- a/statutory/docker/statutory/Dockerfile
+++ b/statutory/docker/statutory/Dockerfile
@@ -21,7 +21,7 @@ COPY --chown=node:node package.json package-lock.json ./
 USER node
 
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
- && npm ci --legacy-peer-deps
+ && npm ci --legacy-peer-deps --omit=dev
 
 # Now copy the rest of the source
 COPY --chown=node:node . .

--- a/statutory/docker/statutory/Dockerfile
+++ b/statutory/docker/statutory/Dockerfile
@@ -3,30 +3,28 @@ FROM --platform=$BUILDPLATFORM node:22-alpine
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl \
- && mkdir -p /usr/app/src \
- && mkdir -p /usr/app/media \
- && mkdir -p /usr/app/scripts
+ && mkdir -p /usr/app/src /usr/app/media /usr/app/scripts \
+ && chown -R node:node /usr/app
 
 WORKDIR /usr/app/src
 
 # Copy bootstrap script first (rarely changes)
-COPY ./docker/statutory/bootstrap.sh /usr/app/scripts/bootstrap.sh
+COPY --chown=node:node ./docker/statutory/bootstrap.sh /usr/app/scripts/bootstrap.sh
 
 # Inject version from CI if provided (defaults to whatever is in package.json)
 ARG PACKAGE_VERSION
 
 # Copy only dependency manifests first to maximise layer caching.
 # Rebuilds that only change source code will skip the npm ci step.
-COPY package.json package-lock.json ./
+COPY --chown=node:node package.json package-lock.json ./
+
+USER node
+
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
  && npm ci --legacy-peer-deps
 
 # Now copy the rest of the source
-COPY . .
-
-RUN chown -R node:node /usr/app
-
-USER node
+COPY --chown=node:node . .
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:${PATH}"

--- a/summeruniversity/docker/summeruniversity/Dockerfile
+++ b/summeruniversity/docker/summeruniversity/Dockerfile
@@ -21,7 +21,7 @@ COPY --chown=node:node package.json package-lock.json ./
 USER node
 
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
- && npm ci --legacy-peer-deps
+ && npm ci --legacy-peer-deps --omit=dev
 
 # Now copy the rest of the source
 COPY --chown=node:node . .

--- a/summeruniversity/docker/summeruniversity/Dockerfile
+++ b/summeruniversity/docker/summeruniversity/Dockerfile
@@ -3,30 +3,28 @@ FROM --platform=$BUILDPLATFORM node:22-alpine
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl \
- && mkdir -p /usr/app/src \
- && mkdir -p /usr/app/media/headimages \
- && mkdir -p /usr/app/scripts
+ && mkdir -p /usr/app/src /usr/app/media/headimages /usr/app/scripts \
+ && chown -R node:node /usr/app
 
 WORKDIR /usr/app/src
 
 # Copy bootstrap script first (rarely changes)
-COPY ./docker/summeruniversity/bootstrap.sh /usr/app/scripts/bootstrap.sh
+COPY --chown=node:node ./docker/summeruniversity/bootstrap.sh /usr/app/scripts/bootstrap.sh
 
 # Inject version from CI if provided (defaults to whatever is in package.json)
 ARG PACKAGE_VERSION
 
 # Copy only dependency manifests first to maximise layer caching.
 # Rebuilds that only change source code will skip the npm ci step.
-COPY package.json package-lock.json ./
+COPY --chown=node:node package.json package-lock.json ./
+
+USER node
+
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
  && npm ci --legacy-peer-deps
 
 # Now copy the rest of the source
-COPY . .
-
-RUN chown -R node:node /usr/app
-
-USER node
+COPY --chown=node:node . .
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:${PATH}"


### PR DESCRIPTION
## Summary

- Replace expensive `chown -R node:node /usr/app` with `COPY --chown=node:node` and early `USER node`, eliminating the duplicate layer that re-wrote every file in `node_modules`
- Add `--omit=dev` to `npm ci` so devDependencies (eslint, jest, semantic-release, faker, etc. — 74-85% of all packages) are excluded from production images

## Image size comparison

| Image | Before | After | Savings |
|---|---|---|---|
| `aegee/core` | 515 MB | 228 MB | -287 MB (56%) |
| `aegee/network` | 517 MB | 229 MB | -288 MB (56%) |
| `aegee/knowledge` | 506 MB | 223 MB | -283 MB (56%) |
| `aegee/events` | 537 MB | 251 MB | -286 MB (53%) |
| `aegee/statutory` | 549 MB | 247 MB | -302 MB (55%) |
| `aegee/summeruniversity` | 538 MB | 252 MB | -286 MB (53%) |
| `aegee/discounts` | 558 MB | 223 MB | -335 MB (60%) |
| `aegee/gsuite-wrapper` | 658 MB | 300 MB | -358 MB (54%) |

## Notes

- `sequelize-cli` is in production `dependencies` (not `devDependencies`) for all 7 services that need it, so migrations continue to work
- `gsuite-wrapper` does not use Sequelize at all
- Build speed also improves since `npm ci --omit=dev` installs fewer packages and the `chown -R` walk is eliminated