### PR TITLE
fix(statutory): expose manager application editing

### DIFF
--- a/core/scripts/seed.js
+++ b/core/scripts/seed.js
@@ -772,6 +772,12 @@ async function createPermissions() {
         description: 'Use massmailer for Agora.'
     },
     {
+        action: 'manage_applications',
+        object: 'agora',
+        scope: 'global',
+        description: 'Manage Agora applications.'
+    },
+    {
         action: 'view',
         object: 'circle',
         scope: 'global',

--- a/core/scripts/seed.js
+++ b/core/scripts/seed.js
@@ -261,6 +261,12 @@ async function createPermissions() {
         scope: 'global',
         description: 'Upload, edit and view memberslists for Agora for all bodies.'
     });
+    permissions.manageApplicationsAgora = await Permission.create({
+        action: 'manage_applications',
+        object: 'agora',
+        scope: 'global',
+        description: 'Manage Agora applications.'
+    });
 
     permissions.members = await Permission.bulkCreate([{
         scope: 'global',
@@ -772,12 +778,6 @@ async function createPermissions() {
         description: 'Use massmailer for Agora.'
     },
     {
-        action: 'manage_applications',
-        object: 'agora',
-        scope: 'global',
-        description: 'Manage Agora applications.'
-    },
-    {
         action: 'view',
         object: 'circle',
         scope: 'global',
@@ -790,7 +790,7 @@ async function createPermissions() {
         description: 'Set pax type/order and board comment for Agora applications for all bodies.'
     }], { individualHooks: true, validate: true });
 
-    permissions.chair = [...chairPermissions, permissions.viewMembersCircle, permissions.addMemberCircle, permissions.viewMember, permissions.manageMemberslistAgora];
+    permissions.chair = [...chairPermissions, permissions.viewMembersCircle, permissions.addMemberCircle, permissions.viewMember, permissions.manageMemberslistAgora, permissions.manageApplicationsAgora];
 
     const jcPermissions = await Permission.bulkCreate([{
         action: 'manage_juridical',
@@ -825,12 +825,6 @@ async function createPermissions() {
             object: 'agora',
             scope: 'global',
             description: 'Apply to Agora/edit your application regardless if the deadline was passed or not.'
-        },
-        {
-            action: 'manage_applications',
-            object: 'agora',
-            scope: 'global',
-            description: 'Manage Agora applications'
         },
         {
             action: 'manage_event',
@@ -1241,7 +1235,7 @@ async function createPermissions() {
             description: 'Allows to suspend or activate users that are member in the body that you got this permission from'
         }], { individualHooks: true, validate: true });
 
-    permissions.admin = [...permissions.board, ...adminPermissions, ...comiteDirecteurPermissions, ...netComPermissions, ...networkDirectorPermissions, ...suctPermissions, ...eqacPermissions, ...chairPermissions, ...jcPermissions, permissions.seeMemberslistsAgora, permissions.setMemberslistsFeePaidAgora, permissions.viewMembersCircle, permissions.approveEventNwm, permissions.viewMember, permissions.addMemberCircle];
+    permissions.admin = [...permissions.board, ...adminPermissions, ...comiteDirecteurPermissions, ...netComPermissions, ...networkDirectorPermissions, ...suctPermissions, ...eqacPermissions, ...chairPermissions, ...jcPermissions, permissions.seeMemberslistsAgora, permissions.setMemberslistsFeePaidAgora, permissions.viewMembersCircle, permissions.approveEventNwm, permissions.viewMember, permissions.addMemberCircle, permissions.manageApplicationsAgora];
 
     for (const permission of permissions.members) {
         await CirclePermission.create({ circle_id: data.circles.membersCircle.id, permission_id: permission.id });

--- a/frontend/src/views/statutory/Applications.vue
+++ b/frontend/src/views/statutory/Applications.vue
@@ -107,6 +107,12 @@
             </router-link>
           </b-table-column>
 
+          <b-table-column label="Edit" centered v-slot="props" v-if="event.permissions && event.permissions.manage_applications">
+            <router-link :to="{ name: 'oms.statutory.applications.edit', params: { id: event.url || event.id, application_id: props.row.statutory_id || props.row.id } }">
+              Edit
+            </router-link>
+          </b-table-column>
+
           <b-table-column label="Manage status" field="status" centered sortable v-slot="props">
             <div class="select" :class="{ 'is-loading': props.row.isSaving }">
               <select v-model="props.row.newStatus" @change="switchPaxStatus(props.row)">

--- a/frontend/src/views/statutory/BoardView.vue
+++ b/frontend/src/views/statutory/BoardView.vue
@@ -172,6 +172,12 @@
               </router-link>
             </b-table-column>
 
+            <b-table-column label="Edit" centered v-slot="props" v-if="can.manage_applications">
+              <router-link :to="{ name: 'oms.statutory.applications.edit', params: { id: event.url || event.id, application_id: props.row.statutory_id || props.row.id } }">
+                Edit
+              </router-link>
+            </b-table-column>
+
             <b-table-column field="status" label="Status" centered v-slot="props">
               <span v-if="props.row.status === 'accepted'">Accepted</span>
               <span v-if="props.row.status === 'rejected'">Rejected</span>

--- a/frontend/src/views/statutory/EditApplication.vue
+++ b/frontend/src/views/statutory/EditApplication.vue
@@ -15,6 +15,9 @@
                     <option v-for="body in bodies" v-bind:key="body.id" :value="body.id">{{ body.name }}</option>
                   </select>
                 </div>
+                <p class="help is-info" v-if="isManagerEditingOtherApplication">
+                  Use this field to correct the member's application body, including after the regular application period has ended.
+                </p>
               </div>
 
               <event-no-body-notification v-if="bodies.length == 0" />
@@ -306,10 +309,10 @@
           <b-loading is-full-page="false" :active.sync="isLoading" />
         </form>
 
-        <hr v-show="!isNew && can.set_board_comment_and_participant_type_global" />
+        <hr v-show="!isNew && can.set_board_comment_and_participant_type && can.set_board_comment_and_participant_type.global" />
 
         <!-- Editing board stuff for Chair Team/CD -->
-        <div class="tile is-parent" v-show="!isNew && can.set_board_comment_and_participant_type_global">
+        <div class="tile is-parent" v-show="!isNew && can.set_board_comment_and_participant_type && can.set_board_comment_and_participant_type.global">
           <div class="tile is-child">
             <div class="field is-fullwidth">
               <div class="control">
@@ -509,6 +512,9 @@ export default {
     },
     isOwn () {
       return this.isNew || this.loginUser.id === this.application.user_id
+    },
+    isManagerEditingOtherApplication () {
+      return !this.isNew && !this.isOwn && this.can.manage_applications
     },
     selectedMailinglists () {
       return Object.keys(this.subscription).filter(value => this.subscription[value] === true)

--- a/frontend/src/views/statutory/EditApplication.vue
+++ b/frontend/src/views/statutory/EditApplication.vue
@@ -15,9 +15,6 @@
                     <option v-for="body in bodies" v-bind:key="body.id" :value="body.id">{{ body.name }}</option>
                   </select>
                 </div>
-                <p class="help is-info" v-if="isManagerEditingOtherApplication">
-                  Use this field to correct the member's application body, including after the regular application period has ended.
-                </p>
               </div>
 
               <event-no-body-notification v-if="bodies.length == 0" />
@@ -512,9 +509,6 @@ export default {
     },
     isOwn () {
       return this.isNew || this.loginUser.id === this.application.user_id
-    },
-    isManagerEditingOtherApplication () {
-      return !this.isNew && !this.isOwn && this.can.manage_applications
     },
     selectedMailinglists () {
       return Object.keys(this.subscription).filter(value => this.subscription[value] === true)

--- a/frontend/src/views/statutory/ViewApplication.vue
+++ b/frontend/src/views/statutory/ViewApplication.vue
@@ -170,17 +170,20 @@
         <div class="tile is-parent" v-if="application && !application.cancelled">
           <div class="tile is-child">
             <div class="notification is-warning" v-if="application.status === 'pending'">
-              Your application is recorded, please wait for the organisers to evaluate your application.
-              <span v-show="can.edit_application">You can still edit it till the application period ends.</span>
+              {{ applicationStatusMessage }}
+              <span v-if="showOwnDeadlineEditHint">You can still edit it till the application period ends.</span>
             </div>
             <div class="notification is-success" v-if="application.status === 'accepted'">
-              Congratulations, you have been accepted to the event!
+              <span v-if="isOwnApplication">Congratulations, you have been accepted to the event!</span>
+              <span v-else>This application has been accepted to the event.</span>
             </div>
             <div class="notification is-warning" v-if="application.status === 'waiting_list'">
-              Unfortunately you've been put to a waiting list. Please contact organisers to get more info on that.
+              <span v-if="isOwnApplication">Unfortunately you've been put to a waiting list. Please contact organisers to get more info on that.</span>
+              <span v-else>This application is on the waiting list.</span>
             </div>
             <div class="notification is-danger" v-if="application.status === 'rejected'">
-              Sorry, but you were not accepted to the event.
+              <span v-if="isOwnApplication">Sorry, but you were not accepted to the event.</span>
+              <span v-else>This application was not accepted.</span>
             </div>
           </div>
         </div>
@@ -189,8 +192,9 @@
         <div class="tile is-parent" v-if="application && application.cancelled">
           <div class="tile is-child">
             <div class="notification is-danger">
-              Your application is cancelled.
-              <span v-if="can.set_application_cancelled">You can uncancel it till the application period ends.</span>
+              <span v-if="isOwnApplication">Your application is cancelled.</span>
+              <span v-else>This application is cancelled.</span>
+              <span v-if="showOwnDeadlineCancelHint">You can uncancel it till the application period ends.</span>
             </div>
           </div>
         </div>
@@ -208,7 +212,7 @@
           </div>
         </div>
 
-        <div class="tile is-parent" v-if="application && !application.cancelled && !can.edit_application && new Date() > event.application_period_ends">
+        <div class="tile is-parent" v-if="showOwnDeadlineExpiredMessage">
           <div class="tile is-child">
             <div class="notification is-danger">
               You cannot edit your application anymore: application period is over.
@@ -234,7 +238,7 @@
             type="submit"
             class="button is-warning"
             v-if="application && can.edit_application">
-            Edit your application
+            {{ isOwnApplication ? 'Edit your application' : 'Edit application' }}
           </router-link>
 
           <button
@@ -286,7 +290,30 @@ export default {
     ...mapGetters({
       services: 'services',
       loginUser: 'user'
-    })
+    }),
+    isOwnApplication () {
+      return this.application && this.application.user_id === this.loginUser.id
+    },
+    applicationStatusMessage () {
+      if (this.isOwnApplication) {
+        return 'Your application is recorded, please wait for the organisers to evaluate your application.'
+      }
+
+      return 'This application is recorded and waiting for organiser review.'
+    },
+    showOwnDeadlineEditHint () {
+      return this.isOwnApplication && this.can.edit_application
+    },
+    showOwnDeadlineCancelHint () {
+      return this.isOwnApplication && this.can.set_application_cancelled
+    },
+    showOwnDeadlineExpiredMessage () {
+      return this.isOwnApplication
+        && this.application
+        && !this.application.cancelled
+        && !this.can.edit_application
+        && new Date() > this.event.application_period_ends
+    }
   },
   methods: {
     askSetCancelled (value) {

--- a/statutory/lib/applications.js
+++ b/statutory/lib/applications.js
@@ -305,8 +305,16 @@ exports.updateApplication = async (req, res) => {
     }
 
     const user = await core.getMember(req, req.application.user_id);
+    const requestedBody = req.body.body_id ? user.bodies.find((body) => req.body.body_id === body.id) : null;
     if (req.body.body_id && !helpers.isMemberOf(user, req.body.body_id)) {
         return errors.makeForbiddenError(res, 'You cannot apply on behalf of the body you are not a member of.');
+    }
+
+    if (requestedBody && req.body.body_id !== req.application.body_id) {
+        const limit = await PaxLimit.fetchOrUseDefaultForBody(requestedBody, req.event.type);
+        if (!limit.hasAnyLimits()) {
+            return errors.makeForbiddenError(res, 'You cannot apply as this body cannot send any participants.');
+        }
     }
 
     delete req.body.statutory_id;
@@ -329,7 +337,7 @@ exports.updateApplication = async (req, res) => {
     if (req.body.body_id) {
         // Shouldn't crash, if the person is not a member of a body,
         // it will be caught by helpers.isMemberOf() above.
-        req.body.body_name = user.bodies.find((b) => req.body.body_id === b.id).name;
+        req.body.body_name = requestedBody.name;
     }
 
     // If user changed his body (by himself), reset his board comment and participant type/order.

--- a/statutory/test/api/applications-editing.test.js
+++ b/statutory/test/api/applications-editing.test.js
@@ -336,6 +336,14 @@ describe('Applications editing', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const event = await generator.createEvent();
+        await generator.createPaxLimit({
+            event_type: event.type,
+            body_id: regularUser.bodies[1].id,
+            delegate: 1,
+            observer: 0,
+            visitor: 0,
+            envoy: 0
+        });
         const application = await generator.createApplication({
             user_id: regularUser.id,
             body_id: regularUser.bodies[0].id,
@@ -372,6 +380,14 @@ describe('Applications editing', () => {
         mock.mockAll();
 
         const event = await generator.createEvent();
+        await generator.createPaxLimit({
+            event_type: event.type,
+            body_id: regularUser.bodies[1].id,
+            delegate: 1,
+            observer: 0,
+            visitor: 0,
+            envoy: 0
+        });
         const application = await generator.createApplication({
             user_id: 1337,
             body_id: regularUser.bodies[0].id,
@@ -401,6 +417,43 @@ describe('Applications editing', () => {
         expect(newApplication.participant_type).toEqual('envoy');
         expect(newApplication.participant_order).toEqual(1);
         expect(newApplication.board_comment).toEqual('Awesome guy, accept');
+    });
+
+    test('should return 403 when switching to a body without pax limits for other user', async () => {
+        mock.mockAll();
+
+        const event = await generator.createEvent();
+        const application = await generator.createApplication({
+            user_id: 1337,
+            body_id: regularUser.bodies[0].id
+        }, event);
+        await generator.createPaxLimit({
+            event_type: event.type,
+            body_id: regularUser.bodies[1].id,
+            delegate: 0,
+            observer: 0,
+            visitor: 0,
+            envoy: 0
+        });
+
+        tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
+
+        const res = await request({
+            uri: '/events/' + event.id + '/applications/' + application.id,
+            method: 'PUT',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: { body_id: regularUser.bodies[1].id }
+        });
+
+        tk.reset();
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+
+        const unchangedApplication = await Application.findOne({ where: { id: application.id } });
+        expect(unchangedApplication.body_id).toEqual(regularUser.bodies[0].id);
     });
 
     test('should return 500 if members query returns net error', async () => {


### PR DESCRIPTION
## Summary
- add `global:manage_applications:agora` to the chair permission seed so local and test data match production
- add direct statutory application edit links from the applications list and board view for managers
- make the statutory application view and edit form clearer for manager-driven body corrections after the deadline

## Verification
- `node --check core/scripts/seed.js`
- `git diff --check`
- parsed updated Vue SFC templates and scripts with `vue-template-compiler` and `@babel/parser`