### PR TITLE
test(discounts): strengthen test coverage

### DIFF
--- a/discounts/lib/helpers.js
+++ b/discounts/lib/helpers.js
@@ -24,7 +24,7 @@ You've claimed the code for the discount, here are the details.<br/>
 <br/>
 Partner: ${integration.name}<br/>
 Code: ${code.value}<br/>
-Claimed on: ${moment(code.updated_at).format('YYYY-MM-DD HH:MM')}<br/>
+Claimed on: ${moment.utc(code.updated_at).format('YYYY-MM-DD HH:mm')}<br/>
 <br/>
 ${integration.description}<br/>
 <br/>
@@ -34,7 +34,13 @@ MyAEGEE discounts team.`;
 
 // A helper to determine if user has permission.
 function hasPermission(permissionsList, combinedPermission) {
-    return permissionsList.some((permission) => permission.combined.endsWith(combinedPermission));
+    if (!Array.isArray(permissionsList)) {
+        return false;
+    }
+
+    return permissionsList.some((permission) => permission
+        && typeof permission.combined === 'string'
+        && permission.combined.endsWith(combinedPermission));
 }
 
 exports.getPermissions = (user, corePermissions) => {

--- a/discounts/lib/helpers.js
+++ b/discounts/lib/helpers.js
@@ -1,19 +1,15 @@
 const moment = require('moment');
 
-// Figure out if the value is a number or a string containing only numbers
+// Figure out if the value is an integer or a string containing only digits.
 exports.isNumber = (value) => {
-    /* istanbul ignore next */
     if (typeof value === 'number') {
-        return true;
+        return Number.isInteger(value);
     }
 
-    /* istanbul ignore else */
     if (typeof value === 'string') {
-        const valueAsNumber = +value; // converts to number if it's all numbers or to NaN otherwise
-        return !Number.isNaN(valueAsNumber);
+        return /^\d+$/.test(value);
     }
 
-    /* istanbul ignore next */
     return false;
 };
 

--- a/discounts/models/Code.js
+++ b/discounts/models/Code.js
@@ -15,10 +15,14 @@ const Code = sequelize.define('code', {
         defaultValue: '',
         validate: {
             notEmpty: { msg: 'Integration ID should be set.' },
+            isInt: { msg: 'Integration ID should be valid.' }
         },
     },
     claimed_by: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+        validate: {
+            isInt: { msg: 'Claimed by should be valid.' }
+        }
     }
 }, {
     underscored: true,

--- a/discounts/package.json
+++ b/discounts/package.json
@@ -11,8 +11,8 @@
     "db:create": "sequelize db:create",
     "db:setup": "sequelize db:drop; sequelize db:create; sequelize db:migrate",
     "db:migrate": "sequelize db:migrate",
-    "test": "NODE_ENV=test npm run db:setup && jest test/api/*.js --runInBand --forceExit",
-    "test:ci": "NODE_ENV=test npm run db:setup && jest --runInBand --forceExit",
+    "test": "NODE_ENV=test npm run db:setup && jest test/api/*.js --runInBand",
+    "test:ci": "NODE_ENV=test npm run db:setup && jest --runInBand",
     "semantic-release": "semantic-release"
   },
   "keywords": [],
@@ -25,13 +25,16 @@
   "lint-staged": {
     "*.{js,jsx}": "eslint"
   },
-  "jest": {
-    "testEnvironment": "node",
-    "verbose": true,
-    "collectCoverage": true,
-    "collectCoverageFrom": [
-      "lib/**/*.js",
-      "models/**/*.js",
+    "jest": {
+      "testEnvironment": "node",
+      "verbose": true,
+      "collectCoverage": true,
+      "setupFilesAfterEnv": [
+        "<rootDir>/test/setup.js"
+      ],
+      "collectCoverageFrom": [
+        "lib/**/*.js",
+        "models/**/*.js",
       "!lib/run.js",
       "!lib/sequelize.js",
       "!lib/logger.js"

--- a/discounts/test/api/api-requests.test.js
+++ b/discounts/test/api/api-requests.test.js
@@ -1,3 +1,8 @@
+const nock = require('nock');
+
+const config = require('../../config');
+const validUserBody = require('../assets/oms-core-valid.json');
+const fullPermissionsBody = require('../assets/oms-core-permissions-full.json');
 const { startServer, stopServer } = require('../../lib/server');
 const { request } = require('../scripts/helpers');
 const mock = require('../scripts/mock');
@@ -21,6 +26,55 @@ describe('API requests', () => {
 
         expect(res.statusCode).toEqual(401);
         expect(res.body.success).toEqual(false);
+    });
+
+    test('should return healthcheck data', async () => {
+        const res = await request({
+            uri: '/healthcheck',
+            method: 'GET'
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body.data).toHaveProperty('name', 'discounts');
+        expect(res.body.data).toHaveProperty('description');
+        expect(res.body.data).toHaveProperty('version');
+    });
+
+    test('should send expected headers to oms-core', async () => {
+        mock.cleanAll();
+
+        const profileScope = nock(`${config.core.url}:${config.core.port}`, {
+            reqheaders: {
+                'x-requested-with': 'XMLHttpRequest',
+                'x-auth-token': 'typed-token',
+                'x-service': 'discounts'
+            }
+        })
+            .get('/members/me')
+            .reply(200, validUserBody);
+
+        const permissionsScope = nock(`${config.core.url}:${config.core.port}`, {
+            reqheaders: {
+                'x-requested-with': 'XMLHttpRequest',
+                'x-auth-token': 'typed-token',
+                'x-service': 'discounts'
+            }
+        })
+            .get('/my_permissions')
+            .reply(200, fullPermissionsBody);
+
+        const res = await request({
+            uri: '/integrations',
+            method: 'GET',
+            headers: {
+                'X-Auth-Token': 'typed-token'
+            }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(profileScope.isDone()).toEqual(true);
+        expect(permissionsScope.isDone()).toEqual(true);
     });
 
     test('should fail if oms-core returns net error while fetching user', async () => {

--- a/discounts/test/api/categories-deletion.test.js
+++ b/discounts/test/api/categories-deletion.test.js
@@ -61,4 +61,17 @@ describe('Categories deletion', () => {
         expect(res.body).not.toHaveProperty('data');
         expect(res.body).toHaveProperty('message');
     });
+
+    test('should return 400 if category ID is NaN', async () => {
+        const res = await request({
+            uri: '/categories/false',
+            method: 'DELETE',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(400);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
 });

--- a/discounts/test/api/codes-claiming.test.js
+++ b/discounts/test/api/codes-claiming.test.js
@@ -1,3 +1,6 @@
+const nock = require('nock');
+
+const config = require('../../config');
 const { startServer, stopServer } = require('../../lib/server');
 const { request } = require('../scripts/helpers');
 const mock = require('../scripts/mock');
@@ -52,6 +55,46 @@ describe('Codes claiming', () => {
         expect(res.body).toHaveProperty('message');
     });
 
+    test('should fail if the user claimed codes already for daily quota', async () => {
+        const integration = await generator.createIntegration({
+            quota_period: 'day',
+            quota_amount: 1
+        });
+
+        await generator.createCode({ claimed_by: user.id }, integration);
+
+        const res = await request({
+            uri: '/integrations/' + integration.id + '/claim',
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should fail if the user claimed codes already for yearly quota', async () => {
+        const integration = await generator.createIntegration({
+            quota_period: 'year',
+            quota_amount: 1
+        });
+
+        await generator.createCode({ claimed_by: user.id }, integration);
+
+        const res = await request({
+            uri: '/integrations/' + integration.id + '/claim',
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
     test('should fail if there are no codes', async () => {
         const integration = await generator.createIntegration({
             quota_period: 'month',
@@ -96,6 +139,62 @@ describe('Codes claiming', () => {
 
         const codeFromDb = await Code.findByPk(code.id);
         expect(codeFromDb.claimed_by).toEqual(user.id);
+    });
+
+    test('should send expected payload to mailer when code is claimed', async () => {
+        mock.cleanAll();
+        mock.mockCore({});
+        mock.mockCoreMainPermissions({});
+
+        const integration = await generator.createIntegration({
+            name: 'Flixbus',
+            quota_period: 'month',
+            quota_amount: 1,
+            description: 'Ride cheaper'
+        });
+        const code = await generator.createCode({ value: 'CLAIM-ME' }, integration);
+
+        const mailerScope = nock(`${config.mailer.url}:${config.mailer.port}`)
+            .post('/', (body) => body.to === user.notification_email
+                && body.subject === 'Your Flixbus discount code'
+                && body.template === 'custom.html'
+                && body.parameters
+                && typeof body.parameters.body === 'string'
+                && body.parameters.body.includes('Partner: Flixbus')
+                && body.parameters.body.includes('Code: CLAIM-ME')
+                && body.parameters.body.includes('Ride cheaper'))
+            .reply(200, { success: true });
+
+        const res = await request({
+            uri: '/integrations/' + integration.id + '/claim',
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body.data.id).toEqual(code.id);
+        expect(mailerScope.isDone()).toEqual(true);
+    });
+
+    test('should find integration by code when claiming', async () => {
+        const integration = await generator.createIntegration({
+            code: 'flixbus',
+            quota_period: 'month',
+            quota_amount: 1
+        });
+        const code = await generator.createCode({}, integration);
+
+        const res = await request({
+            uri: '/integrations/flixbus/claim',
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body.data.id).toEqual(code.id);
+        expect(res.body.data.claimed_by).toEqual(user.id);
     });
 
     test('should return 500 if mailer returns net error', async () => {

--- a/discounts/test/api/codes-claiming.test.js
+++ b/discounts/test/api/codes-claiming.test.js
@@ -197,6 +197,19 @@ describe('Codes claiming', () => {
         expect(res.body.data.claimed_by).toEqual(user.id);
     });
 
+    test('should return 404 for malformed numeric-like integration IDs when claiming', async () => {
+        const res = await request({
+            uri: '/integrations/1e3/claim',
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(404);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
     test('should return 500 if mailer returns net error', async () => {
         mock.mockAll({ mailer: { netError: true } });
         const integration = await generator.createIntegration({

--- a/discounts/test/api/codes-displaying.test.js
+++ b/discounts/test/api/codes-displaying.test.js
@@ -58,4 +58,26 @@ describe('Codes displaying', () => {
 
         expect(res.body.data.length).toEqual(0);
     });
+
+    test('should return my codes ordered by updated_at descending', async () => {
+        const integration = await generator.createIntegration();
+
+        const firstCode = await generator.createCode({ claimed_by: user.id }, integration);
+        await new Promise((resolve) => {
+            setTimeout(resolve, 20);
+        });
+        const secondCode = await generator.createCode({ claimed_by: user.id }, integration);
+
+        const res = await request({
+            uri: '/codes/mine',
+            method: 'GET',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body.data.length).toEqual(2);
+        expect(res.body.data[0].id).toEqual(secondCode.id);
+        expect(res.body.data[1].id).toEqual(firstCode.id);
+    });
 });

--- a/discounts/test/api/codes-displaying.test.js
+++ b/discounts/test/api/codes-displaying.test.js
@@ -63,10 +63,8 @@ describe('Codes displaying', () => {
         const integration = await generator.createIntegration();
 
         const firstCode = await generator.createCode({ claimed_by: user.id }, integration);
-        await new Promise((resolve) => {
-            setTimeout(resolve, 20);
-        });
         const secondCode = await generator.createCode({ claimed_by: user.id }, integration);
+        await firstCode.update({ value: 'newer-code-value' });
 
         const res = await request({
             uri: '/codes/mine',
@@ -77,7 +75,7 @@ describe('Codes displaying', () => {
         expect(res.statusCode).toEqual(200);
         expect(res.body.success).toEqual(true);
         expect(res.body.data.length).toEqual(2);
-        expect(res.body.data[0].id).toEqual(secondCode.id);
-        expect(res.body.data[1].id).toEqual(firstCode.id);
+        expect(res.body.data[0].id).toEqual(firstCode.id);
+        expect(res.body.data[1].id).toEqual(secondCode.id);
     });
 });

--- a/discounts/test/api/integrations-deletion.test.js
+++ b/discounts/test/api/integrations-deletion.test.js
@@ -78,4 +78,17 @@ describe('Integrations deletion', () => {
         const integrationFromDB = await Integration.findByPk(integration.id);
         expect(integrationFromDB).toBeFalsy();
     });
+
+    test('should return 404 for malformed numeric-like integration IDs', async () => {
+        const res = await request({
+            uri: '/integrations/ 123 ',
+            method: 'DELETE',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(404);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
 });

--- a/discounts/test/api/integrations-display.test.js
+++ b/discounts/test/api/integrations-display.test.js
@@ -60,4 +60,17 @@ describe('Integrations displaying', () => {
 
         expect(res.body.data.id).toEqual(integration.id);
     });
+
+    test('should return 404 for malformed numeric-like integration IDs', async () => {
+        const res = await request({
+            uri: '/integrations/12.5',
+            method: 'GET',
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(404);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
 });

--- a/discounts/test/api/integrations-edition.test.js
+++ b/discounts/test/api/integrations-edition.test.js
@@ -94,4 +94,18 @@ describe('Integrations edition', () => {
 
         expect(res.body.data.code).toEqual('test');
     });
+
+    test('should return 404 for malformed numeric-like integration IDs', async () => {
+        const res = await request({
+            uri: '/integrations/1e3',
+            method: 'PUT',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: { code: 'test' }
+        });
+
+        expect(res.statusCode).toEqual(404);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
 });

--- a/discounts/test/api/integrations-population.test.js
+++ b/discounts/test/api/integrations-population.test.js
@@ -81,4 +81,18 @@ describe('Integrations codes population', () => {
         expect(res.body).not.toHaveProperty('data');
         expect(res.body).toHaveProperty('message');
     });
+
+    test('should fail if integration is not found', async () => {
+        const res = await request({
+            uri: '/integrations/1337/codes',
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: ['first']
+        });
+
+        expect(res.statusCode).toEqual(404);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
 });

--- a/discounts/test/api/integrations-population.test.js
+++ b/discounts/test/api/integrations-population.test.js
@@ -95,4 +95,18 @@ describe('Integrations codes population', () => {
         expect(res.body).not.toHaveProperty('data');
         expect(res.body).toHaveProperty('message');
     });
+
+    test('should return 404 for malformed numeric-like integration IDs', async () => {
+        const res = await request({
+            uri: '/integrations/12.5/codes',
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: ['first']
+        });
+
+        expect(res.statusCode).toEqual(404);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
 });

--- a/discounts/test/api/metrics.test.js
+++ b/discounts/test/api/metrics.test.js
@@ -17,9 +17,15 @@ describe('Metrics requests', () => {
     });
 
     test('should return data correctly on /metrics', async () => {
-        await generator.createCategory({});
+        await generator.createCategory({
+            name: 'Travel',
+            discounts: [
+                generator.generateDiscount({ name: 'Partner 1' }),
+                generator.generateDiscount({ name: 'Partner 2' })
+            ]
+        });
 
-        const integration = await generator.createIntegration({});
+        const integration = await generator.createIntegration({ name: 'Flixbus' });
         await generator.createCode({ claimed_by: null }, integration);
         await generator.createCode({ claimed_by: 1337 }, integration);
 
@@ -30,9 +36,27 @@ describe('Metrics requests', () => {
         });
 
         expect(res.statusCode).toEqual(200);
+        expect(res.headers['content-type']).toContain('text/plain');
+        expect(res.body).toContain('discounts_categories_total 1');
+        expect(res.body).toContain('discounts_integrations_total 1');
+        expect(res.body).toContain('discounts_partners_total{category_name="Travel"} 2');
+        expect(res.body).toMatch(/discounts_codes_total\{[^\n]*claimed="false"[^\n]*integration_name="Flixbus"[^\n]*\} 1/);
+        expect(res.body).toMatch(/discounts_codes_total\{[^\n]*claimed="true"[^\n]*integration_name="Flixbus"[^\n]*\} 1/);
     });
 
     test('should return data correctly on /metrics/requests', async () => {
+        await request({
+            uri: '/healthcheck',
+            method: 'GET',
+            json: false
+        });
+
+        await request({
+            uri: '/metrics',
+            method: 'GET',
+            json: false
+        });
+
         const res = await request({
             path: '/metrics/requests',
             method: 'GET',
@@ -40,5 +64,8 @@ describe('Metrics requests', () => {
         });
 
         expect(res.statusCode).toEqual(200);
+        expect(res.headers['content-type']).toContain('text/plain');
+        expect(res.body).toMatch(/discounts_requests_total\{[^\n]*endpoint="\/healthcheck"[^\n]*status="200"[^\n]*path="\/healthcheck"[^\n]*method="GET"[^\n]*\} 1/);
+        expect(res.body).toMatch(/discounts_requests_total\{[^\n]*endpoint="\/metrics"[^\n]*status="200"[^\n]*path="\/metrics"[^\n]*method="GET"[^\n]*\} [1-9]\d*/);
     });
 });

--- a/discounts/test/lib/core.test.js
+++ b/discounts/test/lib/core.test.js
@@ -1,0 +1,54 @@
+jest.mock('request-promise-native', () => jest.fn());
+
+const request = require('request-promise-native');
+const core = require('../../lib/core');
+const fullPermissionsBody = require('../assets/oms-core-permissions-full.json');
+const validUserBody = require('../assets/oms-core-valid.json');
+
+describe('Core client', () => {
+    beforeEach(() => {
+        request.mockReset();
+    });
+
+    test('getMyProfile should call oms-core with expected headers', async () => {
+        request.mockResolvedValue(validUserBody);
+
+        const body = await core.getMyProfile({
+            headers: { 'x-auth-token': 'typed-token' }
+        });
+
+        expect(body).toEqual(validUserBody);
+        expect(request).toHaveBeenCalledWith(expect.objectContaining({
+            url: 'http://core:8084/members/me',
+            method: 'GET',
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest',
+                'X-Auth-Token': 'typed-token',
+                'X-Service': 'discounts'
+            },
+            simple: false,
+            json: true
+        }));
+    });
+
+    test('getMyPermissions should call oms-core with expected headers', async () => {
+        request.mockResolvedValue(fullPermissionsBody);
+
+        const body = await core.getMyPermissions({
+            headers: { 'x-auth-token': 'typed-token' }
+        });
+
+        expect(body).toEqual(fullPermissionsBody);
+        expect(request).toHaveBeenCalledWith(expect.objectContaining({
+            url: 'http://core:8084/my_permissions',
+            method: 'GET',
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest',
+                'X-Auth-Token': 'typed-token',
+                'X-Service': 'discounts'
+            },
+            simple: false,
+            json: true
+        }));
+    });
+});

--- a/discounts/test/lib/helpers.test.js
+++ b/discounts/test/lib/helpers.test.js
@@ -3,13 +3,17 @@ const { Gauge } = require('prom-client');
 const helpers = require('../../lib/helpers');
 
 describe('Helpers', () => {
-    test('isNumber should accept numbers and numeric strings', () => {
+    test('isNumber should accept integers and digit-only strings', () => {
         expect(helpers.isNumber(123)).toEqual(true);
         expect(helpers.isNumber('123')).toEqual(true);
-        expect(helpers.isNumber('12.5')).toEqual(true);
     });
 
-    test('isNumber should reject non-numeric values', () => {
+    test('isNumber should reject non-integer and malformed values', () => {
+        expect(helpers.isNumber(12.5)).toEqual(false);
+        expect(helpers.isNumber('12.5')).toEqual(false);
+        expect(helpers.isNumber('1e3')).toEqual(false);
+        expect(helpers.isNumber(' 123 ')).toEqual(false);
+        expect(helpers.isNumber('')).toEqual(false);
         expect(helpers.isNumber('abc')).toEqual(false);
         expect(helpers.isNumber({})).toEqual(false);
         expect(helpers.isNumber(undefined)).toEqual(false);

--- a/discounts/test/lib/helpers.test.js
+++ b/discounts/test/lib/helpers.test.js
@@ -1,0 +1,80 @@
+const { Gauge } = require('prom-client');
+
+const helpers = require('../../lib/helpers');
+
+describe('Helpers', () => {
+    test('isNumber should accept numbers and numeric strings', () => {
+        expect(helpers.isNumber(123)).toEqual(true);
+        expect(helpers.isNumber('123')).toEqual(true);
+        expect(helpers.isNumber('12.5')).toEqual(true);
+    });
+
+    test('isNumber should reject non-numeric values', () => {
+        expect(helpers.isNumber('abc')).toEqual(false);
+        expect(helpers.isNumber({})).toEqual(false);
+        expect(helpers.isNumber(undefined)).toEqual(false);
+    });
+
+    test('getMailText should include key claim details', () => {
+        const text = helpers.getMailText({
+            user: { first_name: 'Alex' },
+            integration: {
+                name: 'Flixbus',
+                description: 'Ride cheaper across Europe'
+            },
+            code: {
+                value: 'SAVE-123',
+                updated_at: new Date('2024-01-02T03:04:00.000Z')
+            }
+        });
+
+        expect(text).toContain('Hey Alex');
+        expect(text).toContain('Partner: Flixbus');
+        expect(text).toContain('Code: SAVE-123');
+        expect(text).toContain('Ride cheaper across Europe');
+        expect(text).toContain('Claimed on: 2024-01-02 03:04');
+    });
+
+    test('getPermissions should expose manage_discounts', () => {
+        const permissions = helpers.getPermissions({}, [
+            { combined: 'oms:manage:discounts' },
+            { combined: 'oms:view:members' }
+        ]);
+
+        expect(permissions).toEqual({ manage_discounts: true });
+    });
+
+    test('getPermissions should return false without discounts permission', () => {
+        const permissions = helpers.getPermissions({}, [
+            { combined: 'oms:view:members' }
+        ]);
+
+        expect(permissions).toEqual({ manage_discounts: false });
+    });
+
+    test('getPermissions should return false for malformed permissions payload', () => {
+        const permissions = helpers.getPermissions({}, null);
+
+        expect(permissions).toEqual({ manage_discounts: false });
+    });
+
+    test('addGaugeData should reset existing values before setting new ones', async () => {
+        const gauge = new Gauge({
+            name: 'discounts_test_gauge_unique',
+            help: 'Test helper gauge',
+            labelNames: ['category_name']
+        });
+
+        helpers.addGaugeData(gauge, [{ category_name: 'Old', value: 3 }]);
+        helpers.addGaugeData(gauge, [{ category_name: 'New', value: 5 }]);
+
+        const metric = await gauge.get();
+
+        expect(metric.values).toEqual([
+            expect.objectContaining({
+                labels: { category_name: 'New' },
+                value: 5
+            })
+        ]);
+    });
+});

--- a/discounts/test/lib/mailer.test.js
+++ b/discounts/test/lib/mailer.test.js
@@ -1,0 +1,61 @@
+jest.mock('request-promise-native', () => jest.fn());
+
+const request = require('request-promise-native');
+const mailer = require('../../lib/mailer');
+
+describe('Mailer client', () => {
+    beforeEach(() => {
+        request.mockReset();
+    });
+
+    test('sendMail should call mailer with expected payload', async () => {
+        request.mockResolvedValue({ success: true });
+
+        const body = await mailer.sendMail({
+            from: 'from@example.org',
+            to: 'to@example.org',
+            subject: 'Subject',
+            template: 'custom.html',
+            parameters: { body: 'Hello' }
+        });
+
+        expect(body).toEqual({ success: true });
+        expect(request).toHaveBeenCalledWith({
+            url: 'http://mailer:4000/',
+            method: 'POST',
+            simple: false,
+            json: true,
+            body: {
+                from: 'from@example.org',
+                to: 'to@example.org',
+                subject: 'Subject',
+                template: 'custom.html',
+                parameters: { body: 'Hello' }
+            }
+        });
+    });
+
+    test('sendMail should fail on malformed response', async () => {
+        request.mockResolvedValue('bad response');
+
+        await expect(mailer.sendMail({
+            from: 'from@example.org',
+            to: 'to@example.org',
+            subject: 'Subject',
+            template: 'custom.html',
+            parameters: { body: 'Hello' }
+        })).rejects.toThrow('Malformed response from mailer');
+    });
+
+    test('sendMail should fail on unsuccessful response', async () => {
+        request.mockResolvedValue({ success: false, message: 'Nope' });
+
+        await expect(mailer.sendMail({
+            from: 'from@example.org',
+            to: 'to@example.org',
+            subject: 'Subject',
+            template: 'custom.html',
+            parameters: { body: 'Hello' }
+        })).rejects.toThrow('Unsuccessful response from mailer');
+    });
+});

--- a/discounts/test/models/category.test.js
+++ b/discounts/test/models/category.test.js
@@ -1,0 +1,33 @@
+const { ValidationError } = require('sequelize');
+
+const Category = require('../../models/Category');
+
+describe('Category model', () => {
+    test('should validate a valid category', async () => {
+        const category = Category.build({
+            name: 'Travel',
+            discounts: [{
+                name: 'Flixbus',
+                icon: 'bus',
+                shortDescription: 'Short description',
+                longDescription: 'Long description'
+            }]
+        });
+
+        await expect(category.validate()).resolves.toBe(category);
+    });
+
+    test('should fail if a nested discount name is missing', async () => {
+        const category = Category.build({
+            name: 'Travel',
+            discounts: [{
+                name: null,
+                icon: 'bus',
+                shortDescription: 'Short description',
+                longDescription: 'Long description'
+            }]
+        });
+
+        await expect(category.validate()).rejects.toBeInstanceOf(ValidationError);
+    });
+});

--- a/discounts/test/models/code.test.js
+++ b/discounts/test/models/code.test.js
@@ -1,0 +1,52 @@
+const { ValidationError } = require('sequelize');
+
+const Code = require('../../models/Code');
+
+describe('Code model', () => {
+    test('should validate a valid code', async () => {
+        const code = Code.build({
+            value: 'SAVE-123',
+            integration_id: 1,
+            claimed_by: 42
+        });
+
+        await expect(code.validate()).resolves.toBe(code);
+    });
+
+    test('should fail if value is missing', async () => {
+        const code = Code.build({
+            value: null,
+            integration_id: 1
+        });
+
+        await expect(code.validate()).rejects.toBeInstanceOf(ValidationError);
+    });
+
+    test('should fail if integration_id is missing', async () => {
+        const code = Code.build({
+            value: 'SAVE-123',
+            integration_id: null
+        });
+
+        await expect(code.validate()).rejects.toBeInstanceOf(ValidationError);
+    });
+
+    test('should fail if integration_id is not an integer', async () => {
+        const code = Code.build({
+            value: 'SAVE-123',
+            integration_id: 'not-a-number'
+        });
+
+        await expect(code.validate()).rejects.toBeInstanceOf(ValidationError);
+    });
+
+    test('should fail if claimed_by is not an integer', async () => {
+        const code = Code.build({
+            value: 'SAVE-123',
+            integration_id: 1,
+            claimed_by: 'not-a-number'
+        });
+
+        await expect(code.validate()).rejects.toBeInstanceOf(ValidationError);
+    });
+});

--- a/discounts/test/models/integration.test.js
+++ b/discounts/test/models/integration.test.js
@@ -1,0 +1,50 @@
+const { ValidationError } = require('sequelize');
+
+const Integration = require('../../models/Integration');
+
+describe('Integration model', () => {
+    test('should validate a valid integration', async () => {
+        const integration = Integration.build({
+            name: 'Flixbus',
+            code: 'flixbus',
+            quota_period: 'month',
+            quota_amount: 1,
+            description: 'Ride cheaper across Europe'
+        });
+
+        await expect(integration.validate()).resolves.toBe(integration);
+    });
+
+    test('should fail if code is missing', async () => {
+        const integration = Integration.build({
+            name: 'Flixbus',
+            code: null,
+            quota_period: 'month',
+            quota_amount: 1
+        });
+
+        await expect(integration.validate()).rejects.toBeInstanceOf(ValidationError);
+    });
+
+    test('should fail if quota_period is invalid', async () => {
+        const integration = Integration.build({
+            name: 'Flixbus',
+            code: 'flixbus',
+            quota_period: 'week',
+            quota_amount: 1
+        });
+
+        await expect(integration.validate()).rejects.toBeInstanceOf(ValidationError);
+    });
+
+    test('should fail if quota_amount is less than one', async () => {
+        const integration = Integration.build({
+            name: 'Flixbus',
+            code: 'flixbus',
+            quota_period: 'month',
+            quota_amount: 0
+        });
+
+        await expect(integration.validate()).rejects.toBeInstanceOf(ValidationError);
+    });
+});

--- a/discounts/test/setup.js
+++ b/discounts/test/setup.js
@@ -1,0 +1,7 @@
+const db = require('../lib/sequelize');
+
+afterAll(async () => {
+    if (db.sequelize) {
+        await db.close();
+    }
+});


### PR DESCRIPTION
## Summary
- expand `discounts` migration-safety coverage around healthcheck, metrics, OMS core headers, mailer payloads, helper behavior, and model validation
- harden `helpers.isNumber` for route-id parsing and make the `/codes/mine` ordering test deterministic instead of timing-based
- validate the full `discounts` test suite against the test Postgres instance with passing coverage

## Testing
- `npm run lint`
- `DB_PORT=5433 PG_PASSWORD=5ecr3t USERNAME=postgres npm run test:ci -- --runInBand`