### PR TITLE
build(frontend): update axios

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,7 @@
         "@vue/cli-service": "^4.5.15",
         "@vue/eslint-config-airbnb": "^7.0.0",
         "animate.css": "^4.1.1",
-        "axios": "^1.13.3",
+        "axios": "^1.16.0",
         "buefy": "^0.9.29",
         "chart.js": "^2.9.4",
         "compression-webpack-plugin": "^6.1.1",
@@ -4476,14 +4476,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.3.tgz",
-      "integrity": "sha512-ERT8kdX7DZjtUm7IitEyV7InTHAF42iJuMArIiDIV5YtPanJkgw4hw5Dyg9fh0mihdWNn1GKaeIWErfe56UQ1g==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -14692,10 +14692,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/prr": {
       "version": "1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "@vue/cli-service": "^4.5.15",
     "@vue/eslint-config-airbnb": "^7.0.0",
     "animate.css": "^4.1.1",
-    "axios": "^1.13.3",
+    "axios": "^1.16.0",
     "buefy": "^0.9.29",
     "chart.js": "^2.9.4",
     "compression-webpack-plugin": "^6.1.1",

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -3,6 +3,7 @@ const webpack = require('webpack');
 
 module.exports = {
   lintOnSave: true,
+  transpileDependencies: ['axios'],
   configureWebpack: {
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary
- Upgrade frontend axios to 1.16.0.
- Transpile axios through Vue CLI so Webpack 4 can parse modern syntax in axios sources.

## Verification
- docker compose -f frontend/docker/docker-compose.yml -f frontend/docker/docker-compose.dev.yml build --no-cache frontend
- npx eslint --ext .js,.vue . --format junit --output-file /tmp/opencode/frontend-eslint.xml