### PR TITLE
fix(frontend): clarify missing memberslist deadline warning

### DIFF
--- a/frontend/src/views/statutory/UploadMembersList.vue
+++ b/frontend/src/views/statutory/UploadMembersList.vue
@@ -137,8 +137,17 @@
           </table>
         </div>
 
+        <article
+          class="message is-warning"
+          v-if="selectedBody && !memberslist && isBetweenMemberslistDeadlines">
+          <div class="message-body">
+            The submission deadline has passed. If your local still needs to submit a members list, reach out to the Network Director at
+            <a href="mailto:network@aegee.eu">network@aegee.eu</a>.
+          </div>
+        </article>
+
         <div v-if="selectedBody && !memberslist">
-          <span>Your local hasn't submitted members list for this event yet.</span>
+          <span>This local hasn't submitted a members list for this event yet.</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- keep the generic missing-memberslist text visible for selected locals even after the submission deadline
- add a separate warning between the submission and edit deadlines that tells locals to contact the Network Director if they still need to submit
- tighten the copy so the status message stays factual and the warning carries the follow-up action