### PR TITLE
fix(statutory): separate memberslist permissions from board approval

### DIFF
--- a/core/scripts/seed.js
+++ b/core/scripts/seed.js
@@ -351,7 +351,7 @@ async function createPermissions() {
             scope: 'local',
             object: 'epm',
             action: 'approve_members',
-            description: 'Approve members for a local/manage memberslists for a local for EPM'
+            description: 'Set pax type/order and board comment for EPM applications.'
         },
         {
             scope: 'local',
@@ -366,6 +366,18 @@ async function createPermissions() {
             description: 'Set pax type/order and board comment for Agora applications.'
         },
         {
+            scope: 'local',
+            object: 'agora',
+            action: 'manage_memberslist',
+            description: 'Upload, edit and view memberslists for Agora for your local.'
+        },
+        {
+            scope: 'local',
+            object: 'epm',
+            action: 'manage_memberslist',
+            description: 'Upload, edit and view memberslists for EPM for your local.'
+        },
+        {
             scope: 'join_request',
             object: 'member',
             action: 'view',
@@ -375,7 +387,13 @@ async function createPermissions() {
             scope: 'local',
             object: 'spm',
             action: 'approve_members',
-            description: ' Approve members for SPM and put board comments for boardies'
+            description: 'Set pax type/order and board comment for SPM applications.'
+        },
+        {
+            scope: 'local',
+            object: 'spm',
+            action: 'manage_memberslist',
+            description: 'Upload, edit and view memberslists for SPM for your local.'
         },
         {
             action: 'search',
@@ -485,7 +503,13 @@ async function createPermissions() {
             action: 'approve_members',
             object: 'epm',
             scope: 'global',
-            description: 'Approve EPM members'
+            description: 'Set pax type/order and board comment for EPM applications for all bodies.'
+        },
+        {
+            action: 'manage_memberslist',
+            object: 'epm',
+            scope: 'global',
+            description: 'Upload, edit and view memberslists for EPM for all bodies.'
         },
         {
             action: 'manage_applications',
@@ -620,6 +644,12 @@ async function createPermissions() {
         object: 'fulfilment_report',
         scope: 'global',
         description: 'Set the fulfilment of the `fulfilment report` Antenna Criterion'
+    },
+    {
+        action: 'manage_memberslist',
+        object: 'agora',
+        scope: 'global',
+        description: 'Upload, edit and view memberslists for Agora for all bodies.'
     }], { individualHooks: true, validate: true });
 
     permissions.networkDirector = [...networkDirectorPermissions, ...permissions.netCom, permissions.setMemberslistsFeePaidAgora];
@@ -746,6 +776,18 @@ async function createPermissions() {
         object: 'circle',
         scope: 'global',
         description: 'List and view the details of any circle, excluding members data'
+    },
+    {
+        action: 'approve_members',
+        object: 'agora',
+        scope: 'global',
+        description: 'Set pax type/order and board comment for Agora applications for all bodies.'
+    },
+    {
+        action: 'manage_memberslist',
+        object: 'agora',
+        scope: 'global',
+        description: 'Upload, edit and view memberslists for Agora for all bodies.'
     }], { individualHooks: true, validate: true });
 
     permissions.chair = [...chairPermissions, permissions.viewMembersCircle, permissions.addMemberCircle, permissions.viewMember];
