### PR TITLE
feat(summeruniversity): support scheduled application periods

### DIFF
--- a/frontend/src/views/summeruniversity/ApplicationPeriodModal.vue
+++ b/frontend/src/views/summeruniversity/ApplicationPeriodModal.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title">Set application period</p>
+      <button class="delete" aria-label="close" @click="$parent.close()" />
+    </header>
+
+    <section class="modal-card-body">
+      <form @submit.prevent="saveApplicationPeriod()">
+        <div class="field">
+          <label class="label">Application starts</label>
+          <div class="control">
+            <input
+              v-model="applicationStarts"
+              class="input"
+              type="datetime-local">
+          </div>
+          <p class="help">Leave empty to start immediately.</p>
+        </div>
+
+        <div class="field">
+          <label class="label">Application ends <span class="has-text-danger">*</span></label>
+          <div class="control">
+            <input
+              v-model="applicationEnds"
+              class="input"
+              type="datetime-local"
+              required>
+          </div>
+        </div>
+
+        <div class="notification is-info">
+          Times are entered in your browser's local timezone
+          <span v-if="timezone">({{ timezone }})</span>
+          and sent to the backend as exact timestamps.
+        </div>
+
+        <div class="field is-grouped is-grouped-right">
+          <div class="control">
+            <button type="button" class="button" @click="$parent.close()">
+              Cancel
+            </button>
+          </div>
+          <div class="control">
+            <button type="submit" class="button is-primary" :class="{ 'is-loading': isSaving }" :disabled="isSaving">
+              Save
+            </button>
+          </div>
+        </div>
+      </form>
+    </section>
+
+    <footer class="modal-card-foot" />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ApplicationPeriodModal',
+  props: ['event', 'services', 'showError', 'showSuccess', 'onUpdated'],
+  data () {
+    return {
+      applicationStarts: this.formatForInput(this.event.application_starts),
+      applicationEnds: this.formatForInput(this.event.application_ends),
+      isSaving: false,
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
+    }
+  },
+  methods: {
+    formatForInput (value) {
+      if (!value) {
+        return ''
+      }
+
+      const date = new Date(value)
+      if (Number.isNaN(date.getTime())) {
+        return ''
+      }
+
+      const timezoneOffset = date.getTimezoneOffset() * 60000
+      return new Date(date.getTime() - timezoneOffset).toISOString().slice(0, 16)
+    },
+    saveApplicationPeriod () {
+      if (this.applicationStarts && new Date(this.applicationStarts) >= new Date(this.applicationEnds)) {
+        this.showError('Application start must be before application end.')
+        return
+      }
+
+      this.isSaving = true
+
+      const payload = {
+        application_ends: new Date(this.applicationEnds).toISOString()
+      }
+
+      if (this.applicationStarts) {
+        payload.application_starts = new Date(this.applicationStarts).toISOString()
+      }
+
+      this.axios.put(this.services['summeruniversity'] + '/single/' + this.event.id + '/application_period', payload).then((response) => {
+        this.showSuccess('Event application period was updated.')
+        this.onUpdated(response.data.data)
+        this.$parent.close()
+      }).catch((err) => {
+        this.showError('Could not update event application period', err)
+      }).finally(() => {
+        this.isSaving = false
+      })
+    }
+  }
+}
+</script>

--- a/frontend/src/views/summeruniversity/ChangeStatus.vue
+++ b/frontend/src/views/summeruniversity/ChangeStatus.vue
@@ -116,12 +116,12 @@
             </div>
           </b-table-column>
 
-          <b-table-column field="application_status" label="Change application deadline" sortable v-slot="props">
+          <b-table-column field="application_status" label="Change application period" sortable v-slot="props">
             <div class="buttons">
               <button
                 class="button is-small is-info"
                 @click="askChangeApplicationPeriod(props.row)">
-                Change application deadline
+                Change application period
               </button>
             </div>
           </b-table-column>
@@ -138,6 +138,7 @@
 <script>
 import { mapGetters } from 'vuex'
 import constants from '../../constants'
