### PR TITLE
fix(statutory): restrict post-deadline application body reassignment

### DIFF
--- a/statutory/lib/applications.js
+++ b/statutory/lib/applications.js
@@ -305,7 +305,12 @@ exports.updateApplication = async (req, res) => {
     }
 
     const user = await core.getMember(req, req.application.user_id);
-    if (req.body.body_id && !helpers.isMemberOf(user, req.body.body_id)) {
+    const bodyIdChanged = req.body.body_id && req.body.body_id !== req.application.body_id;
+    if (bodyIdChanged && moment().isAfter(req.event.application_period_ends) && !req.permissions.manage_applications) {
+        return errors.makeForbiddenError(res, 'Only users with manage applications permission can change body after the application deadline.');
+    }
+
+    if (bodyIdChanged && !helpers.isMemberOf(user, req.body.body_id)) {
         return errors.makeForbiddenError(res, 'You cannot apply on behalf of the body you are not a member of.');
     }
 
@@ -333,7 +338,7 @@ exports.updateApplication = async (req, res) => {
     }
 
     // If user changed his body (by himself), reset his board comment and participant type/order.
-    if (req.application.user_id === req.user.id && req.body.body_id && req.body.body_id !== req.application.body_id) {
+    if (req.application.user_id === req.user.id && bodyIdChanged) {
         req.body.participant_type = null;
         req.body.participant_order = null;
         req.body.board_comment = null;

--- a/statutory/test/api/applications-editing.test.js
+++ b/statutory/test/api/applications-editing.test.js
@@ -136,6 +136,32 @@ describe('Applications editing', () => {
         expect(res.body).toHaveProperty('message');
     });
 
+    test('should return 403 for user with apply permissions changing body after deadline', async () => {
+        const event = await generator.createEvent({ type: 'agora' });
+        const application = await generator.createApplication({
+            user_id: regularUser.id,
+            body_id: regularUser.bodies[0].id
+        }, event);
+
+        tk.travel(moment(event.application_period_ends).add(5, 'minutes').toDate());
+
+        mock.mockAll({ mainPermissions: { applyPermissions: true } });
+
+        const res = await request({
+            uri: '/events/' + event.id + '/applications/' + application.id,
+            method: 'PUT',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: { body_id: regularUser.bodies[1].id }
+        });
+
+        tk.reset();
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
     test('should succeed for user who has permissions', async () => {
         const event = await generator.createEvent();
         const application = await generator.createApplication({}, event);
@@ -316,6 +342,54 @@ describe('Applications editing', () => {
         }, event);
 
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
+
+        const res = await request({
+            uri: '/events/' + event.id + '/applications/' + application.id,
+            method: 'PUT',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: { body_id: 1337 }
+        });
+
+        tk.reset();
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should succeed for manage applications user changing body after deadline', async () => {
+        const event = await generator.createEvent({ type: 'agora' });
+        const application = await generator.createApplication({
+            user_id: regularUser.id,
+            body_id: regularUser.bodies[0].id,
+        }, event);
+
+        tk.travel(moment(event.application_period_ends).add(5, 'minutes').toDate());
+
+        const res = await request({
+            uri: '/events/' + event.id + '/applications/' + application.id,
+            method: 'PUT',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: { body_id: regularUser.bodies[1].id }
+        });
+
+        tk.reset();
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body.data.body_id).toEqual(regularUser.bodies[1].id);
+    });
+
+    test('should return 403 for manage applications user changing to body applicant is not member of after deadline', async () => {
+        const event = await generator.createEvent({ type: 'agora' });
+        const application = await generator.createApplication({
+            user_id: regularUser.id,
+            body_id: regularUser.bodies[0].id,
+        }, event);
+
+        tk.travel(moment(event.application_period_ends).add(5, 'minutes').toDate());
 
         const res = await request({
             uri: '/events/' + event.id + '/applications/' + application.id,


### PR DESCRIPTION
## Summary
- Require `manage_applications` when changing an application's `body_id` after `application_period_ends`.
- Keep the membership guard for body changes so reassignment is only allowed to bodies the applicant belongs to.
- Add API tests covering allowed/forbidden post-deadline body changes for apply vs manage permissions.

## Testing
- `NODE_ENV=test npm run db:setup && npx jest test/api/applications-editing.test.js --runInBand --forceExit`
- `npx eslint lib/applications.js test/api/applications-editing.test.js`