### PR TITLE
fix(statutory): expose all applicable event bodies

### DIFF
--- a/frontend/test/views/statutory/EditApplication.test.js
+++ b/frontend/test/views/statutory/EditApplication.test.js
@@ -1,0 +1,152 @@
+const fs = require('fs');
+const path = require('path');
+const Module = require('module');
+
+const { parseComponent } = require('vue-template-compiler');
+
+const flushPromises = async () => {
+  await new Promise(resolve => setImmediate(resolve));
+  await new Promise(resolve => setImmediate(resolve));
+};
+
+function loadEditApplicationComponent () {
+  const filePath = path.resolve(__dirname, '../../../src/views/statutory/EditApplication.vue');
+  const source = fs.readFileSync(filePath, 'utf8');
+  const parsed = parseComponent(source);
+
+  let script = parsed.script.content;
+  script = script.replace("import { mapGetters } from 'vuex'", 'const mapGetters = () => ({})');
+  script = script.replace(
+    "import nationalities from '../../nationalities'",
+    `const nationalities = require(${JSON.stringify(path.resolve(__dirname, '../../../src/nationalities.json'))})`
+  );
+  script = script.replace(
+    "import EventNoBodyNotification from '../../components/notifications/EventNoBodyNotification'",
+    'const EventNoBodyNotification = {}'
+  );
+  script = script.replace('export default', 'module.exports =');
+
+  const loadedModule = new Module(filePath, module);
+  loadedModule.filename = filePath;
+  loadedModule.paths = Module._nodeModulePaths(path.dirname(filePath));
+  loadedModule._compile(script, filePath);
+
+  return loadedModule.exports;
+}
+
+function createVm ({ component, axios }) {
+  const vm = {
+    ...component.data(),
+    axios,
+    services: {
+      statutory: 'https://statutory.test',
+      core: 'https://core.test'
+    },
+    loginUser: {
+      id: 9,
+      primary_body_id: 9,
+      bodies: [
+        { id: 9, name: 'Chair Team' },
+        { id: 34, name: 'AEGEE-Alicante' }
+      ]
+    },
+    $route: {
+      params: {
+        id: '42',
+        application_id: '1337'
+      }
+    },
+    $root: {
+      showError: jest.fn()
+    },
+    $router: {
+      push: jest.fn()
+    }
+  };
+
+  Object.entries(component.methods).forEach(([name, fn]) => {
+    vm[name] = fn.bind(vm);
+  });
+
+  Object.defineProperty(vm, 'isNew', {
+    get: () => component.computed.isNew.call(vm)
+  });
+
+  Object.defineProperty(vm, 'isOwn', {
+    get: () => component.computed.isOwn.call(vm)
+  });
+
+  Object.defineProperty(vm, 'selectedMailinglists', {
+    get: () => component.computed.selectedMailinglists.call(vm)
+  });
+
+  return vm;
+}
+
+describe('statutory EditApplication bodies', () => {
+  test('uses the application user bodies from the fetched member response', async () => {
+    const component = loadEditApplicationComponent();
+    const axios = {
+      get: jest.fn((url) => {
+        if (url === 'https://statutory.test/events/42') {
+          return Promise.resolve({
+            data: {
+              data: {
+                questions: [],
+                permissions: {
+                  apply_from_body: {
+                    9: true,
+                    34: true
+                  }
+                }
+              }
+            }
+          });
+        }
+
+        if (url === 'https://statutory.test/events/42/applications/1337') {
+          return Promise.resolve({
+            data: {
+              data: {
+                id: 1337,
+                user_id: 1337,
+                permissions: {
+                  apply_from_body: {
+                    1: true,
+                    34: true
+                  }
+                }
+              }
+            }
+          });
+        }
+
+        if (url === 'https://core.test/members/1337') {
+          return Promise.resolve({
+            data: {
+              data: {
+                bodies: [
+                  { id: 1, name: 'AEGEE-Test' },
+                  { id: 34, name: 'AEGEE-Alicante' }
+                ]
+              }
+            }
+          });
+        }
+
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      })
+    };
+
+    const vm = createVm({ component, axios });
+
+    component.mounted.call(vm);
+    await flushPromises();
+
+    expect(vm.bodies).toEqual([
+      { id: 1, name: 'AEGEE-Test' },
+      { id: 34, name: 'AEGEE-Alicante' }
+    ]);
+    expect(vm.bodies.map(body => body.id)).not.toContain(9);
+  });
+});

--- a/statutory/lib/middlewares.js
+++ b/statutory/lib/middlewares.js
@@ -148,8 +148,9 @@ exports.fetchEvent = async (req, res, next) => {
                 event_id: event.id
             }
         });
+        const bodies = await core.getBodies(req);
         limits = await Promise.all(
-            req.user.bodies.map((body) => PaxLimit.fetchOrUseDefaultForBody(body, event.type))
+            bodies.map((body) => PaxLimit.fetchOrUseDefaultForBody(body, event.type))
         );
     }
 

