### PR TITLE
feat: add application bans

### DIFF
--- a/core/lib/server.js
+++ b/core/lib/server.js
@@ -96,6 +96,8 @@ GeneralRouter.post('/campaigns', middlewares.ensureAuthorized, campaigns.createC
 MemberRouter.use(middlewares.maybeAuthorize, middlewares.ensureAuthorized, fetch.fetchUser);
 MemberRouter.get('/my_permissions', myPermissions.getMyPermissions);
 MemberRouter.put('/active', members.setUserActive);
+MemberRouter.put('/event-application-ban', members.setEventApplicationBan);
+MemberRouter.delete('/event-application-ban', members.liftEventApplicationBan);
 MemberRouter.put('/superadmin', members.setUserSuperadmin);
 MemberRouter.post('/confirm', members.confirmUser);
 MemberRouter.put('/primary-body', members.setPrimaryBody);

--- a/core/middlewares/members.js
+++ b/core/middlewares/members.js
@@ -2,13 +2,29 @@ const moment = require('moment');
 const _ = require('lodash');
 const { request } = require('../lib/http');
 
-const { User, Body, BodyMembership, MailChange, MailConfirmation } = require('../models');
+const { User, Body, BodyMembership, MailChange, MailConfirmation, EventApplicationBan } = require('../models');
 const config = require('../config');
 const constants = require('../lib/constants');
 const helpers = require('../lib/helpers');
 const errors = require('../lib/errors');
 const mailer = require('../lib/mailer');
 const { sequelize, Sequelize } = require('../lib/sequelize');
+
+const MAX_EVENT_APPLICATION_BAN_MONTHS = 3;
+
+function canViewEventApplicationBan(req, user) {
+    return req.user.id === user.id || req.permissions.hasPermission('global:update_application_ban:member');
+}
+
+async function addActiveEventApplicationBan(req, user) {
+    if (!canViewEventApplicationBan(req, user)) {
+        delete user.dataValues.event_application_ban;
+        return user;
+    }
+
+    user.dataValues.event_application_ban = await EventApplicationBan.findActiveForUser(user.id);
+    return user;
+}
 
 exports.listAllUsers = async (req, res) => {
     if (!req.permissions.hasPermission('global:view:member')) {
@@ -104,6 +120,8 @@ exports.getUser = async (req, res) => {
         return errors.makeForbiddenError(res, 'Permission view:member is required, but not present.');
     }
 
+    await addActiveEventApplicationBan(req, req.currentUser);
+
     return res.json({
         success: true,
         data: req.currentUser
@@ -191,6 +209,72 @@ exports.setUserActive = async (req, res) => {
     return res.json({
         success: true,
         data: req.currentUser
+    });
+};
+
+exports.setEventApplicationBan = async (req, res) => {
+    if (!req.permissions.hasPermission('global:update_application_ban:member')) {
+        return errors.makeForbiddenError(res, 'Permission global:update_application_ban:member is required, but not present.');
+    }
+
+    const banUntil = moment(req.body.ban_until);
+    if (!banUntil.isValid()) {
+        return errors.makeValidationError(res, { ban_until: ['Ban end date should be valid.'] });
+    }
+
+    if (banUntil.isSameOrBefore(moment())) {
+        return errors.makeValidationError(res, { ban_until: ['Ban end date should be in the future.'] });
+    }
+
+    if (banUntil.isAfter(moment().add(MAX_EVENT_APPLICATION_BAN_MONTHS, 'months'))) {
+        return errors.makeValidationError(res, { ban_until: ['Ban end date cannot be more than 3 months in the future.'] });
+    }
+
+    await sequelize.transaction(async (t) => {
+        await EventApplicationBan.update({
+            lifted_at: new Date(),
+            lifted_by_user_id: req.user.id
+        }, {
+            where: {
+                user_id: req.currentUser.id,
+                lifted_at: null
+            },
+            transaction: t
+        });
+
+        await EventApplicationBan.create({
+            user_id: req.currentUser.id,
+            banned_by_user_id: req.user.id,
+            ban_until: banUntil.toDate()
+        }, { transaction: t });
+    });
+
+    await addActiveEventApplicationBan(req, req.currentUser);
+
+    return res.json({
+        success: true,
+        data: req.currentUser.dataValues.event_application_ban
+    });
+};
+
+exports.liftEventApplicationBan = async (req, res) => {
+    if (!req.permissions.hasPermission('global:update_application_ban:member')) {
+        return errors.makeForbiddenError(res, 'Permission global:update_application_ban:member is required, but not present.');
+    }
+
+    const activeBan = await EventApplicationBan.findActiveForUser(req.currentUser.id);
+    if (!activeBan) {
+        return errors.makeNotFoundError(res, 'This user does not have an active event application ban.');
+    }
+
+    await activeBan.update({
+        lifted_at: new Date(),
+        lifted_by_user_id: req.user.id
+    });
+
+    return res.json({
+        success: true,
+        message: 'Event application ban was lifted.'
     });
 };
 

--- a/core/migrations/20260426120000-create-event-application-bans.js
+++ b/core/migrations/20260426120000-create-event-application-bans.js
@@ -1,0 +1,54 @@
+module.exports = {
+    up: (queryInterface, Sequelize) => queryInterface.createTable('event_application_bans', {
+        id: {
+            allowNull: false,
+            autoIncrement: true,
+            primaryKey: true,
+            type: Sequelize.INTEGER
+        },
+        user_id: {
+            allowNull: false,
+            type: Sequelize.INTEGER,
+            references: {
+                model: 'users',
+                key: 'id'
+            },
+            onDelete: 'CASCADE'
+        },
+        banned_by_user_id: {
+            allowNull: false,
+            type: Sequelize.INTEGER,
+            references: {
+                model: 'users',
+                key: 'id'
+            },
+            onDelete: 'RESTRICT'
+        },
+        ban_until: {
+            allowNull: false,
+            type: Sequelize.DATE
+        },
+        lifted_by_user_id: {
+            allowNull: true,
+            type: Sequelize.INTEGER,
+            references: {
+                model: 'users',
+                key: 'id'
+            },
+            onDelete: 'SET NULL'
+        },
+        lifted_at: {
+            allowNull: true,
+            type: Sequelize.DATE
+        },
+        created_at: {
+            allowNull: false,
+            type: Sequelize.DATE
+        },
+        updated_at: {
+            allowNull: false,
+            type: Sequelize.DATE
+        }
+    }),
+    down: (queryInterface) => queryInterface.dropTable('event_application_bans')
+};

--- a/core/migrations/20260426120000-create-event-application-bans.js
+++ b/core/migrations/20260426120000-create-event-application-bans.js
@@ -1,54 +1,62 @@
 module.exports = {
-    up: (queryInterface, Sequelize) => queryInterface.createTable('event_application_bans', {
-        id: {
-            allowNull: false,
-            autoIncrement: true,
-            primaryKey: true,
-            type: Sequelize.INTEGER
-        },
-        user_id: {
-            allowNull: false,
-            type: Sequelize.INTEGER,
-            references: {
-                model: 'users',
-                key: 'id'
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.createTable('event_application_bans', {
+            id: {
+                allowNull: false,
+                autoIncrement: true,
+                primaryKey: true,
+                type: Sequelize.INTEGER
             },
-            onDelete: 'CASCADE'
-        },
-        banned_by_user_id: {
-            allowNull: false,
-            type: Sequelize.INTEGER,
-            references: {
-                model: 'users',
-                key: 'id'
+            user_id: {
+                allowNull: false,
+                type: Sequelize.INTEGER,
+                references: {
+                    model: 'users',
+                    key: 'id'
+                },
+                onDelete: 'CASCADE'
             },
-            onDelete: 'RESTRICT'
-        },
-        ban_until: {
-            allowNull: false,
-            type: Sequelize.DATE
-        },
-        lifted_by_user_id: {
-            allowNull: true,
-            type: Sequelize.INTEGER,
-            references: {
-                model: 'users',
-                key: 'id'
+            banned_by_user_id: {
+                allowNull: false,
+                type: Sequelize.INTEGER,
+                references: {
+                    model: 'users',
+                    key: 'id'
+                },
+                onDelete: 'RESTRICT'
             },
-            onDelete: 'SET NULL'
-        },
-        lifted_at: {
-            allowNull: true,
-            type: Sequelize.DATE
-        },
-        created_at: {
-            allowNull: false,
-            type: Sequelize.DATE
-        },
-        updated_at: {
-            allowNull: false,
-            type: Sequelize.DATE
-        }
-    }),
+            ban_until: {
+                allowNull: false,
+                type: Sequelize.DATE
+            },
+            lifted_by_user_id: {
+                allowNull: true,
+                type: Sequelize.INTEGER,
+                references: {
+                    model: 'users',
+                    key: 'id'
+                },
+                onDelete: 'SET NULL'
+            },
+            lifted_at: {
+                allowNull: true,
+                type: Sequelize.DATE
+            },
+            created_at: {
+                allowNull: false,
+                type: Sequelize.DATE
+            },
+            updated_at: {
+                allowNull: false,
+                type: Sequelize.DATE
+            }
+        });
+
+        await queryInterface.addIndex('event_application_bans', ['user_id'], {
+            name: 'event_application_bans_one_open_ban_per_user',
+            unique: true,
+            where: { lifted_at: null }
+        });
+    },
     down: (queryInterface) => queryInterface.dropTable('event_application_bans')
 };

--- a/core/models/EventApplicationBan.js
+++ b/core/models/EventApplicationBan.js
@@ -1,0 +1,65 @@
+const moment = require('moment');
+
+const { Sequelize, sequelize } = require('../lib/sequelize');
+
+const EventApplicationBan = sequelize.define('event_application_ban', {
+    user_id: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        validate: {
+            notEmpty: { msg: 'User should be set.' },
+            isInt: { msg: 'User ID should be a number.' }
+        }
+    },
+    banned_by_user_id: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+        validate: {
+            notEmpty: { msg: 'Banning user should be set.' },
+            isInt: { msg: 'Banning user ID should be a number.' }
+        }
+    },
+    ban_until: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        validate: {
+            notEmpty: { msg: 'Ban end date should be set.' },
+            isDate: { msg: 'Ban end date should be valid.' },
+            isFuture(value) {
+                if (moment(value).isSameOrBefore(moment())) {
+                    throw new Error('Ban end date should be in the future.');
+                }
+            }
+        }
+    },
+    lifted_by_user_id: {
+        allowNull: true,
+        type: Sequelize.INTEGER,
+        validate: {
+            isInt: { msg: 'Lifting user ID should be a number.' }
+        }
+    },
+    lifted_at: {
+        allowNull: true,
+        type: Sequelize.DATE,
+        validate: {
+            isDate: { msg: 'Lift date should be valid.' }
+        }
+    }
+}, {
+    underscored: true,
+    tableName: 'event_application_bans',
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
+});
+
+EventApplicationBan.findActiveForUser = (userId) => EventApplicationBan.findOne({
+    where: {
+        user_id: userId,
+        lifted_at: null,
+        ban_until: { [Sequelize.Op.gt]: new Date() }
+    },
+    order: [['created_at', 'DESC']]
+});
+
+module.exports = EventApplicationBan;

--- a/core/models/index.js
+++ b/core/models/index.js
@@ -13,6 +13,7 @@ const CircleMembership = require('./CircleMembership');
 const BodyMembership = require('./BodyMembership');
 const JoinRequest = require('./JoinRequest');
 const Payment = require('./Payment');
+const EventApplicationBan = require('./EventApplicationBan');
 
 Campaign.hasMany(User, { foreignKey: 'campaign_id' });
 User.belongsTo(Campaign, { foreignKey: 'campaign_id' });
@@ -86,6 +87,11 @@ User.hasMany(Payment, { foreignKey: 'user_id' });
 Payment.belongsTo(Body, { foreignKey: 'body_id' });
 Body.hasMany(Payment, { foreignKey: 'body_id' });
 
+User.hasMany(EventApplicationBan, { foreignKey: 'user_id', as: 'event_application_bans' });
+EventApplicationBan.belongsTo(User, { foreignKey: 'user_id', as: 'user' });
+EventApplicationBan.belongsTo(User, { foreignKey: 'banned_by_user_id', as: 'banned_by' });
+EventApplicationBan.belongsTo(User, { foreignKey: 'lifted_by_user_id', as: 'lifted_by' });
+
 module.exports = {
     User,
     Campaign,
@@ -102,4 +108,5 @@ module.exports = {
     BodyMembership,
     JoinRequest,
     Payment,
+    EventApplicationBan,
 };

--- a/core/scripts/seed.js
+++ b/core/scripts/seed.js
@@ -558,6 +558,12 @@ async function createPermissions() {
             description: 'See all memberslists for EPM>'
         },
         {
+            action: 'update_application_ban',
+            object: 'member',
+            scope: 'global',
+            description: 'Set or lift temporary bans from applying to events.'
+        },
+        {
             action: 'use_massmailer',
             object: 'epm',
             scope: 'global',

--- a/core/test/api/users-event-application-ban.test.js
+++ b/core/test/api/users-event-application-ban.test.js
@@ -1,0 +1,146 @@
+const moment = require('moment');
+
+const { startServer, stopServer } = require('../../lib/server');
+const { request } = require('../scripts/helpers');
+const generator = require('../scripts/generator');
+
+describe('User event application ban', () => {
+    beforeAll(async () => {
+        await startServer();
+    });
+
+    afterAll(async () => {
+        await stopServer();
+    });
+
+    afterEach(async () => {
+        await generator.clearAll();
+    });
+
+    test('should require permission to set a ban', async () => {
+        const user = await generator.createUser();
+        const target = await generator.createUser();
+        const token = await generator.createAccessToken(user);
+
+        const res = await request({
+            uri: '/members/' + target.id + '/event-application-ban',
+            method: 'PUT',
+            headers: { 'X-Auth-Token': token.value },
+            body: { ban_until: moment().add(1, 'month').toISOString() }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+    });
+
+    test('should set and return active ban', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const target = await generator.createUser();
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'update_application_ban', object: 'member' });
+        await generator.createPermission({ scope: 'global', action: 'view', object: 'member' });
+
+        const res = await request({
+            uri: '/members/' + target.id + '/event-application-ban',
+            method: 'PUT',
+            headers: { 'X-Auth-Token': token.value },
+            body: { ban_until: moment().add(1, 'month').toISOString() }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body.data.user_id).toEqual(target.id);
+
+        const userRes = await request({
+            uri: '/members/' + target.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(userRes.statusCode).toEqual(200);
+        expect(userRes.body.data.event_application_ban.user_id).toEqual(target.id);
+    });
+
+    test('should show active ban to the banned user', async () => {
+        const user = await generator.createUser();
+        const banner = await generator.createUser();
+        const token = await generator.createAccessToken(user);
+
+        await generator.createEventApplicationBan(user, banner, { ban_until: moment().add(1, 'month').toDate() });
+
+        const res = await request({
+            uri: '/members/me',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.data.event_application_ban.user_id).toEqual(user.id);
+    });
+
+    test('should hide active ban from users without ban management permission', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const target = await generator.createUser();
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'view', object: 'member' });
+        await generator.createEventApplicationBan(target, user, { ban_until: moment().add(1, 'month').toDate() });
+
+        const res = await request({
+            uri: '/members/' + target.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.data).not.toHaveProperty('event_application_ban');
+    });
+
+    test('should reject bans longer than 3 months', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const target = await generator.createUser();
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'update_application_ban', object: 'member' });
+
+        const res = await request({
+            uri: '/members/' + target.id + '/event-application-ban',
+            method: 'PUT',
+            headers: { 'X-Auth-Token': token.value },
+            body: { ban_until: moment().add(3, 'months').add(1, 'day').toISOString() }
+        });
+
+        expect(res.statusCode).toEqual(422);
+        expect(res.body.success).toEqual(false);
+        expect(res.body.errors).toHaveProperty('ban_until');
+    });
+
+    test('should lift active ban', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const target = await generator.createUser();
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'update_application_ban', object: 'member' });
+        await generator.createPermission({ scope: 'global', action: 'view', object: 'member' });
+        await generator.createEventApplicationBan(target, user, { ban_until: moment().add(1, 'month').toDate() });
+
+        const res = await request({
+            uri: '/members/' + target.id + '/event-application-ban',
+            method: 'DELETE',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+
+        const userRes = await request({
+            uri: '/members/' + target.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(userRes.statusCode).toEqual(200);
+        expect(userRes.body.data.event_application_ban).toBeNull();
+    });
+});

--- a/core/test/api/users-event-application-ban.test.js
+++ b/core/test/api/users-event-application-ban.test.js
@@ -3,6 +3,7 @@ const moment = require('moment');
 const { startServer, stopServer } = require('../../lib/server');
 const { request } = require('../scripts/helpers');
 const generator = require('../scripts/generator');
+const { EventApplicationBan } = require('../../models');
 
 describe('User event application ban', () => {
     beforeAll(async () => {
@@ -23,7 +24,7 @@ describe('User event application ban', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + target.id + '/event-application-ban',
+            path: '/members/' + target.id + '/event-application-ban',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { ban_until: moment().add(1, 'month').toISOString() }
@@ -42,7 +43,7 @@ describe('User event application ban', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + target.id + '/event-application-ban',
+            path: '/members/' + target.id + '/event-application-ban',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { ban_until: moment().add(1, 'month').toISOString() }
@@ -53,7 +54,7 @@ describe('User event application ban', () => {
         expect(res.body.data.user_id).toEqual(target.id);
 
         const userRes = await request({
-            uri: '/members/' + target.id,
+            path: '/members/' + target.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -70,7 +71,7 @@ describe('User event application ban', () => {
         await generator.createEventApplicationBan(user, banner, { ban_until: moment().add(1, 'month').toDate() });
 
         const res = await request({
-            uri: '/members/me',
+            path: '/members/me',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -88,7 +89,7 @@ describe('User event application ban', () => {
         await generator.createEventApplicationBan(target, user, { ban_until: moment().add(1, 'month').toDate() });
 
         const res = await request({
-            uri: '/members/' + target.id,
+            path: '/members/' + target.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -105,7 +106,7 @@ describe('User event application ban', () => {
         await generator.createPermission({ scope: 'global', action: 'update_application_ban', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + target.id + '/event-application-ban',
+            path: '/members/' + target.id + '/event-application-ban',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { ban_until: moment().add(3, 'months').add(1, 'day').toISOString() }
@@ -114,6 +115,41 @@ describe('User event application ban', () => {
         expect(res.statusCode).toEqual(422);
         expect(res.body.success).toEqual(false);
         expect(res.body.errors).toHaveProperty('ban_until');
+    });
+
+    test('should replace an existing active ban when setting a new ban', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const target = await generator.createUser();
+        const token = await generator.createAccessToken(user);
+        const firstBan = await generator.createEventApplicationBan(target, user, {
+            ban_until: moment().add(1, 'month').toDate()
+        });
+
+        await generator.createPermission({ scope: 'global', action: 'update_application_ban', object: 'member' });
+
+        const res = await request({
+            path: '/members/' + target.id + '/event-application-ban',
+            method: 'PUT',
+            headers: { 'X-Auth-Token': token.value },
+            body: { ban_until: moment().add(2, 'months').toISOString() }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body.data.id).not.toEqual(firstBan.id);
+
+        await firstBan.reload();
+        expect(firstBan.lifted_at).not.toBeNull();
+        expect(firstBan.lifted_by_user_id).toEqual(user.id);
+
+        const activeBans = await EventApplicationBan.findAll({
+            where: {
+                user_id: target.id,
+                lifted_at: null
+            }
+        });
+        expect(activeBans).toHaveLength(1);
+        expect(activeBans[0].id).toEqual(res.body.data.id);
     });
 
     test('should lift active ban', async () => {
@@ -126,7 +162,7 @@ describe('User event application ban', () => {
         await generator.createEventApplicationBan(target, user, { ban_until: moment().add(1, 'month').toDate() });
 
         const res = await request({
-            uri: '/members/' + target.id + '/event-application-ban',
+            path: '/members/' + target.id + '/event-application-ban',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -135,7 +171,7 @@ describe('User event application ban', () => {
         expect(res.body.success).toEqual(true);
 
         const userRes = await request({
-            uri: '/members/' + target.id,
+            path: '/members/' + target.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/scripts/generator.js
+++ b/core/test/scripts/generator.js
@@ -15,7 +15,8 @@ const {
     CircleMembership,
     BodyMembership,
     JoinRequest,
-    Payment
+    Payment,
+    EventApplicationBan
 } = require('../../models');
 
 const notSet = (field) => typeof field === 'undefined';
@@ -175,6 +176,14 @@ exports.createPayment = (body, user, options = {}) => {
     return Payment.create(exports.generatePayment(body, user, options));
 };
 
+exports.createEventApplicationBan = (user, bannedBy, options = {}) => {
+    if (notSet(options.user_id)) options.user_id = user.id;
+    if (notSet(options.banned_by_user_id)) options.banned_by_user_id = bannedBy.id;
+    if (notSet(options.ban_until)) options.ban_until = faker.date.future();
+
+    return EventApplicationBan.create(options);
+};
+
 exports.generatePayment = (body, user, options = {}) => {
     if (body && body.id) options.body_id = body.id;
     if (user && user.id) options.user_id = user.id;
@@ -202,6 +211,7 @@ exports.createMailChange = (user = null, options = {}) => {
 
 exports.clearAll = async () => {
     await MailChange.destroy({ where: {}, truncate: { cascade: true } });
+    await EventApplicationBan.destroy({ where: {}, truncate: { cascade: true } });
     await Payment.destroy({ where: {}, truncate: { cascade: true } });
     await JoinRequest.destroy({ where: {}, truncate: { cascade: true } });
     await BodyMembership.destroy({ where: {}, truncate: { cascade: true } });

--- a/events/lib/applications.js
+++ b/events/lib/applications.js
@@ -2,10 +2,53 @@ const xlsx = require('node-xlsx');
 
 const core = require('./core');
 const errors = require('./errors');
-const { Application } = require('../models');
+const { Application, Event } = require('../models');
 const helpers = require('./helpers');
 const mailer = require('./mailer');
-const { sequelize } = require('./sequelize');
+const { sequelize, Sequelize } = require('./sequelize');
+
+function isApplicationBanActive(user) {
+    return user.event_application_ban && new Date(user.event_application_ban.ban_until) > new Date();
+}
+
+exports.listFutureApplicationsForUser = async (req, res) => {
+    if (!Object.values(req.permissions.manage_event).some(Boolean)) {
+        return errors.makeForbiddenError(res, 'You are not allowed to see future applications.');
+    }
+
+    if (!helpers.isNumber(req.params.user_id)) {
+        return errors.makeBadRequestError(res, 'User ID should be a number.');
+    }
+
+    const applications = await Application.findAll({
+        where: {
+            user_id: Number(req.params.user_id),
+            status: { [Sequelize.Op.in]: ['pending', 'accepted'] }
+        },
+        include: [{
+            model: Event,
+            required: true,
+            where: {
+                starts: { [Sequelize.Op.gt]: new Date() },
+                deleted: false
+            }
+        }],
+        order: [[Event, 'starts', 'ASC']]
+    });
+
+    return res.json({
+        success: true,
+        data: applications.map((application) => ({
+            service: 'events',
+            application_id: application.id,
+            application_status: application.status,
+            event_id: application.event.id,
+            event_name: application.event.name,
+            event_type: application.event.type,
+            event_starts: application.event.starts
+        }))
+    });
+};
 
 exports.listAllApplications = async (req, res) => {
     if (!req.permissions.list_applications) {
@@ -38,6 +81,10 @@ exports.createApplication = async (req, res) => {
     // Check for permission
     if (!req.permissions.apply || !req.event.has_applications) {
         return errors.makeForbiddenError(res, 'You cannot apply to this event.');
+    }
+
+    if (isApplicationBanActive(req.user)) {
+        return errors.makeForbiddenError(res, 'You are temporarily banned from applying to events.');
     }
 
     if (typeof req.body.body_id !== 'undefined' && !helpers.isMemberOf(req.user, req.body.body_id)) {

--- a/events/lib/applications.js
+++ b/events/lib/applications.js
@@ -11,8 +11,13 @@ function isApplicationBanActive(user) {
     return user.event_application_ban && new Date(user.event_application_ban.ban_until) > new Date();
 }
 
+function canListFutureApplicationsForBan(corePermissions) {
+    return Array.isArray(corePermissions)
+        && corePermissions.some((permission) => permission.combined === 'global:update_application_ban:member');
+}
+
 exports.listFutureApplicationsForUser = async (req, res) => {
-    if (!Object.values(req.permissions.manage_event).some(Boolean)) {
+    if (!canListFutureApplicationsForBan(req.corePermissions) && !Object.values(req.permissions.manage_event).some(Boolean)) {
         return errors.makeForbiddenError(res, 'You are not allowed to see future applications.');
     }
 

--- a/events/lib/server.js
+++ b/events/lib/server.js
@@ -51,6 +51,7 @@ GeneralRouter.get('/mine/organizing', middlewares.ensureAuthorized, events.listU
 GeneralRouter.get('/mine/participating', middlewares.ensureAuthorized, events.listUserAppliedEvents);
 GeneralRouter.get('/mine/approvable', middlewares.ensureAuthorized, events.listApprovableEvents);
 GeneralRouter.get('/boardview/:body_id', middlewares.ensureAuthorized, events.listBodyApplications);
+GeneralRouter.get('/applications/future/:user_id', middlewares.ensureAuthorized, applications.listFutureApplicationsForUser);
 
 GeneralRouter.get('/recents', middlewares.ensureAuthorized, events.listMostRecentEuropeanEvents);
 

--- a/events/test/api/applications-creating.test.js
+++ b/events/test/api/applications-creating.test.js
@@ -19,6 +19,33 @@ describe('Events application creating', () => {
         await generator.clearAll();
     });
 
+    it('should disallow application when user has an active event application ban', async () => {
+        mock.mockAll({ core: { eventApplicationBanned: true } });
+
+        const event = await generator.createEvent({
+            application_starts: moment().subtract(1, 'weeks').toDate(),
+            application_ends: moment().add(1, 'week').toDate(),
+            status: 'published',
+            applications: [],
+            questions: []
+        });
+
+        const res = await request({
+            uri: '/single/' + event.id + '/applications',
+            headers: { 'X-Auth-Token': 'foobar' },
+            method: 'POST',
+            body: {
+                body_id: user.bodies[0].id,
+                answers: [],
+                agreed_to_privacy_policy: true
+            }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).toHaveProperty('message');
+    });
+
     it('should disallow application for events with closed deadline', async () => {
         const event = await generator.createEvent({
             application_starts: moment().subtract(2, 'weeks').toDate(),

--- a/events/test/api/applications-creating.test.js
+++ b/events/test/api/applications-creating.test.js
@@ -31,7 +31,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {

--- a/events/test/api/applications-future.test.js
+++ b/events/test/api/applications-future.test.js
@@ -1,0 +1,64 @@
+const moment = require('moment');
+
+const { startServer, stopServer } = require('../../lib/server');
+const { request } = require('../scripts/helpers');
+const mock = require('../scripts/mock-core-registry');
+const generator = require('../scripts/generator');
+const user = require('../assets/oms-core-valid.json').data;
+
+describe('Events future applications', () => {
+    beforeEach(async () => {
+        await startServer();
+    });
+
+    afterEach(async () => {
+        await stopServer();
+        mock.cleanAll();
+        await generator.clearAll();
+    });
+
+    it('should allow application ban managers to list future applications without event management permissions', async () => {
+        mock.mockAll({ mainPermissions: { applicationBanPermission: true }, approvePermissions: { noPermissions: true } });
+
+        const event = await generator.createEvent({
+            name: 'Future event',
+            application_starts: moment().subtract(1, 'week').toDate(),
+            application_ends: moment().add(1, 'week').toDate(),
+            starts: moment().add(1, 'month').toDate(),
+            ends: moment().add(1, 'month').add(1, 'day').toDate(),
+            status: 'published',
+            deleted: false
+        });
+        await generator.createApplication(event, {
+            user_id: user.id,
+            status: 'pending'
+        });
+
+        const res = await request({
+            path: '/applications/future/' + user.id,
+            headers: { 'X-Auth-Token': 'foobar' }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body.data).toHaveLength(1);
+        expect(res.body.data[0]).toMatchObject({
+            service: 'events',
+            event_id: event.id,
+            event_name: 'Future event',
+            application_status: 'pending'
+        });
+    });
+
+    it('should reject users without application ban or event management permissions', async () => {
+        mock.mockAll({ mainPermissions: { noPermissions: true }, approvePermissions: { noPermissions: true } });
+
+        const res = await request({
+            path: '/applications/future/' + user.id,
+            headers: { 'X-Auth-Token': 'foobar' }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+    });
+});

--- a/events/test/scripts/mock-core-registry.js
+++ b/events/test/scripts/mock-core-registry.js
@@ -43,6 +43,21 @@ exports.mockCore = (options) => {
             .replyWithFile(200, path.join(__dirname, '..', 'assets', 'oms-core-valid-not-superadmin.json'));
     }
 
+    if (options.eventApplicationBanned) {
+        return nock(config.core.url + ':' + config.core.port)
+            .persist()
+            .get('/members/me')
+            .reply(200, {
+                success: true,
+                data: {
+                    ...regularUser,
+                    event_application_ban: {
+                        ban_until: new Date(Date.now() + 10 * 365 * 24 * 60 * 60 * 1000)
+                    }
+                }
+            });
+    }
+
     return nock(config.core.url + ':' + config.core.port)
         .persist()
         .get('/members/me')

--- a/events/test/scripts/mock-core-registry.js
+++ b/events/test/scripts/mock-core-registry.js
@@ -100,6 +100,16 @@ exports.mockCoreMainPermissions = (options) => {
             .replyWithFile(200, path.join(__dirname, '..', 'assets', 'oms-core-empty.json'));
     }
 
+    if (options.applicationBanPermission) {
+        return nock(`${config.core.url}:${config.core.port}`)
+            .persist()
+            .get('/my_permissions')
+            .reply(200, {
+                success: true,
+                data: [{ combined: 'global:update_application_ban:member' }]
+            });
+    }
+
     return nock(`${config.core.url}:${config.core.port}`)
         .persist()
         .get('/my_permissions')

--- a/frontend/src/views/core/members/Single.vue
+++ b/frontend/src/views/core/members/Single.vue
@@ -10,8 +10,8 @@
         </article>
       </div>
       <div class="tile is-parent">
-        <article class="tile is-child is-info" v-if="can.edit">
-          <div class="field is-grouped">
+        <article class="tile is-child is-info" v-if="can.edit || can.setActive || can.setEventApplicationBan || can.setSuperadmin || can.delete">
+          <div class="field is-grouped" v-if="can.edit">
             <a class="button is-fullwidth is-primary" @click="openPictureModal()">
               <span>Change picture</span>
               <span class="icon"><font-awesome-icon icon="camera" /></span>

--- a/frontend/src/views/core/members/Single.vue
+++ b/frontend/src/views/core/members/Single.vue
@@ -416,7 +416,7 @@ export default {
       this.fetchFutureApplications().then((applications) => {
         const futureApplications = applications.length > 0
           ? '<p>This user already has future applications. These applications will remain active:</p><ul>'
-            + applications.map((application) => '<li>' + application.event_name + ' (' + application.service + ', ' + application.application_status + ')</li>').join('')
+            + applications.map((application) => '<li>' + this.escapeHtml(application.event_name) + ' (' + this.escapeHtml(application.service) + ', ' + this.escapeHtml(application.application_status) + ')</li>').join('')
             + '</ul>'
           : '<p>This user has no active future applications.</p>'
 
@@ -444,6 +444,15 @@ export default {
       ]
 
       return Promise.all(links.map(link => this.axios.get(link).then(response => response.data.data))).then((responses) => responses.reduce((acc, list) => acc.concat(list), []))
+    },
+    escapeHtml (value) {
+      return String(value).replace(/[&<>'"]/g, (character) => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        "'": '&#39;',
+        '"': '&quot;'
+      }[character]))
     },
     setEventApplicationBan (banUntil) {
       this.axios

--- a/frontend/src/views/core/members/Single.vue
+++ b/frontend/src/views/core/members/Single.vue
@@ -84,6 +84,28 @@
             </a>
           </div>
 
+          <div class="field is-grouped" v-if="can.setEventApplicationBan && !activeEventApplicationBan">
+            <a
+              class="button is-fullwidth is-danger"
+              :class="{ 'is-loading': isSwitchingEventApplicationBan }"
+              @click="askSetEventApplicationBan()"
+            >
+              <span>Ban event applications</span>
+              <span class="icon"><font-awesome-icon icon="minus" /></span>
+            </a>
+          </div>
+
+          <div class="field is-grouped" v-if="can.setEventApplicationBan && activeEventApplicationBan">
+            <a
+              class="button is-fullwidth is-primary"
+              :class="{ 'is-loading': isSwitchingEventApplicationBan }"
+              @click="askLiftEventApplicationBan()"
+            >
+              <span>Lift event application ban</span>
+              <span class="icon"><font-awesome-icon icon="plus" /></span>
+            </a>
+          </div>
+
           <div class="field is-grouped" v-if="can.setSuperadmin">
             <a
               v-if="!user.superadmin"
@@ -185,6 +207,13 @@
                   <th>Login suspended?</th>
                   <td>{{ user.active ? 'No' : 'Yes' }}</td>
                 </tr>
+                <tr v-if="can.viewEventApplicationBan">
+                  <th>Event application ban</th>
+                  <td v-if="activeEventApplicationBan">
+                    Until {{ user.event_application_ban.ban_until | datetime }}
+                  </td>
+                  <td v-if="!activeEventApplicationBan">No active ban</td>
+                </tr>
               </tbody>
             </table>
           </div>
@@ -248,6 +277,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import moment from 'moment'
 import EditPrimaryBodyModal from './EditPrimaryBodyModal.vue'
 import EditPrimaryEmailModal from './EditPrimaryEmailModal.vue'
 import PictureModal from './PictureModal.vue'
@@ -269,16 +299,20 @@ export default {
         notification_email: null,
         active: null,
         superadmin: null,
+        event_application_ban: null,
         username: null,
         image: null
       },
       isOwnProfile: false,
       isLoading: false,
       isSwitchingStatus: false,
+      isSwitchingEventApplicationBan: false,
       permissions: [],
       can: {
         edit: false,
         setActive: false,
+        setEventApplicationBan: false,
+        viewEventApplicationBan: false,
         setSuperadmin: false,
         delete: false
       }
@@ -361,6 +395,93 @@ export default {
         .catch((err) => {
           this.$root.showError('Error changing user status', err)
           this.isSwitchingStatus = false
+        })
+    },
+    askSetEventApplicationBan () {
+      this.$buefy.dialog.prompt({
+        title: 'Ban event applications',
+        message: 'Set the end date of the temporary ban. The maximum is 3 months from today.',
+        inputAttrs: {
+          type: 'date',
+          min: moment().add(1, 'day').format('YYYY-MM-DD'),
+          max: moment().add(3, 'months').format('YYYY-MM-DD'),
+          required: true
+        },
+        trapFocus: true,
+        onConfirm: (banUntil) => this.confirmEventApplicationBan(banUntil)
+      })
+    },
+    confirmEventApplicationBan (banUntil) {
+      this.isSwitchingEventApplicationBan = true
+      this.fetchFutureApplications().then((applications) => {
+        const futureApplications = applications.length > 0
+          ? '<p>This user already has future applications. These applications will remain active:</p><ul>'
+            + applications.map((application) => '<li>' + application.event_name + ' (' + application.service + ', ' + application.application_status + ')</li>').join('')
+            + '</ul>'
+          : '<p>This user has no active future applications.</p>'
+
+        this.$buefy.dialog.confirm({
+          title: 'Confirm event application ban',
+          message: futureApplications + '<p>Do you want to apply the ban until <b>' + moment(banUntil).format('YYYY-MM-DD') + '</b>?</p>',
+          confirmText: 'Apply ban',
+          type: 'is-danger',
+          hasIcon: true,
+          onConfirm: () => this.setEventApplicationBan(banUntil),
+          onCancel: () => {
+            this.isSwitchingEventApplicationBan = false
+          }
+        })
+      }).catch((err) => {
+        this.isSwitchingEventApplicationBan = false
+        this.$root.showError('Could not fetch future applications', err)
+      })
+    },
+    fetchFutureApplications () {
+      const links = [
+        this.services['events'] + '/applications/future/' + this.user.id,
+        this.services['statutory'] + '/applications/future/' + this.user.id,
+        this.services['summeruniversity'] + '/applications/future/' + this.user.id
+      ]
+
+      return Promise.all(links.map(link => this.axios.get(link).then(response => response.data.data))).then((responses) => responses.reduce((acc, list) => acc.concat(list), []))
+    },
+    setEventApplicationBan (banUntil) {
+      this.axios
+        .put(this.services['core'] + '/members/' + this.user.id + '/event-application-ban', {
+          ban_until: banUntil
+        })
+        .then((response) => {
+          this.user.event_application_ban = response.data.data
+          this.$root.showSuccess('Event application ban is active.')
+          this.isSwitchingEventApplicationBan = false
+        })
+        .catch((err) => {
+          this.$root.showError('Error setting event application ban', err)
+          this.isSwitchingEventApplicationBan = false
+        })
+    },
+    askLiftEventApplicationBan () {
+      this.$buefy.dialog.confirm({
+        title: 'Lift event application ban',
+        message: 'Are you sure you want to lift this user\'s event application ban?',
+        confirmText: 'Lift ban',
+        type: 'is-primary',
+        hasIcon: true,
+        onConfirm: () => this.liftEventApplicationBan()
+      })
+    },
+    liftEventApplicationBan () {
+      this.isSwitchingEventApplicationBan = true
+      this.axios
+        .delete(this.services['core'] + '/members/' + this.user.id + '/event-application-ban')
+        .then(() => {
+          this.user.event_application_ban = null
+          this.$root.showSuccess('Event application ban is lifted.')
+          this.isSwitchingEventApplicationBan = false
+        })
+        .catch((err) => {
+          this.$root.showError('Error lifting event application ban', err)
+          this.isSwitchingEventApplicationBan = false
         })
     },
     askToggleSuperadmin () {
@@ -456,6 +577,8 @@ export default {
           // set the permission to true if at least one set of permissions have
           // the required permission (either first for global, or others for local).
           this.can.setActive = responses.some((list) => list.data.data.some((permission) => permission.combined.endsWith('update_active:member')))
+          this.can.setEventApplicationBan = responses.some((list) => list.data.data.some((permission) => permission.combined === 'global:update_application_ban:member'))
+          this.can.viewEventApplicationBan = this.isOwnProfile || this.can.setEventApplicationBan
           this.can.setSuperadmin = responses.some((list) => list.data.data.some((permission) => permission.combined.endsWith('update_superadmin:member')))
           this.can.edit = responses.some((list) => list.data.data.some((permission) => permission.combined.endsWith('update:member'))) || this.isOwnProfile
           this.can.delete = responses.some((list) => list.data.data.some((permission) => permission.combined.endsWith('delete:member')))
@@ -481,9 +604,14 @@ export default {
   mounted () {
     this.fetchUser()
   },
-  computed: mapGetters({
-    loginUser: 'user',
-    services: 'services'
-  })
+  computed: {
+    ...mapGetters({
+      loginUser: 'user',
+      services: 'services'
+    }),
+    activeEventApplicationBan () {
+      return this.user.event_application_ban && new Date(this.user.event_application_ban.ban_until) > new Date()
+    }
+  }
 }
 </script>

--- a/frontend/src/views/events/Apply.vue
+++ b/frontend/src/views/events/Apply.vue
@@ -11,9 +11,12 @@
           <div class="title" v-show="!isNew && !this.can.apply">See your application on {{ event.name }}</div>
 
           <div class="subtitle" v-show="isNew && !this.can.apply">You cannot apply: the applications are closed or the event is not published yet.</div>
+          <div class="notification is-warning" v-if="isNew && activeEventApplicationBan">
+            You are temporarily banned from submitting new event applications until {{ loginUser.event_application_ban.ban_until | datetime }}.
+          </div>
 
           <form @submit.prevent="saveApplication()">
-            <div class="tile is-parent" v-show="this.can.apply">
+            <div class="tile is-parent" v-show="canSubmitApplication">
               <div class="tile is-child">
                 <div class="field">
                   <label class="label">Body <span class="has-text-danger">*</span></label>
@@ -204,6 +207,10 @@ export default {
   },
   methods: {
     saveApplication () {
+      if (this.isNew && this.activeEventApplicationBan) {
+        return this.$root.showError('You are temporarily banned from submitting new event applications.')
+      }
+
       if (!this.application.body_id) {
         return this.$root.showError('Please select a body.')
       }
@@ -247,6 +254,12 @@ export default {
     }),
     isNew () {
       return !this.application.id
+    },
+    activeEventApplicationBan () {
+      return this.loginUser.event_application_ban && new Date(this.loginUser.event_application_ban.ban_until) > new Date()
+    },
+    canSubmitApplication () {
+      return this.can.apply && (!this.isNew || !this.activeEventApplicationBan)
     }
   },
   mounted () {

--- a/frontend/src/views/events/Single.vue
+++ b/frontend/src/views/events/Single.vue
@@ -136,6 +136,11 @@
             >!
           </div>
 
+          <div class="notification is-warning" v-if="activeEventApplicationBan">
+            You are temporarily banned from submitting new event applications until {{ loginUser.event_application_ban.ban_until | datetime }}.
+            Existing applications can still be managed.
+          </div>
+
           <div class="content">
             <table class="table is-narrow">
               <tbody>
@@ -579,6 +584,9 @@ export default {
     },
     isOnlineEvent () {
       return this.event.method === 'online'
+    },
+    activeEventApplicationBan () {
+      return this.loginUser.event_application_ban && new Date(this.loginUser.event_application_ban.ban_until) > new Date()
     }
   }
 }

--- a/frontend/src/views/statutory/EditApplication.vue
+++ b/frontend/src/views/statutory/EditApplication.vue
@@ -519,7 +519,7 @@ export default {
       return this.loginUser.event_application_ban && new Date(this.loginUser.event_application_ban.ban_until) > new Date()
     },
     canSubmitApplication () {
-      return this.can.apply && (!this.isNew || !this.activeEventApplicationBan)
+      return !this.isNew || (this.can.apply && !this.activeEventApplicationBan)
     },
     isOwn () {
       return this.isNew || this.loginUser.id === this.application.user_id

--- a/frontend/src/views/statutory/EditApplication.vue
+++ b/frontend/src/views/statutory/EditApplication.vue
@@ -5,8 +5,12 @@
         <div class="title" v-show="isNew">Apply to {{ event.name }}</div>
         <div class="title" v-show="!isNew">Edit application on {{ event.name }}</div>
 
+        <div class="notification is-warning" v-if="isNew && activeEventApplicationBan">
+          You are temporarily banned from submitting new event applications until {{ loginUser.event_application_ban.ban_until | datetime }}.
+        </div>
+
         <form @submit.prevent="saveApplication()">
-          <div class="tile is-parent">
+          <div class="tile is-parent" v-show="canSubmitApplication">
             <div class="tile is-child">
               <div class="field">
                 <label class="label">Body <span class="has-text-danger">*</span></label>
@@ -420,6 +424,10 @@ export default {
   },
   methods: {
     saveApplication () {
+      if (this.isNew && this.activeEventApplicationBan) {
+        return this.$root.showError('You are temporarily banned from submitting new event applications.')
+      }
+
       if (!this.application.body_id) {
         return this.$root.showError('Please select a body.')
       }
@@ -506,6 +514,12 @@ export default {
     }),
     isNew () {
       return !this.$route.params.application_id
+    },
+    activeEventApplicationBan () {
+      return this.loginUser.event_application_ban && new Date(this.loginUser.event_application_ban.ban_until) > new Date()
+    },
+    canSubmitApplication () {
+      return this.can.apply && (!this.isNew || !this.activeEventApplicationBan)
     },
     isOwn () {
       return this.isNew || this.loginUser.id === this.application.user_id

--- a/frontend/src/views/statutory/Single.vue
+++ b/frontend/src/views/statutory/Single.vue
@@ -284,6 +284,11 @@
         <div class="content">
           <p class="title">{{ event.name }}</p>
 
+          <div class="notification is-warning" v-if="activeEventApplicationBan">
+            You are temporarily banned from submitting new event applications until {{ loginUser.event_application_ban.ban_until | datetime }}.
+            Existing applications can still be managed and position applications remain available.
+          </div>
+
           <div class="content">
             <table class="table is-narrow">
               <tbody>
@@ -618,6 +623,9 @@ export default {
         this.event.type === 'agora'
         && moment().isBetween(this.event.starts, this.event.ends, null, '[]')
       )
+    },
+    activeEventApplicationBan () {
+      return this.loginUser.event_application_ban && new Date(this.loginUser.event_application_ban.ban_until) > new Date()
     }
   }
 }

--- a/frontend/src/views/summeruniversity/Apply.vue
+++ b/frontend/src/views/summeruniversity/Apply.vue
@@ -7,6 +7,9 @@
         <div class="title" v-show="!isNew && !this.can.apply">See your application on {{ event.name }}</div>
 
         <div class="subtitle" v-show="isNew && !this.can.apply">You cannot apply to this event.</div>
+        <div class="notification is-warning" v-if="isNew && activeEventApplicationBan">
+          You are temporarily banned from submitting new event applications until {{ loginUser.event_application_ban.ban_until | datetime }}.
+        </div>
 
         <div class="tile is-parent" v-if="application && application.cancelled">
           <div class="tile is-child">
@@ -19,7 +22,7 @@
 
         <!-- TODO: add all fields -->
         <form @submit.prevent="saveApplication()">
-          <div class="tile is-parent" v-show="this.can.apply">
+          <div class="tile is-parent" v-show="canSubmitApplication">
             <div class="tile is-child">
               <div class="field">
                 <label class="label">Body <span class="has-text-danger">*</span></label>
@@ -548,6 +551,10 @@ export default {
   },
   methods: {
     saveApplication () {
+      if (this.isNew && this.activeEventApplicationBan) {
+        return this.$root.showError('You are temporarily banned from submitting new event applications.')
+      }
+
       if (!this.application.body_id) {
         return this.$root.showError('Please select a body.')
       }
@@ -603,6 +610,12 @@ export default {
     }),
     isNew () {
       return !this.application.id
+    },
+    activeEventApplicationBan () {
+      return this.loginUser.event_application_ban && new Date(this.loginUser.event_application_ban.ban_until) > new Date()
+    },
+    canSubmitApplication () {
+      return this.can.apply && (!this.isNew || !this.activeEventApplicationBan)
     }
   },
   mounted () {

--- a/frontend/src/views/summeruniversity/Single.vue
+++ b/frontend/src/views/summeruniversity/Single.vue
@@ -34,7 +34,7 @@
             </router-link>
           </div>
 
-          <div class="field is-grouped" v-if="can.apply">
+          <div class="field is-grouped" v-if="can.apply && !activeEventApplicationBan">
             <router-link
               :to="{
                 name: 'oms.summeruniversity.apply',
@@ -232,6 +232,11 @@
       <article class="tile is-child">
         <div class="content">
           <p class="title">{{ event.name }}</p>
+
+          <div class="notification is-warning" v-if="activeEventApplicationBan">
+            You are temporarily banned from submitting new event applications until {{ loginUser.event_application_ban.ban_until | datetime }}.
+            Existing applications can still be managed.
+          </div>
 
           <div class="content">
             <table class="table is-narrow">
@@ -788,6 +793,9 @@ export default {
     }),
     isOrganizer () {
       return this.event.organizers.some((org) => org.user_id === this.loginUser.id)
+    },
+    activeEventApplicationBan () {
+      return this.loginUser.event_application_ban && new Date(this.loginUser.event_application_ban.ban_until) > new Date()
     }
   }
 }

--- a/statutory/lib/applications.js
+++ b/statutory/lib/applications.js
@@ -5,10 +5,10 @@ const xlsx = require('node-xlsx').default;
 const errors = require('./errors');
 const core = require('./core');
 const mailer = require('./mailer');
-const { Application, VotesPerAntenna, PaxLimit } = require('../models');
+const { Application, VotesPerAntenna, PaxLimit, Event } = require('../models');
 const constants = require('./constants');
 const helpers = require('./helpers');
-const { sequelize } = require('./sequelize');
+const { sequelize, Sequelize } = require('./sequelize');
 const logger = require('./logger');
 
 async function getEditableBodiesForUser(req, user) {
@@ -21,6 +21,55 @@ async function getEditableBodiesForUser(req, user) {
         return limit && limit.hasAnyLimits();
     });
 }
+
+function hasManageApplicationsPermission(corePermissions) {
+    return Array.isArray(corePermissions)
+        && corePermissions.some((permission) => permission.combined.match(/^global:manage_applications:(agora|epm|spm)$/));
+}
+
+function isApplicationBanActive(user) {
+    return user.event_application_ban && new Date(user.event_application_ban.ban_until) > new Date();
+}
+
+exports.listFutureApplicationsForUser = async (req, res) => {
+    if (!hasManageApplicationsPermission(req.corePermissions)) {
+        return errors.makeForbiddenError(res, 'You are not allowed to see future applications.');
+    }
+
+    if (!helpers.isNumber(req.params.user_id)) {
+        return errors.makeBadRequestError(res, 'User ID should be a number.');
+    }
+
+    const applications = await Application.findAll({
+        where: {
+            user_id: Number(req.params.user_id),
+            cancelled: false,
+            status: { [Sequelize.Op.in]: ['pending', 'waiting_list', 'accepted'] }
+        },
+        include: [{
+            model: Event,
+            required: true,
+            where: {
+                starts: { [Sequelize.Op.gt]: new Date() },
+                status: 'published'
+            }
+        }],
+        order: [[Event, 'starts', 'ASC']]
+    });
+
+    return res.json({
+        success: true,
+        data: applications.map((application) => ({
+            service: 'statutory',
+            application_id: application.id,
+            application_status: application.status,
+            event_id: application.event.id,
+            event_name: application.event.name,
+            event_type: application.event.type,
+            event_starts: application.event.starts
+        }))
+    });
+};
 
 exports.listAllApplications = async (req, res) => {
     if (!req.permissions.see_applications) {
@@ -679,6 +728,10 @@ exports.setBoardForBody = async (req, res) => {
 exports.postApplication = async (req, res) => {
     if (!req.permissions.apply) {
         return errors.makeForbiddenError(res, 'The deadline for applications has passed or the applications period hasn\'t started yet.');
+    }
+
+    if (isApplicationBanActive(req.user)) {
+        return errors.makeForbiddenError(res, 'You are temporarily banned from applying to events.');
     }
 
     req.body.user_id = req.user.id;

--- a/statutory/lib/applications.js
+++ b/statutory/lib/applications.js
@@ -27,12 +27,17 @@ function hasManageApplicationsPermission(corePermissions) {
         && corePermissions.some((permission) => permission.combined.match(/^global:manage_applications:(agora|epm|spm)$/));
 }
 
+function canListFutureApplicationsForBan(corePermissions) {
+    return Array.isArray(corePermissions)
+        && corePermissions.some((permission) => permission.combined === 'global:update_application_ban:member');
+}
+
 function isApplicationBanActive(user) {
     return user.event_application_ban && new Date(user.event_application_ban.ban_until) > new Date();
 }
 
 exports.listFutureApplicationsForUser = async (req, res) => {
-    if (!hasManageApplicationsPermission(req.corePermissions)) {
+    if (!canListFutureApplicationsForBan(req.corePermissions) && !hasManageApplicationsPermission(req.corePermissions)) {
         return errors.makeForbiddenError(res, 'You are not allowed to see future applications.');
     }
 

--- a/statutory/lib/server.js
+++ b/statutory/lib/server.js
@@ -69,6 +69,7 @@ GeneralRouter.use(middlewares.ensureAuthorized);
 GeneralRouter.post('/', events.addEvent);
 GeneralRouter.get('/tasks', middlewares.getTasksList);
 GeneralRouter.get('/mine', events.listUserAppliedEvents);
+GeneralRouter.get('/applications/future/:user_id', applications.listFutureApplicationsForUser);
 
 GeneralRouter.get('/recents', middlewares.ensureAuthorized, events.listMostRecentEvents);
 

--- a/statutory/test/api/applications-creation.test.js
+++ b/statutory/test/api/applications-creation.test.js
@@ -33,7 +33,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateApplication({

--- a/statutory/test/api/applications-creation.test.js
+++ b/statutory/test/api/applications-creation.test.js
@@ -26,6 +26,28 @@ describe('Applications creation', () => {
         mock.cleanAll();
     });
 
+    test('should return 403 when user has an active event application ban', async () => {
+        mock.mockAll({ core: { eventApplicationBanned: true }, mainPermissions: { noPermissions: true } });
+        const event = await generator.createEvent({ applications: [] });
+
+        tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
+
+        const res = await request({
+            uri: '/events/' + event.id + '/applications/',
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: generator.generateApplication({
+                body_id: regularUser.bodies[0].id
+            }, event)
+        });
+
+        tk.reset();
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).toHaveProperty('message');
+    });
+
     test('should succeed if user can apply within deadline but without permissions', async () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
         const event = await generator.createEvent({ applications: [] });

--- a/statutory/test/api/applications-future.test.js
+++ b/statutory/test/api/applications-future.test.js
@@ -1,0 +1,68 @@
+const moment = require('moment');
+
+const { startServer, stopServer } = require('../../lib/server');
+const { request } = require('../scripts/helpers');
+const mock = require('../scripts/mock-core-registry');
+const generator = require('../scripts/generator');
+const user = require('../assets/core-valid.json').data;
+
+describe('Statutory future applications', () => {
+    beforeEach(async () => {
+        await startServer();
+    });
+
+    afterEach(async () => {
+        await stopServer();
+        mock.cleanAll();
+        await generator.clearAll();
+    });
+
+    test('should allow application ban managers to list future applications without statutory management permissions', async () => {
+        mock.mockAll({ mainPermissions: { applicationBanPermission: true }, approvePermissions: { noPermissions: true } });
+
+        const event = await generator.createEvent({
+            name: 'Future statutory event',
+            application_period_starts: moment().subtract(1, 'week').toDate(),
+            application_period_ends: moment().add(1, 'week').toDate(),
+            board_approve_deadline: moment().add(2, 'weeks').toDate(),
+            participants_list_publish_deadline: moment().add(3, 'weeks').toDate(),
+            memberslist_submission_deadline: moment().add(4, 'weeks').toDate(),
+            starts: moment().add(1, 'month').toDate(),
+            ends: moment().add(1, 'month').add(1, 'day').toDate(),
+            status: 'published',
+            applications: []
+        });
+        await generator.createApplication({
+            user_id: user.id,
+            status: 'pending',
+            cancelled: false
+        }, event);
+
+        const res = await request({
+            path: '/applications/future/' + user.id,
+            headers: { 'X-Auth-Token': 'foobar' }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body.data).toHaveLength(1);
+        expect(res.body.data[0]).toMatchObject({
+            service: 'statutory',
+            event_id: event.id,
+            event_name: 'Future statutory event',
+            application_status: 'pending'
+        });
+    });
+
+    test('should reject users without application ban or statutory management permissions', async () => {
+        mock.mockAll({ mainPermissions: { noPermissions: true }, approvePermissions: { noPermissions: true } });
+
+        const res = await request({
+            path: '/applications/future/' + user.id,
+            headers: { 'X-Auth-Token': 'foobar' }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+    });
+});

--- a/statutory/test/api/candidatures-submission.test.js
+++ b/statutory/test/api/candidatures-submission.test.js
@@ -36,7 +36,7 @@ describe('Candidates submission', () => {
         const candidate = generator.generateCandidate({ body_id: regularUser.bodies[0].id });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }

--- a/statutory/test/api/candidatures-submission.test.js
+++ b/statutory/test/api/candidatures-submission.test.js
@@ -25,6 +25,28 @@ describe('Candidates submission', () => {
         mock.cleanAll();
     });
 
+    test('should allow candidature submission when user has an active event application ban', async () => {
+        mock.mockAll({ core: { eventApplicationBanned: true }, mainPermissions: { noPermissions: true } });
+
+        const event = await generator.createEvent({ type: 'agora', applications: [] });
+        const position = await generator.createPosition({
+            starts: moment().subtract(1, 'week').toDate(),
+            ends: moment().add(1, 'week').toDate()
+        }, event);
+        const candidate = generator.generateCandidate({ body_id: regularUser.bodies[0].id });
+
+        const res = await request({
+            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            method: 'POST',
+            body: candidate,
+            headers: { 'X-Auth-Token': 'blablabla' }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+    });
+
     test('should return 403 if the applications have not started', async () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 

--- a/statutory/test/scripts/mock-core-registry.js
+++ b/statutory/test/scripts/mock-core-registry.js
@@ -128,6 +128,16 @@ exports.mockCoreMainPermissions = (options) => {
             .replyWithFile(200, path.join(__dirname, '..', 'assets', 'core-empty.json'));
     }
 
+    if (options.applicationBanPermission) {
+        return nock(`${config.core.url}:${config.core.port}`)
+            .persist()
+            .get('/my_permissions')
+            .reply(200, {
+                success: true,
+                data: [{ combined: 'global:update_application_ban:member' }]
+            });
+    }
+
     return nock(`${config.core.url}:${config.core.port}`)
         .persist()
         .get('/my_permissions')

--- a/statutory/test/scripts/mock-core-registry.js
+++ b/statutory/test/scripts/mock-core-registry.js
@@ -36,6 +36,21 @@ exports.mockCore = (options) => {
             .replyWithFile(401, path.join(__dirname, '..', 'assets', 'core-unauthorized.json'));
     }
 
+    if (options.eventApplicationBanned) {
+        return nock(`${config.core.url}:${config.core.port}`)
+            .persist()
+            .get('/members/me')
+            .reply(200, {
+                success: true,
+                data: {
+                    ...regularUser,
+                    event_application_ban: {
+                        ban_until: new Date(Date.now() + 10 * 365 * 24 * 60 * 60 * 1000)
+                    }
+                }
+            });
+    }
+
     return nock(`${config.core.url}:${config.core.port}`)
         .persist()
         .get('/members/me')

--- a/summeruniversity/lib/applications.js
+++ b/summeruniversity/lib/applications.js
@@ -7,6 +7,50 @@ const helpers = require('./helpers');
 const mailer = require('./mailer');
 const { sequelize, Sequelize } = require('./sequelize');
 
+function isApplicationBanActive(user) {
+    return user.event_application_ban && new Date(user.event_application_ban.ban_until) > new Date();
+}
+
+exports.listFutureApplicationsForUser = async (req, res) => {
+    if (!Object.values(req.permissions.manage_summeruniversity).some(Boolean)) {
+        return errors.makeForbiddenError(res, 'You are not allowed to see future applications.');
+    }
+
+    if (!helpers.isNumber(req.params.user_id)) {
+        return errors.makeBadRequestError(res, 'User ID should be a number.');
+    }
+
+    const applications = await Application.findAll({
+        where: {
+            user_id: Number(req.params.user_id),
+            cancelled: false,
+            status: { [Sequelize.Op.in]: ['pending', 'accepted'] }
+        },
+        include: [{
+            model: Event,
+            required: true,
+            where: {
+                starts: { [Sequelize.Op.gt]: new Date() },
+                deleted: false
+            }
+        }],
+        order: [[Event, 'starts', 'ASC']]
+    });
+
+    return res.json({
+        success: true,
+        data: applications.map((application) => ({
+            service: 'summeruniversity',
+            application_id: application.id,
+            application_status: application.status,
+            event_id: application.event.id,
+            event_name: application.event.name,
+            event_type: application.event.type,
+            event_starts: application.event.starts
+        }))
+    });
+};
+
 exports.listAllApplications = async (req, res) => {
     if (!req.permissions.list_applications) {
         return errors.makeForbiddenError(res, 'You cannot see applications for this event.');
@@ -39,6 +83,10 @@ exports.createApplication = async (req, res) => {
     // Check for permission
     if (!req.permissions.apply) {
         return errors.makeForbiddenError(res, 'You cannot apply to this event.');
+    }
+
+    if (isApplicationBanActive(req.user)) {
+        return errors.makeForbiddenError(res, 'You are temporarily banned from applying to events.');
     }
 
     if (typeof req.body.body_id !== 'undefined' && !helpers.isMemberOf(req.user, req.body.body_id)) {

--- a/summeruniversity/lib/applications.js
+++ b/summeruniversity/lib/applications.js
@@ -11,8 +11,13 @@ function isApplicationBanActive(user) {
     return user.event_application_ban && new Date(user.event_application_ban.ban_until) > new Date();
 }
 
+function canListFutureApplicationsForBan(corePermissions) {
+    return Array.isArray(corePermissions)
+        && corePermissions.some((permission) => permission.combined === 'global:update_application_ban:member');
+}
+
 exports.listFutureApplicationsForUser = async (req, res) => {
-    if (!Object.values(req.permissions.manage_summeruniversity).some(Boolean)) {
+    if (!canListFutureApplicationsForBan(req.corePermissions) && !Object.values(req.permissions.manage_summeruniversity).some(Boolean)) {
         return errors.makeForbiddenError(res, 'You are not allowed to see future applications.');
     }
 

--- a/summeruniversity/lib/server.js
+++ b/summeruniversity/lib/server.js
@@ -52,6 +52,7 @@ GeneralRouter.get('/mine/participating', middlewares.ensureAuthorized, events.li
 GeneralRouter.get('/mine/approvable', middlewares.ensureAuthorized, events.listApprovableEvents);
 GeneralRouter.get('/boardview/:body_id', middlewares.ensureAuthorized, events.listBodyApplications);
 
+GeneralRouter.get('/applications/future/:user_id', middlewares.ensureAuthorized, applications.listFutureApplicationsForUser);
 GeneralRouter.get('/applications', middlewares.ensureAuthorized, applications.getStats);
 
 GeneralRouter.get('/recents', middlewares.ensureAuthorized, events.listMostRecentEvents);


### PR DESCRIPTION
## Summary
- Add auditable temporary event application bans with manual lift and expiry support in core.
- Enforce bans for new Events, Statutory participation, and Summer University applications while preserving existing applications and statutory candidatures.
- Add CD/member-only visibility for ban status, admin UI controls, and future-application warnings.

## Testing
- `NODE_ENV=test USERNAME=postgres DB_USERNAME=postgres PG_PASSWORD=5ecr3t npx jest test/api/users-event-application-ban.test.js --runInBand --forceExit`
- `npm run lint -- src/views/core/members/Single.vue`
- `npx eslint middlewares/members.js test/api/users-event-application-ban.test.js`