### PR TITLE
fix(frontend): trim bundle size

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -72,7 +72,6 @@ export default {
 
 <style lang="scss">
 @import '~flatpickr/dist/flatpickr.css';
-@import '~animate.css';
 @import '~vue-multiselect/dist/vue-multiselect.min.css';
 
 .animated {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -71,9 +71,6 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~flatpickr/dist/flatpickr.css';
-@import '~vue-multiselect/dist/vue-multiselect.min.css';
-
 @import './styles/main.scss';
 
 html, body, #app, .app-main {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -74,10 +74,6 @@ export default {
 @import '~flatpickr/dist/flatpickr.css';
 @import '~vue-multiselect/dist/vue-multiselect.min.css';
 
-.animated {
-  animation-duration: .377s;
-}
-
 @import './styles/main.scss';
 
 html, body, #app, .app-main {

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -4,10 +4,27 @@ import Vue from 'vue'
 import axios from 'axios'
 import VueAxios from 'vue-axios'
 import { sync } from 'vuex-router-sync'
-import Buefy from 'buefy'
-import flatPickr from 'vue-flatpickr-component'
-import Multiselect from 'vue-multiselect'
-import InputTag from 'vue-input-tag'
+import {
+  Autocomplete,
+  Button,
+  Checkbox,
+  Collapse,
+  ConfigProgrammatic,
+  Datepicker,
+  Dialog,
+  Field,
+  Icon,
+  Input,
+  Loading,
+  Message,
+  Modal,
+  Radio,
+  Select,
+  Switch,
+  Table,
+  Tag,
+  Toast
+} from 'buefy'
 import qs from 'qs'
 import Vue2TouchEvents from 'vue2-touch-events'
 import VTooltip from 'v-tooltip'
@@ -34,12 +51,27 @@ Vue.router = router
 Vue.use(VueAxios, axios)
 Vue.use(Auth)
 Vue.use(NProgress)
-Vue.use(Buefy, { defaultNoticeQueue: false, defaultIconPack: 'fa' })
-Vue.use(flatPickr)
+ConfigProgrammatic.setOptions({ defaultNoticeQueue: false, defaultIconPack: 'fa' })
+Vue.use(Autocomplete)
+Vue.use(Button)
+Vue.use(Checkbox)
+Vue.use(Collapse)
+Vue.use(Datepicker)
+Vue.use(Dialog)
+Vue.use(Field)
+Vue.use(Icon)
+Vue.use(Input)
+Vue.use(Loading)
+Vue.use(Message)
+Vue.use(Modal)
+Vue.use(Radio)
+Vue.use(Select)
+Vue.use(Switch)
+Vue.use(Table)
+Vue.use(Tag)
+Vue.use(Toast)
 Vue.use(Vue2TouchEvents)
 Vue.use(VTooltip)
-Vue.component('multiselect', Multiselect)
-Vue.component('input-tag', InputTag)
 Vue.component('select-or-custom', SelectOrCustom)
 Vue.component('password-toggle', PasswordToggle)
 Vue.component('empty-table-stub', EmptyTableStub)

--- a/frontend/src/components/layout/AppMain.vue
+++ b/frontend/src/components/layout/AppMain.vue
@@ -6,9 +6,9 @@
   >
     <div class="container is-fluid is-marginless app-content">
       <levelbar />
-      <transition mode="out-in" enter-active-class="fadeIn" leave-active-class="fadeOut" appear>
+      <transition name="route-fade" mode="out-in" appear>
         <div class="box">
-          <router-view class="animated" />
+          <router-view />
         </div>
       </transition>
     </div>
@@ -66,5 +66,16 @@ html {
 
 .app-content {
   padding: 20px;
+}
+
+.route-fade-enter-active,
+.route-fade-leave-active {
+  transition: opacity .377s ease, transform .377s ease;
+}
+
+.route-fade-enter,
+.route-fade-leave-to {
+  opacity: 0;
+  transform: translate3d(0, 8px, 0);
 }
 </style>

--- a/frontend/src/components/layout/AppMain.vue
+++ b/frontend/src/components/layout/AppMain.vue
@@ -36,7 +36,9 @@ export default {
 </script>
 
 <style lang="scss">
-@import '../../styles/main.scss';
+@import '~bulma/sass/utilities/initial-variables';
+@import '~bulma/sass/utilities/derived-variables';
+@import '~bulma/sass/utilities/mixins';
 
 html {
   background-color: #fafafa;

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside class="menu app-sidebar animate__animated" :class="{ animate__slideInLeft: show, animate__slideOutLeft: !show, 'is-menu-opened': navbar.menuOpened }">
+  <aside class="menu app-sidebar" :class="{ 'is-visible': show, 'is-hidden': !show, 'is-menu-opened': navbar.menuOpened }">
     <div v-for="category in filteredMenu" v-bind:key="category.categoryName">
       <p class="menu-label">
         {{ category.categoryName }}
@@ -214,6 +214,25 @@ export default {
   box-shadow: 0 2px 3px rgba(17, 17, 17, 0.1), 0 0 0 1px rgba(17, 17, 17, 0.1);
   overflow-y: auto;
   overflow-x: hidden;
+  transition: transform .377s ease, opacity .377s ease;
+
+  &.is-visible {
+    opacity: 1;
+  }
+
+  &.is-hidden {
+    opacity: 0;
+  }
+
+  @include mobile() {
+    &.is-visible {
+      transform: translate3d(0, 0, 0);
+    }
+
+    &.is-hidden {
+      transform: translate3d(-180px, 0, 0);
+    }
+  }
 
   &.is-menu-opened {
     @include mobile() {

--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -60,8 +60,6 @@ h1, h2, h3, h4, h5, h6 {
 
 @import '~bulma';
 @import '~buefy/dist/buefy.min.css';
-@import '~mapbox-gl/dist/mapbox-gl.css';
-@import '~animate.css/animate.min.css';
 
 @import '~nprogress/nprogress.css';
 

--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -58,8 +58,53 @@ h1, h2, h3, h4, h5, h6 {
 
 /* ------ end of VI colors ------------- */
 
-@import '~bulma';
-@import '~buefy/dist/buefy.min.css';
+@import '~bulma/sass/utilities/_all';
+@import '~bulma/sass/base/_all';
+@import '~bulma/sass/elements/box';
+@import '~bulma/sass/elements/button';
+@import '~bulma/sass/elements/container';
+@import '~bulma/sass/elements/content';
+@import '~bulma/sass/elements/icon';
+@import '~bulma/sass/elements/image';
+@import '~bulma/sass/elements/notification';
+@import '~bulma/sass/elements/table';
+@import '~bulma/sass/elements/tag';
+@import '~bulma/sass/elements/title';
+@import '~bulma/sass/elements/other';
+@import '~bulma/sass/form/_all';
+@import '~bulma/sass/components/card';
+@import '~bulma/sass/components/dropdown';
+@import '~bulma/sass/components/level';
+@import '~bulma/sass/components/media';
+@import '~bulma/sass/components/menu';
+@import '~bulma/sass/components/message';
+@import '~bulma/sass/components/modal';
+@import '~bulma/sass/components/navbar';
+@import '~bulma/sass/components/pagination';
+@import '~bulma/sass/components/tabs';
+@import '~bulma/sass/grid/_all';
+@import '~bulma/sass/helpers/_all';
+@import '~bulma/sass/layout/section';
+@import '~bulma/sass/layout/footer';
+@import '~buefy/src/scss/utils/_all';
+@import '~buefy/src/scss/utils/_variables-ext';
+@import '~buefy/src/scss/components/_autocomplete';
+@import '~buefy/src/scss/components/_checkbox';
+@import '~buefy/src/scss/components/_collapse';
+@import '~buefy/src/scss/components/_datepicker';
+@import '~buefy/src/scss/components/_dialog';
+@import '~buefy/src/scss/components/_dropdown';
+@import '~buefy/src/scss/components/_form';
+@import '~buefy/src/scss/components/_icon';
+@import '~buefy/src/scss/components/_loading';
+@import '~buefy/src/scss/components/_message';
+@import '~buefy/src/scss/components/_modal';
+@import '~buefy/src/scss/components/_notices';
+@import '~buefy/src/scss/components/_radio';
+@import '~buefy/src/scss/components/_select';
+@import '~buefy/src/scss/components/_switch';
+@import '~buefy/src/scss/components/_table';
+@import '~buefy/src/scss/components/_tag';
 
 @import '~nprogress/nprogress.css';
 

--- a/frontend/src/views/auth/Register.vue
+++ b/frontend/src/views/auth/Register.vue
@@ -196,7 +196,7 @@
 <script>
 import { mapGetters } from 'vuex'
 import moment from 'moment'
-import _ from 'lodash'
+import pick from 'lodash/pick'
 
 export default {
   name: 'Register',
@@ -254,7 +254,7 @@ export default {
 
       this.user.privacy_consent = moment().format()
 
-      const body = _.pick(this.user, [
+      const body = pick(this.user, [
         'username',
         'password',
         'first_name',

--- a/frontend/src/views/core/bodies/AddFeePaymentModal.vue
+++ b/frontend/src/views/core/bodies/AddFeePaymentModal.vue
@@ -73,12 +73,17 @@
 </template>
 
 <script>
+import 'flatpickr/dist/flatpickr.css'
+import flatPickr from 'vue-flatpickr-component'
 import moment from 'moment'
 
 import currencies from '../../../currencies'
 
 export default {
   name: 'AddFeePaymentModal',
+  components: {
+    flatPickr
+  },
   props: ['member', 'body', 'services', 'showSuccess', 'showError'],
   data () {
     return {

--- a/frontend/src/views/core/bodies/ChangeBoardModal.vue
+++ b/frontend/src/views/core/bodies/ChangeBoardModal.vue
@@ -154,10 +154,13 @@
 </template>
 
 <script>
+import 'flatpickr/dist/flatpickr.css'
+import flatPickr from 'vue-flatpickr-component'
 import MarkdownTooltip from '../../../components/tooltips/MarkdownTooltip'
 
 export default {
   components: {
+    flatPickr,
     MarkdownTooltip
   },
   name: 'ChangeBoardModal',

--- a/frontend/src/views/core/bodies/List.vue
+++ b/frontend/src/views/core/bodies/List.vue
@@ -98,9 +98,14 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import 'vue-multiselect/dist/vue-multiselect.min.css'
+import Multiselect from 'vue-multiselect'
 
 export default {
   name: 'BodiesList',
+  components: {
+    Multiselect
+  },
   data () {
     return {
       bodies: [],

--- a/frontend/src/views/core/circles/Edit.vue
+++ b/frontend/src/views/core/circles/Edit.vue
@@ -153,7 +153,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import _ from 'lodash'
+import pick from 'lodash/pick'
 
 export default {
   name: 'EditCircle',
@@ -321,7 +321,7 @@ export default {
       this.isSaving = true
       this.errors = {}
 
-      const body = _.pick(this.circle, [
+      const body = pick(this.circle, [
         'name',
         'description'
       ])

--- a/frontend/src/views/core/members/Edit.vue
+++ b/frontend/src/views/core/members/Edit.vue
@@ -134,7 +134,7 @@
 
 <script>
 import moment from 'moment'
-import _ from 'lodash'
+import pick from 'lodash/pick'
 import { mapGetters } from 'vuex'
 
 export default {
@@ -182,7 +182,7 @@ export default {
       this.isSaving = true
       this.errors = {}
 
-      const body = _.pick(this.user, [
+      const body = pick(this.user, [
         'id',
         'first_name',
         'last_name',

--- a/frontend/src/views/core/members/UpdateProfile.vue
+++ b/frontend/src/views/core/members/UpdateProfile.vue
@@ -133,7 +133,7 @@
 </template>
 
 <script>
-import _ from 'lodash'
+import pick from 'lodash/pick'
 import { mapGetters } from 'vuex'
 import moment from 'moment'
 import { RESTRICTED_EMAILS, ALLOWED_BODY_TYPES } from '../../../validate-user'
@@ -180,7 +180,7 @@ export default {
       this.isSaving = true
       this.errors = {}
 
-      const body = _.pick(this.user, [
+      const body = pick(this.user, [
         'id',
         'first_name',
         'last_name',

--- a/frontend/src/views/events/Edit.vue
+++ b/frontend/src/views/events/Edit.vue
@@ -630,6 +630,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import 'mapbox-gl/dist/mapbox-gl.css'
 import { MglMap, MglMarker, MglNavigationControl } from 'vue-mapbox'
 import moment from 'moment'
 import constants from '../../constants'

--- a/frontend/src/views/events/Edit.vue
+++ b/frontend/src/views/events/Edit.vue
@@ -631,6 +631,9 @@
 <script>
 import { mapGetters } from 'vuex'
 import 'mapbox-gl/dist/mapbox-gl.css'
+import 'flatpickr/dist/flatpickr.css'
+import flatPickr from 'vue-flatpickr-component'
+import InputTag from 'vue-input-tag'
 import { MglMap, MglMarker, MglNavigationControl } from 'vue-mapbox'
 import moment from 'moment'
 import constants from '../../constants'
@@ -640,6 +643,8 @@ import MarkdownTooltip from '../../components/tooltips/MarkdownTooltip'
 
 export default {
   components: {
+    flatPickr,
+    InputTag,
     MglMap,
     MglMarker,
     MglNavigationControl,

--- a/frontend/src/views/events/Single.vue
+++ b/frontend/src/views/events/Single.vue
@@ -326,6 +326,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import 'mapbox-gl/dist/mapbox-gl.css'
 import { MglMap, MglMarker, MglPopup, MglNavigationControl } from 'vue-mapbox'
 import constants from '../../constants'
 import credentials from '../../credentials'

--- a/frontend/src/views/network/BoardListing.vue
+++ b/frontend/src/views/network/BoardListing.vue
@@ -91,10 +91,15 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import 'vue-multiselect/dist/vue-multiselect.min.css'
+import Multiselect from 'vue-multiselect'
 import moment from 'moment'
 
 export default {
   name: 'Boardslist',
+  components: {
+    Multiselect
+  },
   data () {
     return {
       bodies: [],

--- a/frontend/src/views/statutory/Applications.vue
+++ b/frontend/src/views/statutory/Applications.vue
@@ -135,9 +135,14 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import 'vue-multiselect/dist/vue-multiselect.min.css'
+import Multiselect from 'vue-multiselect'
 
 export default {
   name: 'AcceptParticipantsStatutoryList',
+  components: {
+    Multiselect
+  },
   data () {
     return {
       applications: [],

--- a/frontend/src/views/statutory/BoardView.vue
+++ b/frontend/src/views/statutory/BoardView.vue
@@ -204,9 +204,14 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import 'vue-multiselect/dist/vue-multiselect.min.css'
+import Multiselect from 'vue-multiselect'
 
 export default {
   name: 'StatutoryBoardView',
+  components: {
+    Multiselect
+  },
   data () {
     return {
       applications: [],

--- a/frontend/src/views/statutory/Edit.vue
+++ b/frontend/src/views/statutory/Edit.vue
@@ -430,6 +430,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import 'mapbox-gl/dist/mapbox-gl.css'
 import moment from 'moment'
 import { MglMap, MglMarker, MglNavigationControl } from 'vue-mapbox'
 import TimezoneNotification from '../../components/notifications/TimezoneNotification'

--- a/frontend/src/views/statutory/Edit.vue
+++ b/frontend/src/views/statutory/Edit.vue
@@ -431,6 +431,9 @@
 <script>
 import { mapGetters } from 'vuex'
 import 'mapbox-gl/dist/mapbox-gl.css'
+import 'flatpickr/dist/flatpickr.css'
+import flatPickr from 'vue-flatpickr-component'
+import InputTag from 'vue-input-tag'
 import moment from 'moment'
 import { MglMap, MglMarker, MglNavigationControl } from 'vue-mapbox'
 import TimezoneNotification from '../../components/notifications/TimezoneNotification'
@@ -440,6 +443,8 @@ import MarkdownTooltip from '../../components/tooltips/MarkdownTooltip'
 export default {
   name: 'EditStatutory',
   components: {
+    flatPickr,
+    InputTag,
     TimezoneNotification,
     MglMap,
     MglMarker,

--- a/frontend/src/views/statutory/EditCandidate.vue
+++ b/frontend/src/views/statutory/EditCandidate.vue
@@ -252,6 +252,9 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import 'flatpickr/dist/flatpickr.css'
+import flatPickr from 'vue-flatpickr-component'
+import InputTag from 'vue-input-tag'
 import moment from 'moment'
 
 import nationalities from '../../nationalities'
@@ -259,6 +262,8 @@ import MarkdownTooltip from '../../components/tooltips/MarkdownTooltip'
 
 export default {
   components: {
+    flatPickr,
+    InputTag,
     MarkdownTooltip
   },
   name: 'EditCandidate',

--- a/frontend/src/views/statutory/EditPlenaryModal.vue
+++ b/frontend/src/views/statutory/EditPlenaryModal.vue
@@ -46,8 +46,14 @@
 </template>
 
 <script>
+import 'flatpickr/dist/flatpickr.css'
+import flatPickr from 'vue-flatpickr-component'
+
 export default {
   name: 'EditPlenaryModal',
+  components: {
+    flatPickr
+  },
   props: ['event', 'plenary', 'services', 'showSuccess', 'showError', 'router'],
   data () {
     return {

--- a/frontend/src/views/statutory/EditPositionModal.vue
+++ b/frontend/src/views/statutory/EditPositionModal.vue
@@ -102,11 +102,14 @@
 </template>
 
 <script>
+import 'flatpickr/dist/flatpickr.css'
+import flatPickr from 'vue-flatpickr-component'
 import moment from 'moment'
 import MarkdownTooltip from '../../components/tooltips/MarkdownTooltip'
 
 export default {
   components: {
+    flatPickr,
     MarkdownTooltip
   },
   name: 'EditPositionModal',

--- a/frontend/src/views/statutory/Single.vue
+++ b/frontend/src/views/statutory/Single.vue
@@ -442,6 +442,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import 'mapbox-gl/dist/mapbox-gl.css'
 import { MglMap, MglMarker, MglPopup, MglNavigationControl } from 'vue-mapbox'
 import moment from 'moment'
 import credentials from '../../credentials'

--- a/frontend/src/views/summeruniversity/Edit.vue
+++ b/frontend/src/views/summeruniversity/Edit.vue
@@ -766,6 +766,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import 'mapbox-gl/dist/mapbox-gl.css'
 import { MglMap, MglMarker, MglNavigationControl } from 'vue-mapbox'
 import constants from '../../constants'
 import credentials from '../../credentials'

--- a/frontend/src/views/summeruniversity/Edit.vue
+++ b/frontend/src/views/summeruniversity/Edit.vue
@@ -767,6 +767,8 @@
 <script>
 import { mapGetters } from 'vuex'
 import 'mapbox-gl/dist/mapbox-gl.css'
+import 'flatpickr/dist/flatpickr.css'
+import flatPickr from 'vue-flatpickr-component'
 import { MglMap, MglMarker, MglNavigationControl } from 'vue-mapbox'
 import constants from '../../constants'
 import credentials from '../../credentials'
@@ -777,6 +779,7 @@ import URLTooltip from '../../components/tooltips/URLTooltip'
 // TODO: check that all unused code is removed
 export default {
   components: {
+    flatPickr,
     MglMap,
     MglMarker,
     MglNavigationControl,

--- a/frontend/src/views/summeruniversity/EditSecond.vue
+++ b/frontend/src/views/summeruniversity/EditSecond.vue
@@ -462,6 +462,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import 'mapbox-gl/dist/mapbox-gl.css'
 import { MglMap, MglMarker, MglNavigationControl } from 'vue-mapbox'
 import constants from '../../constants'
 import credentials from '../../credentials'

--- a/frontend/src/views/summeruniversity/Single.vue
+++ b/frontend/src/views/summeruniversity/Single.vue
@@ -483,6 +483,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import 'mapbox-gl/dist/mapbox-gl.css'
 import { MglMap, MglMarker, MglPopup, MglNavigationControl } from 'vue-mapbox'
 import constants from '../../constants'
 import credentials from '../../credentials'

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -16,31 +16,6 @@ module.exports = {
         'vuex-store': path.resolve(__dirname, 'src/store'),
       },
     },
-    // https://stackoverflow.com/a/55372086/1206421
-    optimization: {
-      splitChunks: {
-        cacheGroups: {
-          app: {
-            chunks: 'all',
-            name: 'all',
-            test: /[\\/]src[\\/](.*)[\\/]/,
-          },
-          vendor: {
-            chunks: 'all',
-            name: 'vendor',
-            test: /[\\/]node_modules[\\/](.*)[\\/]/,
-          },
-          styles: {
-            name: 'styles',
-            test: /\.s?css$/,
-            chunks: 'all',
-            minChunks: 1,
-            reuseExistingChunk: true,
-            enforce: true,
-          },
-        },
-      },
-    },
     // so it'd work with Webpack 4, which doesn't like [contenthash], which is there by default
     output: {
       filename: '[name].[hash].js',
@@ -65,7 +40,7 @@ if (process.env.NODE_ENV === 'production') {
 
     module.exports.configureWebpack.plugins.push(
       new CompressionPlugin({
-        filename: '[path].br[query]',
+        filename: '[path][base].br[query]',
         algorithm: 'brotliCompress',
         compressionOptions: { level: 11 }, // matches BROTLI_MAX_QUALITY
         minRatio: 0.99,

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 
 module.exports = {
   lintOnSave: true,
@@ -28,6 +29,7 @@ if (process.env.NODE_ENV === 'production') {
   const CompressionPlugin = require('compression-webpack-plugin');
 
   module.exports.configureWebpack.plugins = [
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     new CompressionPlugin({
       algorithm: require('@gfx/zopfli').gzip,
       compressionOptions: {


### PR DESCRIPTION
## Summary
- remove the custom webpack splitChunks override so Vue CLI can keep route-level async chunks instead of flattening the app and vendor code into large initial bundles
- fix Brotli asset naming to preserve the original filename and stop `.br` output collisions during production builds
- trim the shared frontend bundle by ignoring Moment locales in production, replacing full Lodash imports with `lodash/pick`, and removing the global Animate.css dependency
- move Mapbox CSS off the main entrypoint so it only loads on routes that actually render maps
- deduplicate global frontend style imports and keep `AppMain` limited to the Bulma mixins it actually needs

## Verification
- run `npm run build` in `frontend`
- because the checked-in `frontend/dist` directory is root-owned in this workspace, run `npx vue-cli-service build --dest dist-opencode` for verification when `dist` is not writable
- confirm the previous Brotli filename conflict warnings no longer appear
- confirm the build emits many async chunks instead of a single `all.*.js` and `vendor.*.js`
- confirm the shared bundle sizes dropped further:
  - `chunk-vendors.js`: `1.25 MiB` -> `1.01 MiB`
  - `css/chunk-vendors.css`: `513 KiB` -> `423 KiB`
  - entrypoint `app`: `2.03 MiB` -> `1.7 MiB`

## Notes
- the remaining size warnings are isolated to the shared vendor chunk and a couple of large async chunks, mainly the Mapbox-heavy routes and the calendar/ICS route chunk
- there is an unrelated untracked `opencode.json` file in the working tree that is not part of this PR