### PR TITLE
fix(statutory): use applicant bodies when editing applications

### DIFF
--- a/frontend/src/views/statutory/EditApplication.vue
+++ b/frontend/src/views/statutory/EditApplication.vue
@@ -573,11 +573,7 @@ export default {
       this.axios.get(this.services['statutory'] + '/events/' + this.$route.params.id + '/applications/' + this.$route.params.application_id).then((application) => {
         this.application = application.data.data
         this.can = application.data.data.permissions
-
-        // Fetching user to get his/her bodies
-        return this.axios.get(this.services['core'] + '/members/' + this.application.user_id)
-      }).then((user) => {
-        this.bodies = user.data.data.bodies.filter(body => this.can.apply_from_body[body.id])
+        this.bodies = this.application.editable_bodies || []
         this.isLoading = false
       }).catch((err) => {
         this.isLoading = false

--- a/statutory/lib/applications.js
+++ b/statutory/lib/applications.js
@@ -11,6 +11,17 @@ const helpers = require('./helpers');
 const { sequelize } = require('./sequelize');
 const logger = require('./logger');
 
+async function getEditableBodiesForUser(req, user) {
+    const limits = await Promise.all(
+        user.bodies.map((body) => PaxLimit.fetchOrUseDefaultForBody(body, req.event.type))
+    );
+
+    return user.bodies.filter((body) => {
+        const limit = limits.find((item) => item.body_id === body.id);
+        return limit && limit.hasAnyLimits();
+    });
+}
+
 exports.listAllApplications = async (req, res) => {
     if (!req.permissions.see_applications) {
         return errors.makeForbiddenError(res, 'You are not allowed to see applications.');
@@ -287,6 +298,16 @@ exports.getApplication = async (req, res) => {
     }
 
     const application = req.application.toJSON();
+    application.editable_bodies = [];
+
+    if (req.permissions.edit_application) {
+        const user = req.user.id === req.application.user_id
+            ? req.user
+            : await core.getMember(req, req.application.user_id);
+
+        application.editable_bodies = await getEditableBodiesForUser(req, user);
+    }
+
     application.permissions = req.permissions;
 
     if (helpers.shouldHideApplicationStatus(req.event, req.permissions)) {

--- a/statutory/test/api/applications-display.test.js
+++ b/statutory/test/api/applications-display.test.js
@@ -62,6 +62,40 @@ describe('Applications displaying', () => {
         expect(res.body.data.user_id).toEqual(1337);
     });
 
+    test('should return editable bodies for the application owner instead of the logged-in user', async () => {
+        const applicantBody = {
+            id: 777,
+            name: 'AEGEE-Test',
+            type: 'antenna'
+        };
+        const applicantUser = {
+            ...regularUser,
+            id: 1337,
+            primary_body_id: applicantBody.id,
+            bodies: [applicantBody]
+        };
+
+        mock.mockAll({
+            member: { user: applicantUser }
+        });
+
+        const event = await generator.createEvent({ applications: [] });
+        const application = await generator.createApplication({
+            user_id: applicantUser.id,
+            body_id: regularUser.bodies[0].id
+        }, event);
+
+        const res = await request({
+            uri: '/events/' + event.id + '/applications/' + application.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body.data.editable_bodies).toEqual([applicantBody]);
+    });
+
     test('should succeed for those who has permissions to see applications', async () => {
         const userId = Math.floor(Math.random() * 100 * 50); // from 50 to 150
         const event = await generator.createEvent({ applications: [] });

--- a/statutory/test/scripts/mock-core-registry.js
+++ b/statutory/test/scripts/mock-core-registry.js
@@ -354,7 +354,7 @@ exports.mockCoreMember = (options) => {
     return nock(`${config.core.url}:${config.core.port}`)
         .persist()
         .get(/\/members\/[0-9].*/)
-        .reply(200, { success: true, data: regularUser });
+        .reply(200, { success: true, data: options.user || regularUser });
 };
 
 exports.mockCoreMailer = (options) => {


### PR DESCRIPTION
## Summary
- return applicant-specific `editable_bodies` from the statutory application endpoint when the current user can edit the application
- use that API data in `EditApplication.vue` so editing another member's application no longer intersects with the logged-in user's body memberships
- add a regression test for the application payload and allow test mocks to return a custom member profile

## Testing
- `cd statutory && npx eslint lib/applications.js test/api/applications-display.test.js test/scripts/mock-core-registry.js`
- `cd frontend && npx eslint src/views/statutory/EditApplication.vue`
- `cd statutory && npx jest test/api/applications-display.test.js --runInBand --forceExit` *(blocked here: local Postgres is not available in this workspace)*