### PR TITLE
chore(mailer): lock Docker build dependencies

### DIFF
--- a/mailer/docker/mailer/Dockerfile
+++ b/mailer/docker/mailer/Dockerfile
@@ -9,8 +9,8 @@ RUN mkdir -p /usr/src/myapp \
 
 WORKDIR /usr/src/myapp
 
-COPY mix.exs /usr/src/myapp/mix.exs
-RUN ["mix", "deps.get"]
+COPY mix.exs mix.lock /usr/src/myapp/
+RUN ["mix", "deps.get", "--locked"]
 
 COPY config /usr/src/myapp/config
 COPY lib /usr/src/myapp/lib


### PR DESCRIPTION
## Summary
- copy `mix.lock` into the mailer Docker build context before fetching dependencies
- run `mix deps.get --locked` so the image build uses the repository's locked Phoenix version
- keep the current Elixir 1.14 base image, which was verified to build successfully

## Testing
- `docker build -f docker/mailer/Dockerfile -t aegee/mailer:test .`