### PR TITLE
fix(statutory): allow statutory IDs in board updates

### DIFF
--- a/statutory/lib/applications.js
+++ b/statutory/lib/applications.js
@@ -460,7 +460,7 @@ exports.setApplicationDeparted = setApplicationBoolean('departed');
 exports.setApplicationIsOnMemberslist = setApplicationBoolean('is_on_memberslist');
 
 exports.setApplicationStatus = async (req, res) => {
-    if (Number.isNaN(Number(req.params.application_id, 10))) {
+    if (req.params.application_id === constants.CURRENT_USER_PREFIX) {
         return errors.makeForbiddenError(res, 'You cannot edit status of yourself.');
     }
 
@@ -488,7 +488,7 @@ exports.setApplicationStatus = async (req, res) => {
 
 // For single application
 exports.setApplicationBoard = async (req, res) => {
-    if (Number.isNaN(Number(req.params.application_id, 10))) {
+    if (req.params.application_id === constants.CURRENT_USER_PREFIX) {
         return errors.makeForbiddenError(res, 'You cannot edit board comment or participant type of yourself.');
     }
 

--- a/statutory/test/api/applications-board.test.js
+++ b/statutory/test/api/applications-board.test.js
@@ -78,6 +78,26 @@ describe('Applications pax type/board comment', () => {
         expect(res.body.data.board_comment).toEqual('test');
     });
 
+    test('should succeed when addressed by statutory ID', async () => {
+        application = await application.update({ user_id: 1337 }, { returning: ['*'] });
+
+        const res = await request({
+            uri: '/events/' + event.id + '/applications/' + application.statutory_id + '/board',
+            method: 'PUT',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: { participant_type: 'delegate', board_comment: 'test', participant_order: 1 }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).not.toHaveProperty('errors');
+        expect(res.body).toHaveProperty('data');
+        expect(res.body.data.id).toEqual(application.id);
+        expect(res.body.data.participant_type).toEqual('delegate');
+        expect(res.body.data.participant_order).toEqual(1);
+        expect(res.body.data.board_comment).toEqual('test');
+    });
+
     test('should return 403 when user does not have permissions', async () => {
         mock.mockAll({ approvePermissions: { noPermissions: true }, mainPermissions: { noPermissions: true } });
 

--- a/statutory/test/api/applications-status.test.js
+++ b/statutory/test/api/applications-status.test.js
@@ -63,6 +63,25 @@ describe('Applications status', () => {
         expect(res.body.data.status).toEqual('accepted');
     });
 
+    test('should succeed when addressed by statutory ID', async () => {
+        const event = await generator.createEvent();
+        const application = await generator.createApplication({}, event);
+
+        const res = await request({
+            uri: '/events/' + event.id + '/applications/' + application.statutory_id + '/status',
+            method: 'PUT',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: { status: 'accepted' }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).not.toHaveProperty('errors');
+        expect(res.body).toHaveProperty('data');
+        expect(res.body.data.id).toEqual(application.id);
+        expect(res.body.data.status).toEqual('accepted');
+    });
+
     test('should return 403 when user does not have permissions', async () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 


### PR DESCRIPTION
## Summary
- accept statutory application IDs for `/status` and `/board` updates instead of rejecting every non-numeric route param
- keep the self-edit restriction limited to the explicit `/applications/me/...` case
- add regression coverage for status and board updates addressed by `statutory_id`

## Testing
- `NODE_ENV=test npx jest test/api/applications-status.test.js --runInBand --forceExit`
- `NODE_ENV=test npx jest test/api/applications-board.test.js --runInBand --forceExit`