+import ApplicationPeriodModal from './ApplicationPeriodModal.vue'
 
 export default {
   name: 'ChangeEventsStatus',
@@ -174,25 +175,22 @@ export default {
       })
     },
     askChangeApplicationPeriod (event) {
-      this.$buefy.dialog.prompt({
-        message: 'Change application deadline (UTC)',
-        inputAttrs: {
-          type: 'datetime-local',
-          required: true,
-          placeholder: 'Change application deadline'
-        },
+      this.$buefy.modal.open({
+        parent: this,
+        component: ApplicationPeriodModal,
+        hasModalCard: true,
         trapFocus: true,
-        onConfirm: (newApplicationEnds) => this.changeApplicationPeriod(event, newApplicationEnds)
+        props: {
+          event,
+          services: this.services,
+          showError: this.$root.showError,
+          showSuccess: this.$root.showSuccess,
+          onUpdated: (updatedEvent) => this.changeApplicationPeriod(event, updatedEvent)
+        }
       })
     },
-    changeApplicationPeriod (event, newApplicationEnds) {
-      this.axios.put(this.services['summeruniversity'] + '/single/' + event.id + '/application_period', {
-        application_ends: newApplicationEnds
-      }).then(() => {
-        this.$root.showSuccess(`Event application deadline is now "${newApplicationEnds}".`)
-      }).catch((err) => {
-        this.$root.showError('Could not update event application deadline', err)
-      })
+    changeApplicationPeriod (event, updatedEvent) {
+      Object.assign(event, updatedEvent)
     },
     fetchData () {
       this.isLoading = true

--- a/frontend/src/views/summeruniversity/Single.vue
+++ b/frontend/src/views/summeruniversity/Single.vue
@@ -266,7 +266,11 @@
                   <th>Application status</th>
                   <td>{{ event.application_status | capitalize }}</td>
                 </tr>
-                <tr v-if="event.application_status === 'open' && event.open_call != true">
+                <tr v-if="event.application_starts && event.open_call != true">
+                  <th>Application period starts <timezone-tooltip /></th>
+                  <td>{{ event.application_starts | datetime }}</td>
+                </tr>
+                <tr v-if="event.application_ends && event.open_call != true">
                   <th>Application period ends <timezone-tooltip /></th>
                   <td>{{ event.application_ends | datetime }}</td>
                 </tr>

--- a/summeruniversity/lib/constants.js
+++ b/summeruniversity/lib/constants.js
@@ -64,6 +64,7 @@ module.exports = {
         'additional_regulation',
         'application_status',
         'published',
+        'application_starts',
         'application_ends',
         'created_at',
         'updated_at'

--- a/summeruniversity/lib/events.js
+++ b/summeruniversity/lib/events.js
@@ -431,14 +431,19 @@ exports.setApplicationPeriod = async (req, res) => {
         return errors.makeForbiddenError(res, 'This event status does not allow changing the application period');
     }
 
-    await req.event.update({
-        application_starts: new Date(),
+    const applicationStarts = typeof req.body.application_starts === 'undefined'
+        ? new Date()
+        : req.body.application_starts;
+
+    const event = await req.event.update({
+        application_starts: applicationStarts,
         application_ends: req.body.application_ends
     });
 
     return res.json({
         success: true,
         message: 'Successfully changed application period',
+        data: event
     });
 };
 

--- a/summeruniversity/models/Event.js
+++ b/summeruniversity/models/Event.js
@@ -109,7 +109,16 @@ const Event = sequelize.define(
             type: Sequelize.DATE,
             allowNull: true,
             validate: {
-                isDate: { msg: 'Event application starts date should be set.' }
+                isDate: { msg: 'Event application starts date should be set.' },
+                beforeApplicationEnd(val) {
+                    if (!val || !this.application_ends) {
+                        return;
+                    }
+
+                    if (moment(val).isSameOrAfter(this.application_ends)) {
+                        throw new Error('Application period cannot start after or at the same time it ends.');
+                    }
+                }
             }
         },
         application_ends: {
@@ -117,11 +126,15 @@ const Event = sequelize.define(
             allowNull: true,
             validate: {
                 isDate: { msg: 'Event application end date should be set.' },
-                // laterThanApplicationStart(val) {
-                //     if (moment(val).isSameOrBefore(this.application_starts)) {
-                //         throw new Error('Application period cannot start after or at the same time it ends.');
-                //     }
-                // },
+                laterThanApplicationStart(val) {
+                    if (!val || !this.application_starts) {
+                        return;
+                    }
+
+                    if (moment(val).isSameOrBefore(this.application_starts)) {
+                        throw new Error('Application period cannot end before or at the same time it starts.');
+                    }
+                },
                 beforeEventStart(val) {
                     if (moment(val).isSameOrAfter(this.starts)) {
                         throw new Error('Application period cannot end before or at the same time the event starts.');


### PR DESCRIPTION
## What changed

This PR adds support for scheduled Summer University application periods.

- the Summer University backend now accepts an optional `application_starts` when updating the application period
- if `application_starts` is omitted, the existing behavior is preserved and the period starts immediately
- the Summer University management UI now uses a dedicated modal that lets operators set both the optional start time and the required end time
- the Summer University event page now displays both the application start and end timestamps when available

## Why

Business wants to be able to schedule Summer University applications to open in advance instead of only opening them immediately.

The previous flow only allowed setting `application_ends`, and the backend always forced `application_starts` to the current time.

## Impact

- operators can schedule application opening without needing a background task
- application availability still changes dynamically at request time based on the configured period
- members can see when the application period starts and ends on the event page

## Notes

- documentation and backend test changes were intentionally left out of this PR
- validation/checks were not run in this environment because the available shell could not execute Node-based tooling
