### PR TITLE
fix(core): preserve pending join requests for deleted bodies

### DIFF
--- a/core/middlewares/bodies.js
+++ b/core/middlewares/bodies.js
@@ -97,7 +97,13 @@ exports.setBodyStatus = async (req, res) => {
         }
 
         // Deleting all the stuff related to body.
-        await JoinRequest.destroy({ where: { body_id: req.currentBody.id }, transaction: t });
+        await JoinRequest.destroy({
+            where: {
+                body_id: req.currentBody.id,
+                status: 'approved'
+            },
+            transaction: t
+        });
         await BodyMembership.destroy({ where: { body_id: req.currentBody.id }, transaction: t });
         await Circle.destroy({ where: { body_id: req.currentBody.id }, transaction: t });
         await Payment.destroy({ where: { body_id: req.currentBody.id }, transaction: t });

--- a/core/test/api/bodies-status.test.js
+++ b/core/test/api/bodies-status.test.js
@@ -120,8 +120,9 @@ describe('Bodies status', () => {
         expect(res.body.data.status).toEqual('active');
     });
 
-    test('should remove all stuff from body once deleted', async () => {
+    test('should preserve pending join requests when body is deleted', async () => {
         const user = await generator.createUser({ superadmin: true });
+        const otherUser = await generator.createUser();
         const token = await generator.createAccessToken(user);
 
         await generator.createPermission({ scope: 'global', action: 'delete', object: 'body' });
@@ -129,7 +130,12 @@ describe('Bodies status', () => {
         const body = await generator.createBody();
         const circle = await generator.createCircle({ body_id: body.id });
 
-        await generator.createJoinRequest(body, user);
+        const pendingJoinRequest = await generator.createJoinRequest(body, user);
+        const approvedJoinRequest = await JoinRequest.create({
+            body_id: body.id,
+            user_id: otherUser.id,
+            status: 'approved'
+        });
         await generator.createCircleMembership(circle, user);
         await generator.createBodyMembership(body, user);
         await generator.createPayment(body, user);
@@ -149,7 +155,8 @@ describe('Bodies status', () => {
 
         expect(await Circle.count({ where: { body_id: body.id } })).toEqual(0);
         expect(await BodyMembership.count({ where: { body_id: body.id } })).toEqual(0);
-        expect(await JoinRequest.count({ where: { body_id: body.id } })).toEqual(0);
+        expect(await JoinRequest.findByPk(pendingJoinRequest.id)).not.toEqual(null);
+        expect(await JoinRequest.findByPk(approvedJoinRequest.id)).toEqual(null);
         expect(await Payment.count({ where: { body_id: body.id } })).toEqual(0);
     });
 });


### PR DESCRIPTION
## Summary
- preserve pending join requests when a body is marked as deleted in core
- continue cleaning up approved join requests, memberships, circles, and payments during body deletion
- update the body status API test to cover the preserved pending request behavior

## Testing
- `NODE_ENV=test DB_HOST=127.0.0.1 DB_PORT=55433 DB_DATABASE=core-testing USERNAME=postgres PG_PASSWORD=5ecr3t npx sequelize db:drop && NODE_ENV=test DB_HOST=127.0.0.1 DB_PORT=55433 DB_DATABASE=core-testing USERNAME=postgres PG_PASSWORD=5ecr3t npx sequelize db:create && NODE_ENV=test DB_HOST=127.0.0.1 DB_PORT=55433 DB_DATABASE=core-testing USERNAME=postgres PG_PASSWORD=5ecr3t npx sequelize db:migrate && NODE_ENV=test DB_HOST=127.0.0.1 DB_PORT=55433 DB_DATABASE=core-testing USERNAME=postgres PG_PASSWORD=5ecr3t npx jest test/api/bodies-status.test.js --runInBand --forceExit`
- `npx eslint core/middlewares/bodies.js core/test/api/bodies-status.test.js`