### PR TITLE
fix(frontend): redirect authenticated users away from login route

### DIFF
--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -58,9 +58,15 @@ const { state } = store
 
 router.beforeEach((to, from, next) => {
   const prefix = to.name === 'oms.login' ? '' : '?to=' + encodeURI(to.fullPath)
+  const loggedInRedirectPath = to.query.to ? decodeURI(to.query.to) : '/dashboard'
 
   // Fuck my life.
   if (state.login.user) {
+    if (to.name === 'oms.login') {
+      console.debug('User is already logged in, redirecting away from /login.')
+      return next(loggedInRedirectPath)
+    }
+
     if (!state.login.isValid && to.meta.auth && to.name !== 'oms.profile.update') {
       console.debug('User is invalid (user fetched):', state.login.validationErrors)
       console.debug('Path', from.path, to.path)
@@ -90,6 +96,11 @@ router.beforeEach((to, from, next) => {
 
   // Fetching user if not fetched.
   return router.app.$auth.fetchUserWithExistingData().then(() => {
+    if (state.login.isLoggedIn && to.name === 'oms.login') {
+      console.debug('User is already logged in after auth check, redirecting away from /login.')
+      return next(loggedInRedirectPath)
+    }
+
     if (!state.login.isLoggedIn && to.meta.auth) {
       throw new Error('Trying to access the auth-only page while being unauthorized.')
     }

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -38,15 +38,25 @@ export default {
       error: null
     }
   },
+  created () {
+    this.redirectIfAuthenticated()
+  },
   methods: {
+    redirectIfAuthenticated () {
+      if (!this.$store.state.login.isLoggedIn) {
+        return
+      }
+
+      if (this.$route.query.to) {
+        this.$router.replace(decodeURI(this.$route.query.to))
+      } else {
+        this.$router.replace('/dashboard')
+      }
+    },
     login () {
       this.error = null
       this.$auth.login(this.data).then(() => {
-        if (this.$route.query.to) {
-          this.$router.push(decodeURI(this.$route.query.to))
-        } else {
-          this.$router.push('/dashboard')
-        }
+        this.redirectIfAuthenticated()
       }).catch((err) => {
         if (err.response && err.response.data && err.response.data.message) {
           this.error = err.response.data.message


### PR DESCRIPTION
## Summary
- Fix the router guard so authenticated users are redirected away from `/login` to either `?to=` target or `/dashboard`.
- Add a defensive redirect in the Vue 2 login view on creation and reuse it after successful login to avoid staying on the login page.
- This addresses the production state where sidebar data loads correctly but the first page render remains on login.

## Validation
- `npm run lint -- src/app.js src/views/auth/Login.vue`