### PR TITLE
feat(statutory): require permission to edit memberslists between deadlines. Fixes HELP-2900

### DIFF
--- a/core/scripts/seed.js
+++ b/core/scripts/seed.js
@@ -574,6 +574,12 @@ async function createPermissions() {
         description: 'Update the is_on_memberslist status for applications for Agora. Should be assigned to Network Director.'
     },
     {
+        action: 'edit_memberslist_between_deadlines',
+        object: 'agora',
+        scope: 'global',
+        description: 'Edit memberslists between submission and edit deadlines for Agora.'
+    },
+    {
         action: 'manage_network',
         object: 'communication_exception',
         scope: 'global',

--- a/frontend/src/views/statutory/UploadMembersList.vue
+++ b/frontend/src/views/statutory/UploadMembersList.vue
@@ -60,6 +60,14 @@
           </div>
         </div>
 
+        <article
+          class="message is-warning"
+          v-if="selectedBody && memberslist && !canEditMemberslist(selectedBody) && isBetweenMemberslistDeadlines">
+          <div class="message-body">
+            Editing members lists between the submission and edit deadlines requires an additional permission.
+          </div>
+        </article>
+
         <div v-if="selectedBody && memberslist">
           <hr />
           <span>Uploaded list:</span>
@@ -164,10 +172,20 @@ export default {
       saved: true
     }
   },