@@ -783,12 +825,6 @@ async function createPermissions() {
             object: 'agora',
             scope: 'global',
             description: 'Apply to Agora/edit your application regardless if the deadline was passed or not.'
-        },
-        {
-            action: 'approve_members',
-            object: 'agora',
-            scope: 'global',
-            description: 'Approve members for Agora for all bodies'
         },
         {
             action: 'manage_applications',
@@ -1034,7 +1070,13 @@ async function createPermissions() {
             action: 'approve_members',
             object: 'spm',
             scope: 'global',
-            description: 'Approve members for SPM and put board comments'
+            description: 'Set pax type/order and board comment for SPM applications for all bodies.'
+        },
+        {
+            action: 'manage_memberslist',
+            object: 'spm',
+            scope: 'global',
+            description: 'Upload, edit and view memberslists for SPM for all bodies.'
         },
         {
             action: 'manage_applications',

--- a/core/scripts/seed.js
+++ b/core/scripts/seed.js
@@ -255,6 +255,12 @@ async function createPermissions() {
         scope: 'global',
         description: 'Manage the Antenna Criteria fulfilment of Locals'
     });
+    permissions.manageMemberslistAgora = await Permission.create({
+        action: 'manage_memberslist',
+        object: 'agora',
+        scope: 'global',
+        description: 'Upload, edit and view memberslists for Agora for all bodies.'
+    });
 
     permissions.members = await Permission.bulkCreate([{
         scope: 'global',
@@ -644,15 +650,9 @@ async function createPermissions() {
         object: 'fulfilment_report',
         scope: 'global',
         description: 'Set the fulfilment of the `fulfilment report` Antenna Criterion'
-    },
-    {
-        action: 'manage_memberslist',
-        object: 'agora',
-        scope: 'global',
-        description: 'Upload, edit and view memberslists for Agora for all bodies.'
     }], { individualHooks: true, validate: true });
 
-    permissions.networkDirector = [...networkDirectorPermissions, ...permissions.netCom, permissions.setMemberslistsFeePaidAgora];
+    permissions.networkDirector = [...networkDirectorPermissions, ...permissions.netCom, permissions.setMemberslistsFeePaidAgora, permissions.manageMemberslistAgora];
 
     const financialDirectorPermissions = await Permission.bulkCreate([{
         action: 'manage_network',
@@ -782,15 +782,9 @@ async function createPermissions() {
         object: 'agora',
         scope: 'global',
         description: 'Set pax type/order and board comment for Agora applications for all bodies.'
-    },
-    {
-        action: 'manage_memberslist',
-        object: 'agora',
-        scope: 'global',
-        description: 'Upload, edit and view memberslists for Agora for all bodies.'
     }], { individualHooks: true, validate: true });
 
-    permissions.chair = [...chairPermissions, permissions.viewMembersCircle, permissions.addMemberCircle, permissions.viewMember];
+    permissions.chair = [...chairPermissions, permissions.viewMembersCircle, permissions.addMemberCircle, permissions.viewMember, permissions.manageMemberslistAgora];
 
     const jcPermissions = await Permission.bulkCreate([{
         action: 'manage_juridical',

--- a/statutory/lib/core.js
+++ b/statutory/lib/core.js
@@ -79,6 +79,23 @@ const getApprovePermissions = async (req, event) => {
     return approveRequest;
 };
 
+const getMemberslistPermissions = async (req, event) => {
+    // Fetching permissions for memberslist management, the list of bodies
+    // where do you have the 'manage_memberslist:<event_type>' permission for it.
+    const memberslistRequest = await makeRequest({
+        url: config.core.url + ':' + config.core.port + '/my_permissions',
+        method: 'POST',
+        token: req.headers['x-auth-token'],
+        resolveWithFullResponse: true,
+        body: {
+            action: 'manage_memberslist',
+            object: event.type
+        }
+    });
+
+    return memberslistRequest;
+};
+
 const getBodies = async (req) => {
     const bodies = await makeRequest({
         url: config.core.url + ':' + config.core.port + '/bodies',
@@ -191,6 +208,7 @@ module.exports = {
     getMails,
     getBody,
     getApprovePermissions,
+    getMemberslistPermissions,
     getBodies,
     getMyProfile,
     getMyPermissions,

--- a/statutory/lib/helpers.js
+++ b/statutory/lib/helpers.js
@@ -306,6 +306,7 @@ exports.getEventPermissions = (data) => {
         permissions,
         corePermissions,
         approvePermissions,
+        memberslistPermissions,
         user,
         event,
         limits,
@@ -349,16 +350,16 @@ exports.getEventPermissions = (data) => {
         global: hasPermission(corePermissions, 'global:approve_members:' + event.type)
     };
     permissions.upload_memberslist = {
-        global: hasPermission(corePermissions, 'global:approve_members:' + event.type)
+        global: hasPermission(corePermissions, 'global:manage_memberslist:' + event.type)
     };
     permissions.edit_memberslist = {
-        global: hasPermission(corePermissions, 'global:approve_members:' + event.type)
+        global: hasPermission(corePermissions, 'global:manage_memberslist:' + event.type)
     };
     if (isBetweenMemberslistDeadlines) {
         permissions.edit_memberslist.global = permissions.edit_memberslist.global && hasMemberslistEditBetweenDeadlinesPermission;
     }
     permissions.see_memberslist = {
-        global: hasPermission(corePermissions, 'global:see_memberslists:' + event.type)
+        global: hasPermission(corePermissions, 'global:manage_memberslist:' + event.type)
     };
     permissions.see_missing_memberslist = {
         global: hasPermission(corePermissions, 'global:see_missing_memberslists:' + event.type)
@@ -376,17 +377,18 @@ exports.getEventPermissions = (data) => {
     permissions.mark_attendance = hasPermission(corePermissions, 'global:mark_attendance:agora');
 
     const approveBodiesList = getBodiesListFromPermissions(approvePermissions);
+    const memberslistBodiesList = getBodiesListFromPermissions(memberslistPermissions);
     const bodies = user ? user.bodies : [];
 
     for (const body of bodies) {
         permissions.set_board_comment_and_participant_type[body.id] = event.can_approve_members && approveBodiesList.includes(body.id);
         permissions.see_boardview[body.id] = approveBodiesList.includes(body.id);
-        permissions.upload_memberslist[body.id] = (event.can_upload_memberslist || hasPermission(corePermissions, 'memberslist_late:' + event.type)) && approveBodiesList.includes(body.id) && exports.isLocal(body);
-        permissions.edit_memberslist[body.id] = (event.can_edit_memberslist || hasPermission(corePermissions, 'memberslist_late:' + event.type)) && approveBodiesList.includes(body.id) && exports.isLocal(body);
+        permissions.upload_memberslist[body.id] = (event.can_upload_memberslist || hasPermission(corePermissions, 'memberslist_late:' + event.type)) && memberslistBodiesList.includes(body.id) && exports.isLocal(body);
+        permissions.edit_memberslist[body.id] = (event.can_edit_memberslist || hasPermission(corePermissions, 'memberslist_late:' + event.type)) && memberslistBodiesList.includes(body.id) && exports.isLocal(body);
         if (isBetweenMemberslistDeadlines) {
             permissions.edit_memberslist[body.id] = permissions.edit_memberslist[body.id] && hasMemberslistEditBetweenDeadlinesPermission;
         }
-        permissions.see_memberslist[body.id] = approveBodiesList.includes(body.id) && exports.isLocal(body);
+        permissions.see_memberslist[body.id] = memberslistBodiesList.includes(body.id) && exports.isLocal(body);
     }
 
     permissions.apply_from_body = {};

--- a/statutory/lib/middlewares.js
+++ b/statutory/lib/middlewares.js
@@ -55,6 +55,7 @@ exports.ensureAuthorized = async (req, res, next) => {
         req.userRequest.statusCode === 401
         || req.permissionsRequest.statusCode === 401
         || (req.approveRequest && req.approveRequest.statusCode === 401)
+        || (req.memberslistRequest && req.memberslistRequest.statusCode === 401)
     ) {
         return errors.makeUnauthorizedError(res, 'Error fetching data: user is not authenticated.');
     }
@@ -116,7 +117,10 @@ exports.fetchEvent = async (req, res, next) => {
         return errors.makeNotFoundError(res, 'Event with such url or ID is not found.');
     }
 
-    const approveRequest = await core.getApprovePermissions(req, event);
+    const [approveRequest, memberslistRequest] = await Promise.all([
+        core.getApprovePermissions(req, event),
+        core.getMemberslistPermissions(req, event)
+    ]);
 
     if (typeof approveRequest.body !== 'object') {
         throw new Error('Malformed response when fetching permissions for approve');
@@ -125,6 +129,14 @@ exports.fetchEvent = async (req, res, next) => {
     // skipping 401 there, will catch them later in ensureAuthorized
     if (!approveRequest.body.success && approveRequest.statusCode !== 401) {
         throw new Error(`Error fetching permissions for approve: ${JSON.stringify(approveRequest.body)}`);
+    }
+
+    if (typeof memberslistRequest.body !== 'object') {
+        throw new Error('Malformed response when fetching permissions for memberslist');
+    }
+
+    if (!memberslistRequest.body.success && memberslistRequest.statusCode !== 401) {
+        throw new Error(`Error fetching permissions for memberslist: ${JSON.stringify(memberslistRequest.body)}`);
     }
 
     let limits = [];
@@ -144,12 +156,15 @@ exports.fetchEvent = async (req, res, next) => {
     req.event = event;
     req.myApplication = myApplication;
     req.approveRequest = approveRequest;
+    req.memberslistRequest = memberslistRequest;
     if (req.approveRequest.body && req.approveRequest.body.success) req.approvePermissions = approveRequest.body.data;
+    if (req.memberslistRequest.body && req.memberslistRequest.body.success) req.memberslistPermissions = memberslistRequest.body.data;
 
     req.permissions = helpers.getEventPermissions({
         permissions: req.permissions,
         corePermissions: req.corePermissions,
         approvePermissions: req.approvePermissions,
+        memberslistPermissions: req.memberslistPermissions,
         user: req.user,
         event,
         limits,

--- a/statutory/test/api/api-requests.test.js
+++ b/statutory/test/api/api-requests.test.js
@@ -192,6 +192,56 @@ describe('API requests', () => {
         expect(res.body.success).toEqual(false);
     });
 
+    test('should return 500 if core returned unsuccessful response for memberslist permissions', async () => {
+        mock.mockAll({ memberslistPermissions: { unsuccessfulResponse: true } });
+
+        const event = await generator.createEvent();
+
+        const res = await request({
+            uri: '/events/' + event.id + '/applications',
+            method: 'GET',
+            headers: {
+                'X-Auth-Token': 'blablabla'
+            }
+        });
+
+        expect(res.statusCode).toEqual(500);
+        expect(res.body.success).toEqual(false);
+    });
+
+    test('should return 401 if the memberslist permissions request returned 401 for auth-only endpoint', async () => {
+        mock.mockAll({ memberslistPermissions: { unauthorized: true } });
+
+        const event = await generator.createEvent();
+
+        const res = await request({
+            uri: '/events/' + event.id + '/applications',
+            method: 'GET',
+            headers: {
+                'X-Auth-Token': 'blablabla'
+            }
+        });
+
+        expect(res.statusCode).toEqual(401);
+        expect(res.body.success).toEqual(false);
+    });
+
+    test('should fail if core returns garbage while fetching memberslist permissions', async () => {
+        mock.mockAll({ memberslistPermissions: { badResponse: true } });
+        const event = await generator.createEvent({});
+
+        const res = await request({
+            uri: '/events/' + event.id,
+            method: 'GET',
+            headers: {
+                'X-Auth-Token': 'blablabla'
+            }
+        });
+
+        expect(res.statusCode).toEqual(500);
+        expect(res.body.success).toEqual(false);
+    });
+
     test('should fail if body is not JSON', async () => {
         const res = await request({
             uri: '/',

--- a/statutory/test/api/applications-board.test.js
+++ b/statutory/test/api/applications-board.test.js
@@ -96,6 +96,41 @@ describe('Applications pax type/board comment', () => {
         expect(res.body).toHaveProperty('message');
     });
 
+    test('should succeed for board comment when user has approve_members but not manage_memberslist', async () => {
+        mock.mockAll({ mainPermissions: { noPermissions: true }, memberslistPermissions: { noPermissions: true } });
+
+        application = await application.update({ user_id: 1337 }, { returning: ['*'] });
+
+        const res = await request({
+            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            method: 'PUT',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: { participant_type: 'delegate', board_comment: 'test', participant_order: 1 }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body.data.participant_type).toEqual('delegate');
+    });
+
+    test('should return 403 for board comment when user has manage_memberslist but not approve_members', async () => {
+        mock.mockAll({ approvePermissions: { noPermissions: true }, mainPermissions: { noPermissions: true } });
+
+        application = await application.update({ user_id: 1337 }, { returning: ['*'] });
+
+        const res = await request({
+            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            method: 'PUT',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: { participant_type: 'delegate', participant_order: 1 }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+    });
+
     test('should return 404 if the application is not found', async () => {
         const res = await request({
             uri: '/events/' + event.id + '/applications/1337/board',

--- a/statutory/test/api/memberslist-single.test.js
+++ b/statutory/test/api/memberslist-single.test.js
@@ -23,7 +23,7 @@ describe('Memberslist displaying', () => {
     });
 
     test('should fail if user has no permissions at all', async () => {
-        mock.mockAll({ mainPermissions: { noPermissions: true }, approvePermissions: { noPermissions: true } });
+        mock.mockAll({ mainPermissions: { noPermissions: true }, approvePermissions: { noPermissions: true }, memberslistPermissions: { noPermissions: true } });
 
         const event = await generator.createEvent({ type: 'agora' });
         await generator.createMembersList({ body_id: regularUser.bodies[0].id }, event);
@@ -79,6 +79,38 @@ describe('Memberslist displaying', () => {
         await generator.createMembersList({ body_id: 1337 }, event);
         const res = await request({
             uri: '/events/' + event.id + '/memberslists/1337',
+            method: 'GET',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+    });
+
+    test('should fail to view memberslist if user has only approve_members but not manage_memberslist', async () => {
+        mock.mockAll({ mainPermissions: { noPermissions: true }, memberslistPermissions: { noPermissions: true } });
+
+        const event = await generator.createEvent({ type: 'agora' });
+        await generator.createMembersList({ body_id: regularUser.bodies[0].id }, event);
+        const res = await request({
+            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+    });
+
+    test('should succeed to view memberslist if user has manage_memberslist but not approve_members', async () => {
+        mock.mockAll({ mainPermissions: { noPermissions: true }, approvePermissions: { noPermissions: true } });
+
+        const event = await generator.createEvent({ type: 'agora' });
+        await generator.createMembersList({ body_id: regularUser.bodies[0].id }, event);
+        const res = await request({
+            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/memberslist-upload.test.js
+++ b/statutory/test/api/memberslist-upload.test.js
@@ -27,7 +27,7 @@ describe('Memberslist uploading', () => {
     });
 
     test('should fail if user has no permissions', async () => {
-        mock.mockAll({ mainPermissions: { noPermissions: true }, approvePermissions: { noPermissions: true } });
+        mock.mockAll({ mainPermissions: { noPermissions: true }, approvePermissions: { noPermissions: true }, memberslistPermissions: { noPermissions: true } });
 
         const event = await generator.createEvent({
             type: 'agora',
@@ -143,6 +143,46 @@ describe('Memberslist uploading', () => {
             members: [{ first_name: 'test', last_name: 'test', fee: 3, user_id: 1 }]
         }, event);
 
+        const res = await request({
+            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: generator.generateMembersList({}, event)
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+    });
+
+    test('should fail if user has only approve_members but not manage_memberslist permission', async () => {
+        mock.mockAll({ mainPermissions: { noPermissions: true }, memberslistPermissions: { noPermissions: true } });
+
+        const event = await generator.createEvent({
+            type: 'agora',
+            application_period_starts: moment().subtract(1, 'week').toDate(),
+            application_period_ends: moment().add(1, 'week').toDate()
+        });
+        const res = await request({
+            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: generator.generateMembersList({}, event)
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+    });
+
+    test('should succeed if user has manage_memberslist but not approve_members permission', async () => {
+        mock.mockAll({ mainPermissions: { noPermissions: true }, approvePermissions: { noPermissions: true } });
+
+        const event = await generator.createEvent({
+            type: 'agora',
+            application_period_starts: moment().subtract(1, 'week').toDate(),
+            application_period_ends: moment().add(1, 'week').toDate()
+        });
         const res = await request({
             uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',

--- a/statutory/test/assets/core-permissions-edit-between-deadlines-global.json
+++ b/statutory/test/assets/core-permissions-edit-between-deadlines-global.json
@@ -13,6 +13,16 @@
     }, {
         "scope": "global",
         "object": "agora",
+        "id": 1004,
+        "filters": [],
+        "description": "Manage memberslists for Agora.",
+        "combined": "global:manage_memberslist:agora",
+        "circles": null,
+        "always_assigned": false,
+        "action": "manage_memberslist"
+    }, {
+        "scope": "global",
+        "object": "agora",
         "id": 1003,
         "filters": [],
         "description": "Edit memberslists between submission and edit deadlines.",

--- a/statutory/test/assets/core-permissions-full.json
+++ b/statutory/test/assets/core-permissions-full.json
@@ -95,6 +95,26 @@
     }, {
       "scope": "global",
       "object": "agora",
+      "id": 100,
+      "filters": [],
+      "description": "Manage memberslists for Agora.",
+      "combined": "global:manage_memberslist:agora",
+      "circles": null,
+      "always_assigned": false,
+      "action": "manage_memberslist"
+    }, {
+      "scope": "global",
+      "object": "epm",
+      "id": 101,
+      "filters": [],
+      "description": "Manage memberslists for EPM.",
+      "combined": "global:manage_memberslist:epm",
+      "circles": null,
+      "always_assigned": false,
+      "action": "manage_memberslist"
+    }, {
+      "scope": "global",
+      "object": "agora",
       "id": 6,
       "filters": [],
       "description": "See memberslists.",

--- a/statutory/test/scripts/mock-core-registry.js
+++ b/statutory/test/scripts/mock-core-registry.js
@@ -113,44 +113,90 @@ exports.mockCoreMainPermissions = (options) => {
 };
 
 exports.mockCoreApprovePermissions = (options) => {
+    const bodyFilter = (body) => body.action === 'approve_members';
+
     if (options.netError) {
         return nock(`${config.core.url}:${config.core.port}`)
             .persist()
-            .post('/my_permissions')
+            .post('/my_permissions', bodyFilter)
             .replyWithError('Some random error.');
     }
 
     if (options.badResponse) {
         return nock(`${config.core.url}:${config.core.port}`)
             .persist()
-            .post('/my_permissions')
+            .post('/my_permissions', bodyFilter)
             .reply(500, 'Some error happened.');
     }
 
     if (options.unsuccessfulResponse) {
         return nock(`${config.core.url}:${config.core.port}`)
             .persist()
-            .post('/my_permissions')
+            .post('/my_permissions', bodyFilter)
             .reply(500, { success: false, message: 'Some error' });
     }
 
     if (options.unauthorized) {
         return nock(`${config.core.url}:${config.core.port}`)
             .persist()
-            .post('/my_permissions')
+            .post('/my_permissions', bodyFilter)
             .replyWithFile(401, path.join(__dirname, '..', 'assets', 'core-unauthorized.json'));
     }
 
     if (options.noPermissions) {
         return nock(`${config.core.url}:${config.core.port}`)
             .persist()
-            .post('/my_permissions')
+            .post('/my_permissions', bodyFilter)
             .replyWithFile(200, path.join(__dirname, '..', 'assets', 'core-empty.json'));
     }
 
     return nock(`${config.core.url}:${config.core.port}`)
         .persist()
-        .post('/my_permissions')
+        .post('/my_permissions', bodyFilter)
+        .replyWithFile(200, path.join(__dirname, '..', 'assets', 'core-approve-permissions-full.json'));
+};
+
+exports.mockCoreMemberslistPermissions = (options) => {
+    const bodyFilter = (body) => body.action === 'manage_memberslist';
+
+    if (options.netError) {
+        return nock(`${config.core.url}:${config.core.port}`)
+            .persist()
+            .post('/my_permissions', bodyFilter)
+            .replyWithError('Some random error.');
+    }
+
+    if (options.badResponse) {
+        return nock(`${config.core.url}:${config.core.port}`)
+            .persist()
+            .post('/my_permissions', bodyFilter)
+            .reply(500, 'Some error happened.');
+    }
+
+    if (options.unsuccessfulResponse) {
+        return nock(`${config.core.url}:${config.core.port}`)
+            .persist()
+            .post('/my_permissions', bodyFilter)
+            .reply(500, { success: false, message: 'Some error' });
+    }
+
+    if (options.unauthorized) {
+        return nock(`${config.core.url}:${config.core.port}`)
+            .persist()
+            .post('/my_permissions', bodyFilter)
+            .replyWithFile(401, path.join(__dirname, '..', 'assets', 'core-unauthorized.json'));
+    }
+
+    if (options.noPermissions) {
+        return nock(`${config.core.url}:${config.core.port}`)
+            .persist()
+            .post('/my_permissions', bodyFilter)
+            .replyWithFile(200, path.join(__dirname, '..', 'assets', 'core-empty.json'));
+    }
+
+    return nock(`${config.core.url}:${config.core.port}`)
+        .persist()
+        .post('/my_permissions', bodyFilter)
         .replyWithFile(200, path.join(__dirname, '..', 'assets', 'core-approve-permissions-full.json'));
 };
 
@@ -456,6 +502,7 @@ exports.mockAll = (options = {}) => {
     const coreStub = exports.mockCore(options.core || {});
     const mainPermissionsStub = exports.mockCoreMainPermissions(options.mainPermissions || {});
     const approvePermissionsStub = exports.mockCoreApprovePermissions(options.approvePermissions || {});
+    const memberslistPermissionsStub = exports.mockCoreMemberslistPermissions(options.memberslistPermissions || {});
     const coreMembersStub = exports.mockCoreMembers(options.members || {});
     const coreBodyMembersStub = exports.mockCoreBodyMembers(options.bodyMembers || {});
     const coreBodiesStub = exports.mockCoreBodies(options.bodies || {});
@@ -470,6 +517,7 @@ exports.mockAll = (options = {}) => {
         coreStub,
         mainPermissionsStub,
         approvePermissionsStub,
+        memberslistPermissionsStub,
         coreMembersStub,
         coreBodiesStub,
         coreBodyStub,


### PR DESCRIPTION
## Summary
- Introduces a new `manage_memberslist:<event_type>` permission to decouple memberslist operations (upload, edit, view) from application approval (`approve_members`)
- Board members can now be granted memberslist management without application approval rights, and vice versa
- Locally assigned to boards, globally to Chair (agora) and Network Director (agora), CD (epm)

## Changes
- **statutory/lib/core.js**: new `getMemberslistPermissions()` fetching `manage_memberslist` from core
- **statutory/lib/middlewares.js**: fetch both permissions in parallel, add `memberslistRequest` to `ensureAuthorized`
- **statutory/lib/helpers.js**: `upload_memberslist`, `edit_memberslist`, `see_memberslist` now use `manage_memberslist` instead of `approve_members`
- **core/scripts/seed.js**: add `manage_memberslist` permission entries, update `approve_members` descriptions
- **Tests**: permission separation tests, error handling tests, updated mock registry with body filtering

## Test plan
- [x] All existing statutory tests pass (65/66 suites, 1 pre-existing cron failure)
- [x] New tests verify: approve_members without manage_memberslist → can set board comments, cannot upload/view memberslists
- [x] New tests verify: manage_memberslist without approve_members → can upload/view memberslists, cannot set board comments
- [x] Error handling tests for memberslist permissions endpoint (bad response, unauthorized, unsuccessful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)