### PR TITLE
fix(docker): respect no-vagrant mode in helper hostname check

### DIFF
--- a/helper.sh
+++ b/helper.sh
@@ -92,7 +92,15 @@ compose_wrapper ()
     service_string=$(printenv ENABLED_SERVICES)
     # shellcheck disable=SC2206
     services=( ${service_string//:/ } )
-    command=( docker-compose -f "${DIR}/base-docker-compose.yml" )
+    if command -v docker-compose >/dev/null 2>&1; then
+        compose_command=( docker-compose )
+    elif docker compose version >/dev/null 2>&1; then
+        compose_command=( docker compose )
+    else
+        echo "[MyAEGEE] ERROR: neither 'docker-compose' nor 'docker compose' is available"
+        return 127
+    fi
+    command=( "${compose_command[@]}" -f "${DIR}/base-docker-compose.yml" )
     for s in "${services[@]}"; do
         if [[ -f "${DIR}/${s}/docker/docker-compose.yml" ]]; then
             if [[ "${MYAEGEE_ENV}" == "production" ]]; then

--- a/helper.sh
+++ b/helper.sh
@@ -157,10 +157,13 @@ function retry {
 
 WANTEDNAME=$(head -n1 Vagrantfile | grep -oP 'machine_name = "\K[^"]+' )
 HOST=$(hostname -f)
-# TODO: ignore this when using --no-vagrant in start.sh
 if [[ ! ${HOST} =~ ^${WANTEDNAME} ]]; then
-  echo "You're on ${HOST}, (the HOST) but you should be on '${WANTEDNAME}' (the GUEST). Exiting..."
-  exit 1
+  if [[ "${NO_VAGRANT}" == "true" ]]; then
+    echo "You're on ${HOST}, (the HOST) but expected '${WANTEDNAME}' (the GUEST). Continuing because NO_VAGRANT=true."
+  else
+    echo "You're on ${HOST}, (the HOST) but you should be on '${WANTEDNAME}' (the GUEST). Exiting..."
+    exit 1
+  fi
 fi
 
 # HUMAN INTERVENTION NEEDED: register in .env your services

--- a/start.sh
+++ b/start.sh
@@ -42,10 +42,12 @@ export $(grep -v '^#' ${DIR}/.env | xargs -d '\n')
 
 #run accordingly
 if ( $novagrant ); then
+  export NO_VAGRANT=true
   check_etc_hosts "127.0.0.1" "localhost"
   sed -i 's/appserver/localhost/' .env
   make bootstrap
 else
+  export NO_VAGRANT=false
   check_etc_hosts "192.168.168.168" "${BASE_URL}"
   if ( $fast ); then
     sed -i 's/development/production/' .env
@@ -56,4 +58,3 @@ else
   export ANSIBLE_NOCOWS=false
   vagrant up
 fi
-


### PR DESCRIPTION
## Summary
- export `NO_VAGRANT` from `start.sh` based on whether `--no-vagrant` is used
- keep the hostname mismatch hard-stop in `helper.sh` for normal (vagrant) runs
- allow `helper.sh` to continue only when `NO_VAGRANT=true`, enabling `start.sh --no-vagrant`