-  computed: mapGetters({
-    services: 'services',
-    loginUser: 'user'
-  }),
+  computed: {
+    ...mapGetters({
+      services: 'services',
+      loginUser: 'user'
+    }),
+    isBetweenMemberslistDeadlines () {
+      if (!this.event.memberslist_submission_deadline || !this.event.memberslist_edit_deadline) {
+        return false
+      }
+
+      const now = moment()
+      return now.isAfter(this.event.memberslist_submission_deadline) && now.isSameOrBefore(this.event.memberslist_edit_deadline)
+    }
+  },
   methods: {
     fetchMembersList () {
       this.isLoading = true

--- a/frontend/src/views/statutory/UploadMembersList.vue
+++ b/frontend/src/views/statutory/UploadMembersList.vue
@@ -64,7 +64,8 @@
           class="message is-warning"
           v-if="selectedBody && memberslist && !canEditMemberslist(selectedBody) && isBetweenMemberslistDeadlines">
           <div class="message-body">
-            Editing members lists between the submission and edit deadlines requires an additional permission.
+            The upload deadline has passed. If you want to make changes to the members list, reach out to the Network Director at
+            <a href="mailto:network@aegee.eu">network@aegee.eu</a>.
           </div>
         </article>
 

--- a/statutory/lib/helpers.js
+++ b/statutory/lib/helpers.js
@@ -296,6 +296,11 @@ exports.getEventPermissions = (data) => {
         myApplication
     } = data;
 
+    const now = moment();
+    const isBetweenMemberslistDeadlines = now.isAfter(event.memberslist_submission_deadline)
+        && now.isSameOrBefore(event.memberslist_edit_deadline);
+    const hasMemberslistEditBetweenDeadlinesPermission = hasPermission(corePermissions, 'global:edit_memberslist_between_deadlines:' + event.type);
+
     // Event-related permissions
     permissions.edit_event = hasPermission(corePermissions, 'global:manage_event:' + event.type);
     permissions.change_event_status = hasPermission(corePermissions, 'global:manage_event:' + event.type);
@@ -333,6 +338,9 @@ exports.getEventPermissions = (data) => {
     permissions.edit_memberslist = {
         global: hasPermission(corePermissions, 'global:approve_members:' + event.type)
     };
+    if (isBetweenMemberslistDeadlines) {
+        permissions.edit_memberslist.global = permissions.edit_memberslist.global && hasMemberslistEditBetweenDeadlinesPermission;
+    }
     permissions.see_memberslist = {
         global: hasPermission(corePermissions, 'global:see_memberslists:' + event.type)
     };
@@ -359,6 +367,9 @@ exports.getEventPermissions = (data) => {
         permissions.see_boardview[body.id] = approveBodiesList.includes(body.id);
         permissions.upload_memberslist[body.id] = (event.can_upload_memberslist || hasPermission(corePermissions, 'memberslist_late:' + event.type)) && approveBodiesList.includes(body.id) && exports.isLocal(body);
         permissions.edit_memberslist[body.id] = (event.can_edit_memberslist || hasPermission(corePermissions, 'memberslist_late:' + event.type)) && approveBodiesList.includes(body.id) && exports.isLocal(body);
+        if (isBetweenMemberslistDeadlines) {
+            permissions.edit_memberslist[body.id] = permissions.edit_memberslist[body.id] && hasMemberslistEditBetweenDeadlinesPermission;
+        }
         permissions.see_memberslist[body.id] = approveBodiesList.includes(body.id) && exports.isLocal(body);
     }
 

--- a/statutory/test/api/memberslist-upload.test.js
+++ b/statutory/test/api/memberslist-upload.test.js
@@ -212,6 +212,137 @@ describe('Memberslist uploading', () => {
         expect(res.body).toHaveProperty('data');
     });
 
+    test('should fail to update memberslist between submission and edit deadlines without dedicated permission', async () => {
+        mock.mockAll({ mainPermissions: { noPermissions: true } });
+
+        const event = await generator.createEvent({
+            type: 'agora',
+            application_period_starts: moment().subtract(21, 'days'),
+            application_period_ends: moment().subtract(20, 'days'),
+            board_approve_deadline: moment().subtract(19, 'days'),
+            participants_list_publish_deadline: moment().subtract(18, 'days'),
+            memberslist_submission_deadline: moment().subtract(1, 'days'),
+            starts: moment().add(20, 'days'),
+            ends: moment().add(21, 'days')
+        });
+
+        await generator.createMembersList({
+            body_id: regularUser.bodies[0].id,
+            user_id: regularUser.id,
+            members: [{ first_name: 'test', last_name: 'test', fee: 3, user_id: 1 }]
+        }, event);
+
+        const res = await request({
+            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: generator.generateMembersList({}, event)
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+    });
+
+    test('should fail to update memberslist between submission and edit deadlines with dedicated local permission', async () => {
+        mock.mockAll({ mainPermissions: { editBetweenDeadlinesLocalPermissions: true } });
+
+        const event = await generator.createEvent({
+            type: 'agora',
+            application_period_starts: moment().subtract(21, 'days'),
+            application_period_ends: moment().subtract(20, 'days'),
+            board_approve_deadline: moment().subtract(19, 'days'),
+            participants_list_publish_deadline: moment().subtract(18, 'days'),
+            memberslist_submission_deadline: moment().subtract(1, 'days'),
+            starts: moment().add(20, 'days'),
+            ends: moment().add(21, 'days')
+        });
+
+        await generator.createMembersList({
+            body_id: regularUser.bodies[0].id,
+            user_id: regularUser.id,
+            members: [{ first_name: 'test', last_name: 'test', fee: 3, user_id: 1 }]
+        }, event);
+
+        const res = await request({
+            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: generator.generateMembersList({}, event)
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+    });
+
+    test('should fail to update memberslist between submission and edit deadlines with global approve permission only', async () => {
+        mock.mockAll({ approvePermissions: { noPermissions: true } });
+
+        const event = await generator.createEvent({
+            type: 'agora',
+            application_period_starts: moment().subtract(21, 'days'),
+            application_period_ends: moment().subtract(20, 'days'),
+            board_approve_deadline: moment().subtract(19, 'days'),
+            participants_list_publish_deadline: moment().subtract(18, 'days'),
+            memberslist_submission_deadline: moment().subtract(1, 'days'),
+            starts: moment().add(20, 'days'),
+            ends: moment().add(21, 'days')
+        });
+
+        await generator.createMembersList({
+            body_id: regularUser.bodies[0].id,
+            user_id: regularUser.id,
+            members: [{ first_name: 'test', last_name: 'test', fee: 3, user_id: 1 }]
+        }, event);
+
+        const res = await request({
+            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: generator.generateMembersList({}, event)
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+    });
+
+    test('should succeed to update memberslist between submission and edit deadlines with dedicated global permission', async () => {
+        mock.mockAll({
+            mainPermissions: { editBetweenDeadlinesGlobalPermissions: true },
+            approvePermissions: { noPermissions: true }
+        });
+
+        const event = await generator.createEvent({
+            type: 'agora',
+            application_period_starts: moment().subtract(21, 'days'),
+            application_period_ends: moment().subtract(20, 'days'),
+            board_approve_deadline: moment().subtract(19, 'days'),
+            participants_list_publish_deadline: moment().subtract(18, 'days'),
+            memberslist_submission_deadline: moment().subtract(1, 'days'),
+            starts: moment().add(20, 'days'),
+            ends: moment().add(21, 'days')
+        });
+
+        await generator.createMembersList({
+            body_id: regularUser.bodies[0].id,
+            user_id: regularUser.id,
+            members: [{ first_name: 'test', last_name: 'test', fee: 3, user_id: 1 }]
+        }, event);
+
+        const res = await request({
+            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: generator.generateMembersList({}, event)
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+    });
+
     test('should discard fee_paid', async () => {
         mock.mockAll({ approvePermissions: { noPermissions: true } });
 

--- a/statutory/test/assets/core-permissions-edit-between-deadlines-global.json
+++ b/statutory/test/assets/core-permissions-edit-between-deadlines-global.json
@@ -1,0 +1,24 @@
+{
+    "success": true,
+    "data": [{
+        "scope": "global",
+        "object": "agora",
+        "id": 1002,
+        "filters": [],
+        "description": "Approve every board.",
+        "combined": "global:approve_members:agora",
+        "circles": null,
+        "always_assigned": false,
+        "action": "approve_members"
+    }, {
+        "scope": "global",
+        "object": "agora",
+        "id": 1003,
+        "filters": [],
+        "description": "Edit memberslists between submission and edit deadlines.",
+        "combined": "global:edit_memberslist_between_deadlines:agora",
+        "circles": null,
+        "always_assigned": false,
+        "action": "edit_memberslist_between_deadlines"
+    }]
+}

--- a/statutory/test/assets/core-permissions-edit-between-deadlines-local.json
+++ b/statutory/test/assets/core-permissions-edit-between-deadlines-local.json
@@ -1,0 +1,13 @@
+{
+    "success": true,
+    "data": [{
+        "scope": "local",
+        "object": "agora",
+        "id": 1001,
+        "filters": [],
+        "description": "Edit memberslist between submission and edit deadlines for Agora statutory events.",
+        "combined": "local:edit_memberslist_between_deadlines:agora",
+        "circles": null,
+        "action": "edit_memberslist_between_deadlines"
+      }]
+}

--- a/statutory/test/scripts/mock-core-registry.js
+++ b/statutory/test/scripts/mock-core-registry.js
@@ -85,6 +85,20 @@ exports.mockCoreMainPermissions = (options) => {
             .replyWithFile(200, path.join(__dirname, '..', 'assets', 'core-permissions-apply.json'));
     }
 
+    if (options.editBetweenDeadlinesLocalPermissions) {
+        return nock(`${config.core.url}:${config.core.port}`)
+            .persist()
+            .get('/my_permissions')
+            .replyWithFile(200, path.join(__dirname, '..', 'assets', 'core-permissions-edit-between-deadlines-local.json'));
+    }
+
+    if (options.editBetweenDeadlinesGlobalPermissions) {
+        return nock(`${config.core.url}:${config.core.port}`)
+            .persist()
+            .get('/my_permissions')
+            .replyWithFile(200, path.join(__dirname, '..', 'assets', 'core-permissions-edit-between-deadlines-global.json'));
+    }
+
     if (options.noPermissions) {
         return nock(`${config.core.url}:${config.core.port}`)
             .persist()


### PR DESCRIPTION
## Summary
- add a new global permission `edit_memberslist_between_deadlines:agora` and include it in Network Director seed permissions
- update statutory permission resolution so editing memberslists between `memberslist_submission_deadline` and `memberslist_edit_deadline` requires this dedicated permission (for both global and local editors)
- update statutory tests and mock permission fixtures to cover allowed/denied scenarios in the between-deadlines window, and show a frontend warning when edit is blocked in that period

## Testing
- `NODE_ENV=test npm run db:setup && npx jest test/api/memberslist-upload.test.js --runInBand --forceExit`