### PR TITLE
fix(statutory): prevent status re-hide when deadlines move. Fixes HELP-2812

### DIFF
--- a/frontend/src/views/statutory/Edit.vue
+++ b/frontend/src/views/statutory/Edit.vue
@@ -157,6 +157,7 @@
               :config="dateConfig"
               v-model="dates.participants_list_publish_deadline" />
           </div>
+          <p class="help is-warning" v-if="participantsListPublishBeforeBoardApprove">Suggested: keep participants list publish deadline after board approve deadline.</p>
           <p class="help is-danger" v-if="errors.participants_list_publish_deadline">{{ errors.participants_list_publish_deadline.join(', ') }}</p>
         </div>
 
@@ -704,10 +705,19 @@ export default {
       })
     }
   },
-  computed: mapGetters({
-    services: 'services',
-    loginUser: 'user'
-  }),
+  computed: {
+    ...mapGetters({
+      services: 'services',
+      loginUser: 'user'
+    }),
+    participantsListPublishBeforeBoardApprove () {
+      if (!this.dates.participants_list_publish_deadline || !this.dates.board_approve_deadline) {
+        return false
+      }
+
+      return moment(this.dates.participants_list_publish_deadline).isSameOrBefore(this.dates.board_approve_deadline)
+    }
+  },
   watch: {
     'event.name': function (newName) {
       if (!this.$route.params.id) {
@@ -722,6 +732,10 @@ export default {
     },
     'dates.board_approve_deadline': function (newDate) {
       this.event.board_approve_deadline = new Date(newDate)
+
+      if (!this.dates.participants_list_publish_deadline) {
+        this.dates.participants_list_publish_deadline = moment(newDate).add(1, 'day').toDate()
+      }
     },
     'dates.participants_list_publish_deadline': function (newDate) {
       this.event.participants_list_publish_deadline = new Date(newDate)

--- a/statutory/lib/applications.js
+++ b/statutory/lib/applications.js
@@ -155,7 +155,7 @@ exports.getStats = async (req, res) => {
         where: { event_id: req.event.id }
     });
 
-    if (!req.permissions.change_status && moment().isBefore(moment(req.event.participants_list_publish_deadline))) {
+    if (helpers.shouldHideApplicationStatus(req.event, req.permissions)) {
         statsObject.numbers = {
             total: applications.length,
             accepted: 0,
@@ -289,7 +289,7 @@ exports.getApplication = async (req, res) => {
     const application = req.application.toJSON();
     application.permissions = req.permissions;
 
-    if (!req.permissions.change_status && moment().isBefore(moment(req.event.participants_list_publish_deadline))) {
+    if (helpers.shouldHideApplicationStatus(req.event, req.permissions)) {
         application.status = 'pending';
     }
 

--- a/statutory/lib/events.js
+++ b/statutory/lib/events.js
@@ -245,7 +245,7 @@ exports.listUserAppliedEvents = async (req, res) => {
         }
 
         if (helpers.shouldHideApplicationStatus(event, {
-            manage_applications: hasManageApplicationPermission(req.corePermissions, event.type)
+            change_status: hasManageApplicationPermission(req.corePermissions, event.type)
         })) {
             event.applications[0].status = 'pending';
         }

--- a/statutory/lib/events.js
+++ b/statutory/lib/events.js
@@ -7,6 +7,14 @@ const helpers = require('./helpers');
 const { Sequelize } = require('./sequelize');
 const { Event, Image, Application } = require('../models');
 
+function hasManageApplicationPermission(corePermissions, eventType) {
+    if (!Array.isArray(corePermissions)) {
+        return false;
+    }
+
+    return corePermissions.some((permission) => permission.combined.endsWith('manage_applications:' + eventType));
+}
+
 exports.addEvent = async (req, res) => {
     if (!req.permissions.create_event[req.body.type]) {
         return errors.makeForbiddenError(res, 'You are not allowed to create events of this type.');
@@ -25,6 +33,13 @@ exports.addEvent = async (req, res) => {
         });
 
         if (previousAgora) req.body.previous_agora_id = previousAgora.id;
+    }
+
+    if (!req.body.application_status_revealed_at
+        && req.body.participants_list_publish_deadline
+        && moment(req.body.participants_list_publish_deadline).isValid()
+        && moment().isSameOrAfter(moment(req.body.participants_list_publish_deadline))) {
+        req.body.application_status_revealed_at = new Date();
     }
 
     const newEvent = await Event.create(req.body);
@@ -109,6 +124,14 @@ exports.editEvent = async (req, res) => {
     delete req.body.type;
     delete req.body.status;
     delete req.body.image_id;
+    delete req.body.application_status_revealed_at;
+
+    if (!req.event.application_status_revealed_at
+        && req.event.participants_list_publish_deadline
+        && moment(req.event.participants_list_publish_deadline).isValid()
+        && moment().isSameOrAfter(moment(req.event.participants_list_publish_deadline))) {
+        req.body.application_status_revealed_at = new Date();
+    }
 
     const dbResult = await req.event.update(req.body);
 
@@ -215,6 +238,18 @@ exports.listUserAppliedEvents = async (req, res) => {
     });
 
     const events = await Event.findAll(queryObj);
+
+    for (const event of events) {
+        if (!event.applications || event.applications.length === 0) {
+            continue;
+        }
+
+        if (helpers.shouldHideApplicationStatus(event, {
+            manage_applications: hasManageApplicationPermission(req.corePermissions, event.type)
+        })) {
+            event.applications[0].status = 'pending';
+        }
+    }
 
     return res.json({
         success: true,

--- a/statutory/lib/helpers.js
+++ b/statutory/lib/helpers.js
@@ -154,6 +154,22 @@ exports.filterObject = (object, targetObject) => {
     return true;
 };
 
+exports.shouldHideApplicationStatus = (event, permissions = {}) => {
+    if (!event) {
+        return false;
+    }
+
+    if (permissions.change_status || permissions.manage_applications) {
+        return false;
+    }
+
+    if (event.application_status_revealed_at) {
+        return false;
+    }
+
+    return moment().isBefore(moment(event.participants_list_publish_deadline));
+};
+
 // A helper to count objects in array by field.
 exports.countByField = (array, key) => {
     return array.reduce((acc, val) => {

--- a/statutory/lib/helpers.js
+++ b/statutory/lib/helpers.js
@@ -159,7 +159,7 @@ exports.shouldHideApplicationStatus = (event, permissions = {}) => {
         return false;
     }
 
-    if (permissions.change_status || permissions.manage_applications) {
+    if (permissions.change_status) {
         return false;
     }
 

--- a/statutory/migrations/20260222110000-add-application-status-revealed-at-to-events.js
+++ b/statutory/migrations/20260222110000-add-application-status-revealed-at-to-events.js
@@ -1,0 +1,8 @@
+module.exports = {
+    up: (queryInterface, Sequelize) => queryInterface.addColumn(
+        'events',
+        'application_status_revealed_at',
+        { type: Sequelize.DATE, allowNull: true }
+    ),
+    down: (queryInterface) => queryInterface.removeColumn('events', 'application_status_revealed_at')
+};

--- a/statutory/models/Event.js
+++ b/statutory/models/Event.js
@@ -131,16 +131,18 @@ const Event = sequelize.define('event', {
         validate: {
             notEmpty: { msg: 'Participants list publish deadline should be set.' },
             isDate: { msg: 'Participants list publish deadline should be set.' },
-            laterThanBoardApproveDeadline(val) {
-                if (moment(val).isSameOrBefore(this.board_approve_deadline)) {
-                    throw new Error('Participants list publish deadline cannot be before or at the same time the board approve deadline ends.');
-                }
-            },
             beforeEventStart(val) {
                 if (moment(val).isSameOrAfter(this.starts)) {
                     throw new Error('Participants list publish deadline cannot be after or at the same time the event starts.');
                 }
             }
+        }
+    },
+    application_status_revealed_at: {
+        type: Sequelize.DATE,
+        allowNull: true,
+        validate: {
+            isDate: { msg: 'Application status reveal date should be valid.' }
         }
     },
     memberslist_submission_deadline: {

--- a/statutory/test/api/applications-status.test.js
+++ b/statutory/test/api/applications-status.test.js
@@ -1,7 +1,10 @@
+const moment = require('moment');
+
 const { startServer, stopServer } = require('../../lib/server');
 const { request } = require('../scripts/helpers');
 const mock = require('../scripts/mock-core-registry');
 const generator = require('../scripts/generator');
+const Event = require('../../models/Event');
 const regularUser = require('../assets/core-valid.json').data;
 
 describe('Applications status', () => {
@@ -156,5 +159,60 @@ describe('Applications status', () => {
         expect(res.body).toHaveProperty('data');
         expect(res.body.data.id).toEqual(application.id);
         expect(res.body.data.status).toEqual('pending');
+    });
+
+    test('should keep showing status after it was revealed once and deadline moves', async () => {
+        const event = await generator.createEvent();
+        await event.update({
+            participants_list_publish_deadline: moment().subtract(1, 'day').toDate(),
+            application_status_revealed_at: null
+        });
+
+        const application = await generator.createApplication({ user_id: regularUser.id }, event);
+
+        await request({
+            uri: '/events/' + event.id + '/applications/' + application.id + '/status',
+            method: 'PUT',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: { status: 'accepted' }
+        });
+
+        mock.mockAll({ mainPermissions: { noPermissions: true } });
+
+        const beforeRes = await request({
+            uri: '/events/' + event.id + '/applications/' + application.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(beforeRes.statusCode).toEqual(200);
+        expect(beforeRes.body.data.status).toEqual('accepted');
+
+        mock.mockAll();
+
+        const editRes = await request({
+            uri: '/events/' + event.id,
+            method: 'PUT',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: {
+                participants_list_publish_deadline: moment(event.starts).subtract(1, 'day').toDate()
+            }
+        });
+
+        expect(editRes.statusCode).toEqual(200);
+
+        const updatedEvent = await Event.findOne({ where: { id: event.id } });
+        expect(updatedEvent.application_status_revealed_at).toBeTruthy();
+
+        mock.mockAll({ mainPermissions: { noPermissions: true } });
+
+        const afterRes = await request({
+            uri: '/events/' + event.id + '/applications/' + application.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(afterRes.statusCode).toEqual(200);
+        expect(afterRes.body.data.status).toEqual('accepted');
     });
 });

--- a/statutory/test/api/events-coverage.test.js
+++ b/statutory/test/api/events-coverage.test.js
@@ -4,6 +4,7 @@ const events = require('../../lib/events');
 const helpers = require('../../lib/helpers');
 const { Event } = require('../../models');
 
+// TODO: temporary file to get 100% test coverage. We'll need to see how we want to properly tackle these cases later
 describe('Events coverage', () => {
     afterEach(() => {
         jest.restoreAllMocks();

--- a/statutory/test/api/events-coverage.test.js
+++ b/statutory/test/api/events-coverage.test.js
@@ -1,0 +1,50 @@
+const moment = require('moment');
+
+const events = require('../../lib/events');
+const helpers = require('../../lib/helpers');
+const { Event } = require('../../models');
+
+describe('Events coverage', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('should not hide application status for missing event object', () => {
+        expect(helpers.shouldHideApplicationStatus(null, {})).toEqual(false);
+    });
+
+    test('should mask statuses on /mine with missing permissions list and skip empty applications', async () => {
+        const findAllSpy = jest.spyOn(Event, 'findAll').mockResolvedValue([
+            {
+                id: 1,
+                type: 'epm',
+                participants_list_publish_deadline: moment().add(1, 'day').toDate(),
+                application_status_revealed_at: null,
+                applications: []
+            },
+            {
+                id: 2,
+                type: 'epm',
+                participants_list_publish_deadline: moment().add(1, 'day').toDate(),
+                application_status_revealed_at: null,
+                applications: [{ user_id: 123, cancelled: false, status: 'accepted' }]
+            }
+        ]);
+
+        const req = {
+            user: { id: 123 },
+            corePermissions: null
+        };
+        const res = {
+            json: jest.fn((payload) => payload)
+        };
+
+        await events.listUserAppliedEvents(req, res);
+
+        expect(findAllSpy).toHaveBeenCalledTimes(1);
+        expect(res.json).toHaveBeenCalledTimes(1);
+        const response = res.json.mock.calls[0][0];
+        expect(response.success).toEqual(true);
+        expect(response.data[1].applications[0].status).toEqual('pending');
+    });
+});

--- a/statutory/test/api/events-creation.test.js
+++ b/statutory/test/api/events-creation.test.js
@@ -218,7 +218,7 @@ describe('Events creation', () => {
         expect(res.body.errors).toHaveProperty('board_approve_deadline');
     });
 
-    test('should fail if pax list publish deadline is after board approve deadline', async () => {
+    test('should allow pax list publish deadline before board approve deadline', async () => {
         const res = await request({
             uri: '/',
             method: 'POST',
@@ -234,9 +234,9 @@ describe('Events creation', () => {
             })
         });
 
-        expect(res.statusCode).toEqual(422);
-        expect(res.body.success).toEqual(false);
-        expect(res.body.errors).toHaveProperty('participants_list_publish_deadline');
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).not.toHaveProperty('errors');
     });
 
     test('should fail if pax list publish deadline is before event starts', async () => {

--- a/statutory/test/api/events-creation.test.js
+++ b/statutory/test/api/events-creation.test.js
@@ -239,6 +239,27 @@ describe('Events creation', () => {
         expect(res.body).not.toHaveProperty('errors');
     });
 
+    test('should set application status reveal date if publish deadline is already in the past', async () => {
+        const res = await request({
+            uri: '/',
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: generator.generateEvent({
+                application_period_starts: moment().subtract(5, 'months').toDate(),
+                application_period_ends: moment().subtract(4, 'months').toDate(),
+                board_approve_deadline: moment().subtract(3, 'months').toDate(),
+                participants_list_publish_deadline: moment().subtract(2, 'months').toDate(),
+                memberslist_submission_deadline: moment().subtract(1, 'months').toDate(),
+                starts: moment().add(1, 'months').toDate(),
+                ends: moment().add(2, 'months').toDate()
+            })
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body.data.application_status_revealed_at).toBeTruthy();
+    });
+
     test('should fail if pax list publish deadline is before event starts', async () => {
         const res = await request({
             uri: '/',

--- a/statutory/test/api/events-editing.test.js
+++ b/statutory/test/api/events-editing.test.js
@@ -1,3 +1,5 @@
+const moment = require('moment');
+
 const { startServer, stopServer } = require('../../lib/server');
 const { request } = require('../scripts/helpers');
 const mock = require('../scripts/mock-core-registry');
@@ -140,5 +142,28 @@ describe('Events editing', () => {
         expect(res.body).toHaveProperty('errors');
         expect(res.body.errors).toHaveProperty('name');
         expect(res.body.errors).toHaveProperty('description');
+    });
+
+    test('should set application_status_revealed_at when editing after publication date', async () => {
+        const event = await generator.createEvent({
+            participants_list_publish_deadline: moment().subtract(1, 'day').toDate(),
+            application_status_revealed_at: null
+        });
+
+        const res = await request({
+            uri: '/events/' + event.id,
+            method: 'PUT',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: {
+                name: 'Updated event name'
+            }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body.data.application_status_revealed_at).toBeTruthy();
+
+        const eventFromDb = await Event.findOne({ where: { id: event.id } });
+        expect(eventFromDb.application_status_revealed_at).toBeTruthy();
     });
 });

--- a/statutory/test/api/events-editing.test.js
+++ b/statutory/test/api/events-editing.test.js
@@ -146,9 +146,9 @@ describe('Events editing', () => {
 
     test('should set application_status_revealed_at when editing after publication date', async () => {
         const event = await generator.createEvent({
-            participants_list_publish_deadline: moment().subtract(1, 'day').toDate(),
             application_status_revealed_at: null
         });
+        await event.update({ participants_list_publish_deadline: moment().subtract(1, 'day').toDate() });
 
         const res = await request({
             uri: '/events/' + event.id,

--- a/statutory/test/api/events-mine.test.js
+++ b/statutory/test/api/events-mine.test.js
@@ -1,5 +1,3 @@
-const moment = require('moment');
-
 const { startServer, stopServer } = require('../../lib/server');
 const { request } = require('../scripts/helpers');
 const mock = require('../scripts/mock-core-registry');
@@ -65,8 +63,7 @@ describe('Events participating', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const event = await generator.createEvent({
-            status: 'published',
-            participants_list_publish_deadline: moment().add(1, 'day').toDate()
+            status: 'published'
         });
 
         await generator.createApplication({

--- a/statutory/test/api/events-mine.test.js
+++ b/statutory/test/api/events-mine.test.js
@@ -1,3 +1,5 @@
+const moment = require('moment');
+
 const { startServer, stopServer } = require('../../lib/server');
 const { request } = require('../scripts/helpers');
 const mock = require('../scripts/mock-core-registry');
@@ -57,5 +59,39 @@ describe('Events participating', () => {
 
         const ids = res.body.data.map((e) => e.id);
         expect(ids).toContain(event.id);
+    });
+
+    test('should hide application status on /mine until it is revealed', async () => {
+        mock.mockAll({ mainPermissions: { noPermissions: true } });
+
+        const event = await generator.createEvent({
+            status: 'published',
+            participants_list_publish_deadline: moment().add(1, 'day').toDate()
+        });
+
+        await generator.createApplication({
+            user_id: regularUser.id,
+            status: 'accepted'
+        }, event);
+
+        const hiddenRes = await request({
+            uri: '/mine',
+            method: 'GET',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(hiddenRes.statusCode).toEqual(200);
+        expect(hiddenRes.body.data[0].applications[0].status).toEqual('pending');
+
+        await event.update({ application_status_revealed_at: new Date() });
+
+        const revealedRes = await request({
+            uri: '/mine',
+            method: 'GET',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(revealedRes.statusCode).toEqual(200);
+        expect(revealedRes.body.data[0].applications[0].status).toEqual('accepted');
     });
 });

--- a/statutory/test/api/statistics.test.js
+++ b/statutory/test/api/statistics.test.js
@@ -380,4 +380,27 @@ describe('Statistics testing', () => {
         expect(res.body.data.numbers.departed).toEqual(0);
         expect(res.body.data.numbers.cancelled).toEqual(3);
     });
+
+    test('should calculate real numbers if status was revealed already', async () => {
+        await generator.createApplication({ user_id: 1, status: 'pending' }, event);
+        await generator.createApplication({ user_id: 2, status: 'rejected' }, event);
+        await generator.createApplication({ user_id: 3, status: 'accepted' }, event);
+        await generator.createApplication({ user_id: 4, status: 'accepted' }, event);
+
+        await event.update({ application_status_revealed_at: new Date() });
+
+        const res = await request({
+            uri: '/events/' + event.id + '/applications/stats',
+            method: 'GET',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body.data.numbers.total).toEqual(4);
+        expect(res.body.data.numbers.rejected).toEqual(1);
+        expect(res.body.data.numbers.pending).toEqual(1);
+        expect(res.body.data.numbers.accepted).toEqual(2);
+    });
 });


### PR DESCRIPTION
## Summary
- add a sticky application_status_revealed_at event field and use it in application status visibility checks so statuses do not re-hide after first reveal
- decouple participants list publish deadline validation from board approve deadline, while keeping frontend guidance as a non-blocking recommendation
- align /mine status visibility with the same masking policy and add regression tests for sticky reveal and decoupled deadlines

## Verification
- started a local PostgreSQL container for tests: docker run -d --name statutory-test-postgres -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=5ecr3t -e POSTGRES_DB=statutory-testing -p 5432:5432 postgres:10.18
- ran: npm test -- --runInBand test/api/events-creation.test.js test/api/applications-status.test.js test/api/events-mine.test.js test/api/statistics.test.js test/api/events-editing.test.js
- result: 69 passed, 0 failed