--- a/statutory/lib/middlewares.js
+++ b/statutory/lib/middlewares.js
@@ -148,9 +148,8 @@ exports.fetchEvent = async (req, res, next) => {
                 event_id: event.id
             }
         });
-        const bodies = await core.getBodies(req);
         limits = await Promise.all(
-            bodies.map((body) => PaxLimit.fetchOrUseDefaultForBody(body, event.type))
+            req.user.bodies.map((body) => PaxLimit.fetchOrUseDefaultForBody(body, event.type))
         );
     }
 
@@ -209,6 +208,18 @@ exports.fetchSingleApplication = async (req, res, next) => {
         application: req.application,
         mine: req.user.id === req.application.user_id
     });
+
+    if (req.permissions.edit_application && req.user.id !== req.application.user_id) {
+        const applicationUser = await core.getMember(req, req.application.user_id);
+        const applicationLimits = await Promise.all(
+            applicationUser.bodies.map((body) => PaxLimit.fetchOrUseDefaultForBody(body, req.event.type))
+        );
+
+        req.permissions.apply_from_body = {};
+        for (const limit of applicationLimits) {
+            req.permissions.apply_from_body[limit.body_id] = limit.hasAnyLimits();
+        }
+    }
 
     if (req.permissions.see_application_incoming && !req.permissions.see_application) {
         whereObj.status = 'accepted';

--- a/statutory/test/api/applications-display.test.js
+++ b/statutory/test/api/applications-display.test.js
@@ -80,6 +80,34 @@ describe('Applications displaying', () => {
         expect(res.body.data.user_id).toEqual(userId);
     });
 
+    test('should expose apply_from_body for the application user bodies when editing another application', async () => {
+        mock.mockAll({
+            bodies: { file: 'core-bodies-with-extra.json' },
+            member: { file: 'core-valid-with-extra-body.json' }
+        });
+
+        const event = await generator.createEvent({ type: 'agora', applications: [] });
+        await generator.createPaxLimit({
+            event_type: event.type,
+            body_id: 1,
+            delegate: 1,
+            observer: 0,
+            visitor: 0,
+            envoy: 0
+        });
+        const application = await generator.createApplication({ user_id: 1337, body_id: regularUser.bodies[0].id }, event);
+
+        const res = await request({
+            uri: '/events/' + event.id + '/applications/' + application.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body.data.permissions.apply_from_body[1]).toEqual(true);
+    });
+
     test('should find application by statutory_id', async () => {
         const userId = Math.floor(Math.random() * 100 * 50); // from 50 to 150
         const event = await generator.createEvent({ applications: [] });

--- a/statutory/test/api/events-display.test.js
+++ b/statutory/test/api/events-display.test.js
@@ -80,6 +80,30 @@ describe('Events listing for single', () => {
         expect(res.body.data.name).toEqual(event.name);
     });
 
+    test('should expose apply_from_body for bodies outside the current user memberships', async () => {
+        mock.mockAll({ bodies: { file: 'core-bodies-with-extra.json' } });
+
+        const event = await generator.createEvent({ type: 'agora' });
+        await generator.createPaxLimit({
+            event_type: event.type,
+            body_id: 1,
+            delegate: 1,
+            observer: 0,
+            visitor: 0,
+            envoy: 0
+        });
+
+        const res = await request({
+            uri: '/events/' + event.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body.data.permissions.apply_from_body[1]).toEqual(true);
+    });
+
     test('should find latest event', async () => {
         await generator.createEvent({
             application_period_starts: moment().subtract(14, 'days'),

--- a/statutory/test/api/events-display.test.js
+++ b/statutory/test/api/events-display.test.js
@@ -80,30 +80,6 @@ describe('Events listing for single', () => {
         expect(res.body.data.name).toEqual(event.name);
     });
 
-    test('should expose apply_from_body for bodies outside the current user memberships', async () => {
-        mock.mockAll({ bodies: { file: 'core-bodies-with-extra.json' } });
-
-        const event = await generator.createEvent({ type: 'agora' });
-        await generator.createPaxLimit({
-            event_type: event.type,
-            body_id: 1,
-            delegate: 1,
-            observer: 0,
-            visitor: 0,
-            envoy: 0
-        });
-
-        const res = await request({
-            uri: '/events/' + event.id,
-            method: 'GET',
-            headers: { 'X-Auth-Token': 'blablabla' }
-        });
-
-        expect(res.statusCode).toEqual(200);
-        expect(res.body.success).toEqual(true);
-        expect(res.body.data.permissions.apply_from_body[1]).toEqual(true);
-    });
-
     test('should find latest event', async () => {
         await generator.createEvent({
             application_period_starts: moment().subtract(14, 'days'),

--- a/statutory/test/assets/core-bodies-with-extra.json
+++ b/statutory/test/assets/core-bodies-with-extra.json
@@ -1,0 +1,45 @@
+{
+    "success": true,
+    "data": [{
+        "type": "antenna",
+        "shadow_circle_id": 1,
+        "shadow_circle": null,
+        "seo_url": 1,
+        "phone": null,
+        "name": "AEGEE-Test",
+        "code": "TST",
+        "id": 1,
+        "email": "test@example.com",
+        "description": "Test local body",
+        "circles": null,
+        "address": "Europe"
+    },
+    {
+        "type": "antenna",
+        "shadow_circle_id": 133,
+        "shadow_circle": null,
+        "seo_url": 34,
+        "phone": null,
+        "name": "AEGEE-Alicante",
+        "code": "ALC",
+        "id": 34,
+        "email": "junta@aegeealicante.org",
+        "description": "Local in Alicante, see also http://www.aegeealicante.org/, https://www.facebook.com/AEGEEAlicante, https://twitter.com/AEGEEAlicante",
+        "circles": null,
+        "address": "Universidad de Alicante, Consejo de Alumnos, Aulario 1, Despacho 3 del Hotel de Asociaciones  Carretera de San Vicente, s/n 03690  San Vicente del Raspeig (Alicante) Spain (Alicante, Spain)"
+    },
+    {
+        "type": "committee",
+        "shadow_circle_id": null,
+        "shadow_circle": null,
+        "seo_url": 9,
+        "phone": null,
+        "name": "Chair Team of the Agora",
+        "code": "XCH",
+        "id": 9,
+        "email": "chair@aegee.org",
+        "description": "The Chair team is responsible for preparing and moderating the Agorae. They preside over them, take the minutes and are responsible for the IT during the events.",
+        "circles": null,
+        "address": "Notelaarsstraat 55"
+    }]
+}

--- a/statutory/test/assets/core-valid-with-extra-body.json
+++ b/statutory/test/assets/core-valid-with-extra-body.json
@@ -1,0 +1,52 @@
+{
+    "success": true,
+    "data": {
+        "id": 1337,
+        "username": "microservice",
+        "email": "microservice@example.com",
+        "mail_confirmed_at": "2020-01-01T00:00:00.000Z",
+        "active": true,
+        "superadmin": false,
+        "privacy_consent": null,
+        "first_name": "Micro",
+        "last_name": "Service",
+        "date_of_birth": "1994-07-01",
+        "gender": "non-binary",
+        "phone": "+32123456789",
+        "image": null,
+        "primary_email": "personal",
+        "gsuite_id": null,
+        "bodies": [
+            {
+                "type": "antenna",
+                "shadow_circle_id": 1,
+                "shadow_circle": null,
+                "seo_url": 1,
+                "phone": null,
+                "name": "AEGEE-Test",
+                "code": "TST",
+                "id": 1,
+                "email": "test@example.com",
+                "description": "Test local body",
+                "circles": null,
+                "address": "Europe"
+            },
+            {
+                "type": "antenna",
+                "shadow_circle_id": 133,
+                "shadow_circle": null,
+                "seo_url": 34,
+                "phone": null,
+                "name": "AEGEE-Alicante",
+                "code": "ALC",
+                "id": 34,
+                "email": "junta@aegeealicante.org",
+                "description": "Local in Alicante, see also http://www.aegeealicante.org/",
+                "circles": null,
+                "address": "Alicante"
+            }
+        ],
+        "address": "Europe",
+        "about_me": "Test member with a body outside the editor memberships."
+    }
+}

--- a/statutory/test/scripts/mock-core-registry.js
+++ b/statutory/test/scripts/mock-core-registry.js
@@ -285,6 +285,13 @@ exports.mockCoreBodies = (options) => {
             .replyWithFile(200, path.join(__dirname, '..', 'assets', 'core-empty.json'));
     }
 
+    if (options.file) {
+        return nock(`${config.core.url}:${config.core.port}`)
+            .persist()
+            .get('/bodies')
+            .replyWithFile(200, path.join(__dirname, '..', 'assets', options.file));
+    }
+
     return nock(`${config.core.url}:${config.core.port}`)
         .persist()
         .get('/bodies')

--- a/statutory/test/scripts/mock-core-registry.js
+++ b/statutory/test/scripts/mock-core-registry.js
@@ -358,6 +358,13 @@ exports.mockCoreMember = (options) => {
             .reply(500, { success: false, message: 'Some error' });
     }
 
+    if (options.file) {
+        return nock(`${config.core.url}:${config.core.port}`)
+            .persist()
+            .get(/\/members\/[0-9].*/)
+            .replyWithFile(200, path.join(__dirname, '..', 'assets', options.file));
+    }
+
     return nock(`${config.core.url}:${config.core.port}`)
         .persist()
         .get(/\/members\/[0-9].*/)


### PR DESCRIPTION
## Summary
- compute statutory `apply_from_body` from all bodies returned by Core instead of only the logged-in user's memberships
- fix the manager application edit flow so body options are not reduced to the overlap with the editor's own bodies
- add a regression test covering an event body that is outside the current user's memberships

## Verification
- `NODE_ENV=test npm run db:setup`
- `NODE_ENV=test jest test/api/events-display.test.js test/api/applications-editing.test.js --runInBand --forceExit`