### PR TITLE
chore(docker): modernize local compose startup

### DIFF
--- a/core/docker/core/Dockerfile
+++ b/core/docker/core/Dockerfile
@@ -34,6 +34,6 @@ RUN npm install -g nodemon@3.1.4 \
  && npm install -g bunyan@1.8.15 \
  && npm cache clean --force
 
-CMD ["sh", "-c", "sh /usr/app/scripts/bootstrap.sh && nodemon -e 'js,json' lib/run.js"]
+CMD ["sh", "-c", "sh /usr/app/scripts/bootstrap.sh && npm run nodemon-start"]
 
 EXPOSE 8084

--- a/core/docker/docker-compose.dev.yml
+++ b/core/docker/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 ### CORE     #######################################
 services:
   core:
@@ -6,7 +5,7 @@ services:
       context: ./${PATH_CORE}/..
       dockerfile: ./docker/core/Dockerfile
     image: aegee/core:dev
-    command: sh -c "sh /usr/app/scripts/bootstrap.sh && nodemon -L -e 'js,json' lib/run.js | bunyan --color"
+    command: "sh -c 'sh /usr/app/scripts/bootstrap.sh && npm run nodemon-start | bunyan'"
     volumes:
       - ./${PATH_CORE}/../config/:/usr/app/src/config
       - ./${PATH_CORE}/../lib/:/usr/app/src/lib

--- a/core/docker/docker-compose.yml
+++ b/core/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
     postgres-core:
         restart: always
@@ -87,5 +85,5 @@ volumes:
 
 networks:
     default:
-        external:
-            name: OMS
+        name: OMS
+        external: true

