### PR TITLE
fix(ci): remove redundant workspace npm ci from docker-build-and-push jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -819,10 +819,6 @@ jobs:
           name: Install monorepo workspace dependencies
           command: npm install --ignore-scripts
       - run:
-          name: Install frontend dependencies (skip husky)
-          working_directory: ~/project/frontend
-          command: npm ci --legacy-peer-deps --ignore-scripts
-      - run:
           name: Run semantic-release for frontend
           working_directory: ~/project/frontend
           command: npm run semantic-release
@@ -1037,10 +1033,6 @@ jobs:
       - run:
           name: Install monorepo workspace dependencies
           command: npm install --ignore-scripts
-      - run:
-          name: Install gsuite-wrapper dependencies (skip husky)
-          working_directory: ~/project/gsuite-wrapper
-          command: npm ci --legacy-peer-deps --ignore-scripts
       - run:
           name: Run semantic-release for gsuite-wrapper
           working_directory: ~/project/gsuite-wrapper


### PR DESCRIPTION
## Summary

Fixes the `semantic-release: not found` failure in `frontend-docker-build-and-push` and `gsuite-wrapper-docker-build-and-push` jobs after the dependency hoisting in #1771.

## Root cause

The frontend and gsuite-wrapper docker-build-and-push jobs had an extra `npm ci --legacy-peer-deps --ignore-scripts` step that ran **in the workspace subdirectory** after the root-level `npm install --ignore-scripts`. This workspace-level install created a separate context where `semantic-release` wasn't available, because it was hoisted to root-only devDependencies in #1771.

The other 8 workspace docker-build-and-push jobs never had this extra step and continued to work fine.

## Fix

Remove the redundant workspace-level `npm ci` from these two jobs. The root `npm install --ignore-scripts` already installs all dependencies for all workspaces via npm workspaces hoisting.

The remaining 3 occurrences of workspace-level `npm ci` (frontend-eslint, gsuite-wrapper-test, gsuite-wrapper-eslint) are unaffected -- those jobs don't run semantic-release and the packages they need (eslint, mocha, etc.) are still declared in the workspace devDependencies.