--- a/core/package.json
+++ b/core/package.json
@@ -17,6 +17,7 @@
     "rimraf": "^6.0.1"
   },
   "scripts": {
+    "nodemon-start": "nodemon -L -e 'js,json' lib/run.js",
     "test": "NODE_ENV=test npm run db:setup && jest test/**/*.test.js --runInBand --forceExit",
     "test:ci": "NODE_ENV=test npm run db:setup && jest --runInBand --forceExit",
     "lint": "eslint .",

--- a/discounts/docker/discounts/Dockerfile
+++ b/discounts/docker/discounts/Dockerfile
@@ -34,6 +34,6 @@ RUN npm install -g nodemon@3.1.4 \
  && npm install -g bunyan@1.8.15 \
  && npm cache clean --force
 
-CMD ["sh", "-c", "sh /usr/app/scripts/bootstrap.sh && nodemon -e js,json lib/run.js"]
+CMD ["sh", "-c", "sh /usr/app/scripts/bootstrap.sh && npm run nodemon-start"]
 
 EXPOSE 8084

--- a/discounts/docker/docker-compose.dev.yml
+++ b/discounts/docker/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   discounts:
     build:
@@ -12,4 +10,4 @@ services:
       - ./${PATH_DISCOUNTS}/../migrations:/usr/app/src/migrations
       - ./${PATH_DISCOUNTS}/../models:/usr/app/src/models
       - ./${PATH_DISCOUNTS}/../cli.js:/usr/app/src/cli.js
-    command: "sh -c '/usr/app/scripts/bootstrap.sh && npm run nodemon-start | bunyan'"
+    command: "sh -c 'sh /usr/app/scripts/bootstrap.sh && npm run nodemon-start | bunyan'"

--- a/discounts/docker/docker-compose.yml
+++ b/discounts/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 ### OMS DISCOUNTS     #######################################
 services:
     postgres-discounts:
@@ -55,5 +54,5 @@ volumes:
 
 networks:
     default:
-        external:
-            name: OMS
+        name: OMS
+        external: true

--- a/events/docker/docker-compose.dev.yml
+++ b/events/docker/docker-compose.dev.yml
@@ -1,11 +1,10 @@
-version: "3.4"
 services:
     events:
         build:
             context: ./${PATH_EVENTS}/..
             dockerfile: ./docker/events/Dockerfile
         image: aegee/events:dev
-        command: sh -c "sh /usr/app/scripts/bootstrap.sh && nodemon -L -e 'js,json' lib/run.js | bunyan"
+        command: "sh -c 'sh /usr/app/scripts/bootstrap.sh && npm run nodemon-start | bunyan'"
         volumes:
             - ./${PATH_EVENTS}/../config:/usr/app/src/config
             - ./${PATH_EVENTS}/../lib:/usr/app/src/lib

--- a/events/docker/docker-compose.yml
+++ b/events/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
     postgres-events:
         restart: always
@@ -82,5 +81,5 @@ volumes:
 
 networks:
     default:
-        external:
-            name: OMS
+        name: OMS
+        external: true

--- a/events/docker/events/Dockerfile
+++ b/events/docker/events/Dockerfile
@@ -34,6 +34,6 @@ RUN npm install -g nodemon@3.1.4 \
  && npm install -g bunyan@1.8.15 \
  && npm cache clean --force
 
-CMD ["sh", "-c", "sh /usr/app/scripts/bootstrap.sh && nodemon -e js,json lib/run.js"]
+CMD ["sh", "-c", "sh /usr/app/scripts/bootstrap.sh && npm run nodemon-start"]
 
 EXPOSE 8084

--- a/events/package.json
+++ b/events/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "scripts": {
+    "nodemon-start": "nodemon -L -e 'js,json' lib/run.js",
     "test": "NODE_ENV=test npm run db:setup && jest test/api/*.js --runInBand --forceExit",
     "test:ci": "NODE_ENV=test npm run db:setup && jest --runInBand --forceExit",
     "lint": "eslint .",

--- a/knowledge/docker/docker-compose.dev.yml
+++ b/knowledge/docker/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   knowledge:
     build:
@@ -12,4 +10,4 @@ services:
       - ./${PATH_KNOWLEDGE}/../migrations:/usr/app/src/migrations
       - ./${PATH_KNOWLEDGE}/../models:/usr/app/src/models
       - ./${PATH_KNOWLEDGE}/../cli.js:/usr/app/src/cli.js
-    command: "sh -c '/usr/app/scripts/bootstrap.sh && npm run nodemon-start | bunyan'"
+    command: "sh -c 'sh /usr/app/scripts/bootstrap.sh && npm run nodemon-start | bunyan'"

--- a/knowledge/docker/docker-compose.yml
+++ b/knowledge/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 ### KNOWLEDGE     #######################################
 services:
     postgres-knowledge:
@@ -53,5 +52,5 @@ volumes:
 
 networks:
     default:
-        external:
-            name: OMS
+        name: OMS
+        external: true

--- a/knowledge/docker/knowledge/Dockerfile
+++ b/knowledge/docker/knowledge/Dockerfile
@@ -34,6 +34,6 @@ RUN npm install -g nodemon@3.1.4 \
  && npm install -g bunyan@1.8.15 \
  && npm cache clean --force
 
-CMD ["sh", "-c", "sh /usr/app/scripts/bootstrap.sh && nodemon -e js,json lib/run.js"]
+CMD ["sh", "-c", "sh /usr/app/scripts/bootstrap.sh && npm run nodemon-start"]
 
 EXPOSE 8084

--- a/network/docker/docker-compose.dev.yml
+++ b/network/docker/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   network:
     build:
@@ -12,4 +10,4 @@ services:
       - ./${PATH_NETWORK}/../migrations:/usr/app/src/migrations
       - ./${PATH_NETWORK}/../models:/usr/app/src/models
       - ./${PATH_NETWORK}/../cli.js:/usr/app/src/cli.js
-    command: "sh -c '/usr/app/scripts/bootstrap.sh && npm run nodemon-start | bunyan'"
+    command: "sh -c 'sh /usr/app/scripts/bootstrap.sh && npm run nodemon-start | bunyan'"

--- a/network/docker/docker-compose.yml
+++ b/network/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 ### NETWORK     #######################################
 services:
     postgres-network:
@@ -55,5 +54,5 @@ volumes:
 
 networks:
     default:
-        external:
-            name: OMS
+        name: OMS
+        external: true

--- a/network/docker/network/Dockerfile
+++ b/network/docker/network/Dockerfile
@@ -34,6 +34,6 @@ RUN npm install -g nodemon@3.1.4 \
  && npm install -g bunyan@1.8.15 \
  && npm cache clean --force
 
-CMD ["sh", "-c", "sh /usr/app/scripts/bootstrap.sh && nodemon -e js,json lib/run.js"]
+CMD ["sh", "-c", "sh /usr/app/scripts/bootstrap.sh && npm run nodemon-start"]
 
 EXPOSE 8084

--- a/network/package.json
+++ b/network/package.json
@@ -5,7 +5,7 @@
   "main": "lib/run.js",
   "scripts": {
     "start": "nodemon -L -e 'js,json' lib/run.js",
-    "nodemon-start": "nodemon -e 'js,json' lib/run.js",
+    "nodemon-start": "nodemon -L -e 'js,json' lib/run.js",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "db:create": "sequelize db:create",

--- a/statutory/docker/docker-compose.dev.yml
+++ b/statutory/docker/docker-compose.dev.yml
@@ -1,12 +1,10 @@
-version: "3.4"
-
 services:
   statutory:
     build:
       context: ./${PATH_STATUTORY}/..
       dockerfile: ./docker/statutory/Dockerfile
     image: aegee/statutory:dev
-    command: sh -c "sh /usr/app/scripts/bootstrap.sh && nodemon -L -e 'js,json' lib/run.js | bunyan --color"
+    command: "sh -c 'sh /usr/app/scripts/bootstrap.sh && npm run nodemon-start | bunyan'"
     volumes:
       - ./${PATH_STATUTORY}/../config:/usr/app/src/config
       - ./${PATH_STATUTORY}/../lib:/usr/app/src/lib

--- a/statutory/docker/docker-compose.yml
+++ b/statutory/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
     postgres-statutory:
         restart: always
@@ -81,5 +80,5 @@ volumes:
 
 networks:
     default:
-        external:
-            name: OMS
+        name: OMS
+        external: true

--- a/statutory/docker/statutory/Dockerfile
+++ b/statutory/docker/statutory/Dockerfile
@@ -34,6 +34,6 @@ RUN npm install -g nodemon@3.1.4 \
  && npm install -g bunyan@1.8.15 \
  && npm cache clean --force
 
-CMD ["sh", "-c", "sh /usr/app/scripts/bootstrap.sh && nodemon -e js,json lib/run.js"]
+CMD ["sh", "-c", "sh /usr/app/scripts/bootstrap.sh && npm run nodemon-start"]
 
 EXPOSE 8084

--- a/statutory/package.json
+++ b/statutory/package.json
@@ -4,6 +4,7 @@
   "description": "Statutory events module for MyAEGEE",
   "main": "lib/server.js",
   "scripts": {
+    "nodemon-start": "nodemon -L -e 'js,json' lib/run.js",
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "db:create": "sequelize db:create",

--- a/summeruniversity/docker/docker-compose.dev.yml
+++ b/summeruniversity/docker/docker-compose.dev.yml
@@ -1,11 +1,10 @@
-version: "3.4"
 services:
     summeruniversity:
         build:
             context: ./${PATH_SUMMERUNIVERSITY}/..
             dockerfile: ./docker/summeruniversity/Dockerfile
         image: aegee/summeruniversity:dev
-        command: sh -c "sh /usr/app/scripts/bootstrap.sh && nodemon -L -e 'js,json' lib/run.js | bunyan"
+        command: "sh -c 'sh /usr/app/scripts/bootstrap.sh && npm run nodemon-start | bunyan'"
         volumes:
             - ./${PATH_SUMMERUNIVERSITY}/../config:/usr/app/src/config
             - ./${PATH_SUMMERUNIVERSITY}/../lib:/usr/app/src/lib

--- a/summeruniversity/docker/docker-compose.yml
+++ b/summeruniversity/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
     postgres-summeruniversity:
         restart: always
@@ -82,5 +81,5 @@ volumes:
 
 networks:
     default:
-        external:
-            name: OMS
+        name: OMS
+        external: true

--- a/summeruniversity/docker/summeruniversity/Dockerfile
+++ b/summeruniversity/docker/summeruniversity/Dockerfile
@@ -34,6 +34,6 @@ RUN npm install -g nodemon@3.1.4 \
  && npm install -g bunyan@1.8.15 \
  && npm cache clean --force
 
-CMD ["sh", "-c", "sh /usr/app/scripts/bootstrap.sh && nodemon -e js,json lib/run.js"]
+CMD ["sh", "-c", "sh /usr/app/scripts/bootstrap.sh && npm run nodemon-start"]
 
 EXPOSE 8084

--- a/summeruniversity/package.json
+++ b/summeruniversity/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "scripts": {
+    "nodemon-start": "nodemon -L -e 'js,json' lib/run.js",
     "test": "NODE_ENV=test npm run db:setup && jest test/api/*.js --runInBand --forceExit",
     "test:ci": "NODE_ENV=test npm run db:setup && jest --runInBand --forceExit",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- Update service Dockerfiles and dev compose commands to use npm `nodemon-start` scripts.
- Remove obsolete Compose version declarations and modernize external OMS network syntax.
- Add or align `nodemon-start` scripts so local Docker startup uses polling consistently.

## Testing
- Not run; PR created from currently staged changes only.