### PR TITLE
fix(monorepo): replace request with native fetch wrapper

### DIFF
--- a/core/lib/http.js
+++ b/core/lib/http.js
@@ -1,0 +1,75 @@
+const parseBody = async (response, parseJson) => {
+    const text = await response.text();
+
+    if (!parseJson) {
+        return text;
+    }
+
+    if (!text) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch (err) { // eslint-disable-line no-unused-vars
+        return text;
+    }
+};
+
+const appendQuery = (url, query) => {
+    if (!query) {
+        return url;
+    }
+
+    const requestUrl = new URL(url);
+    for (const [key, value] of Object.entries(query)) {
+        if (Array.isArray(value)) {
+            value.forEach((item) => requestUrl.searchParams.append(key, item));
+        } else if (typeof value === 'object' && value !== null) {
+            for (const [nestedKey, nestedValue] of Object.entries(value)) {
+                requestUrl.searchParams.append(`${key}[${nestedKey}]`, nestedValue);
+            }
+        } else {
+            requestUrl.searchParams.append(key, value);
+        }
+    }
+
+    return requestUrl.toString();
+};
+
+module.exports.request = async (options) => {
+    const parseJson = options.json !== false;
+    const headers = { ...(options.headers || {}) };
+    const fetchOptions = {
+        method: options.method || 'GET',
+        headers
+    };
+
+    if (options.body !== undefined) {
+        if (parseJson) {
+            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+            fetchOptions.body = JSON.stringify(options.body);
+        } else {
+            fetchOptions.body = options.body;
+        }
+    }
+
+    if (options.form) {
+        headers['Content-Type'] = headers['Content-Type'] || 'application/x-www-form-urlencoded';
+        fetchOptions.body = new URLSearchParams(options.form).toString();
+    }
+
+    const response = await fetch(appendQuery(options.url, options.qs), fetchOptions);
+    const body = await parseBody(response, parseJson);
+
+    if (options.resolveWithFullResponse) {
+        return {
+            statusCode: response.status,
+            statusMessage: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body
+        };
+    }
+
+    return body;
+};

--- a/core/lib/http.js
+++ b/core/lib/http.js
@@ -1,9 +1,5 @@
-const parseBody = async (response, parseJson) => {
+const parseBody = async (response) => {
     const text = await response.text();
-
-    if (!parseJson) {
-        return text;
-    }
 
     if (!text) {
         return null;
@@ -38,7 +34,6 @@ const appendQuery = (url, query) => {
 };
 
 module.exports.request = async (options) => {
-    const parseJson = options.json !== false;
     const headers = { ...(options.headers || {}) };
     const fetchOptions = {
         method: options.method || 'GET',
@@ -46,12 +41,8 @@ module.exports.request = async (options) => {
     };
 
     if (options.body !== undefined) {
-        if (parseJson) {
-            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
-            fetchOptions.body = JSON.stringify(options.body);
-        } else {
-            fetchOptions.body = options.body;
-        }
+        headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+        fetchOptions.body = JSON.stringify(options.body);
     }
 
     if (options.form) {
@@ -60,9 +51,9 @@ module.exports.request = async (options) => {
     }
 
     const response = await fetch(appendQuery(options.url, options.qs), fetchOptions);
-    const body = await parseBody(response, parseJson);
+    const body = await parseBody(response);
 
-    if (options.resolveWithFullResponse) {
+    if (options.fullResponse) {
         return {
             statusCode: response.status,
             statusMessage: response.statusText,

--- a/core/lib/mailer.js
+++ b/core/lib/mailer.js
@@ -14,8 +14,6 @@ module.exports.sendMail = async (options) => {
     const mailerBody = await request({
         url: config.mailer.url + ':' + config.mailer.port + '/',
         method: 'POST',
-        simple: false,
-        json: true,
         body: {
             from: options.from,
             to: options.to,

--- a/core/lib/mailer.js
+++ b/core/lib/mailer.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const { request } = require('./http');
 
 const config = require('../config');
 

--- a/core/middlewares/members.js
+++ b/core/middlewares/members.js
@@ -1,6 +1,6 @@
 const moment = require('moment');
 const _ = require('lodash');
-const request = require('request-promise-native');
+const { request } = require('../lib/http');
 
 const { User, Body, BodyMembership, MailChange, MailConfirmation } = require('../models');
 const config = require('../config');

--- a/core/middlewares/members.js
+++ b/core/middlewares/members.js
@@ -347,7 +347,6 @@ exports.subscribeListserv = async (req, res) => {
         await request({
             url: config.listserv_endpoint,
             method: 'POST',
-            simple: false,
             form: {
                 token: config.listserv_token,
                 email: req.user.notification_email,

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -27,8 +27,6 @@
         "pg": "^8.20.0",
         "prom-client": "^15.1.3",
         "read-chunk": "^3.2.0",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "sequelize": "^6.37.8",
         "sequelize-cli": "^6.6.3"
       },
@@ -2064,6 +2062,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2317,24 +2316,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2344,12 +2325,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2375,21 +2350,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "license": "MIT"
     },
     "node_modules/babel-jest": {
       "version": "30.3.0",
@@ -2559,15 +2519,6 @@
       },
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/bintrees": {
@@ -2826,12 +2777,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3087,18 +3032,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -3196,12 +3129,6 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "license": "MIT"
-    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -3231,18 +3158,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/data-view-buffer": {
@@ -3384,15 +3299,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -3490,16 +3396,6 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/editorconfig": {
       "version": "1.0.7",
@@ -4405,31 +4301,18 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -4630,29 +4513,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/forwarded": {
@@ -4955,15 +4815,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -5079,29 +4930,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -5226,21 +5054,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -5819,12 +5632,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -5889,12 +5696,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6667,12 +6468,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6700,16 +6495,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -6723,6 +6513,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -6748,21 +6539,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/keyv": {
@@ -7690,15 +7466,6 @@
         "set-blocking": "^2.0.0"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8081,12 +7848,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT"
-    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
@@ -8421,18 +8182,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -8447,6 +8196,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8637,90 +8387,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "license": "ISC",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "license": "ISC",
-      "dependencies": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
-      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-directory": {
@@ -9569,31 +9235,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stack-generator": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
@@ -9639,15 +9280,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -10096,19 +9728,6 @@
       "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==",
       "license": "MIT"
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -10158,24 +9777,6 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10461,6 +10062,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -10522,20 +10124,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/walker": {

--- a/core/package.json
+++ b/core/package.json
@@ -73,8 +73,6 @@
     "pg": "^8.20.0",
     "prom-client": "^15.1.3",
     "read-chunk": "^3.2.0",
-    "request": "^2.88.2",
-    "request-promise-native": "^1.0.9",
     "sequelize": "^6.37.8",
     "sequelize-cli": "^6.6.3"
   }

--- a/core/test/api/api-requests.test.js
+++ b/core/test/api/api-requests.test.js
@@ -17,7 +17,7 @@ describe('API requests', () => {
 
     test('should fail if endpoint is not found', async () => {
         const res = await request({
-            uri: '/not-existant',
+            path: '/not-existant',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -33,7 +33,7 @@ describe('API requests', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/bodies',
+            path: '/bodies',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: 'garbage'

--- a/core/test/api/authorization.test.js
+++ b/core/test/api/authorization.test.js
@@ -17,7 +17,7 @@ describe('Authorization', () => {
 
     test('should fail if the user is not found', async () => {
         const res = await request({
-            uri: '/login/',
+            path: '/login/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -35,7 +35,7 @@ describe('Authorization', () => {
     test('should fail if the password is wrong', async () => {
         const user = await generator.createUser();
         const res = await request({
-            uri: '/login/',
+            path: '/login/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -53,7 +53,7 @@ describe('Authorization', () => {
     test('should fail if email is empty', async () => {
         await generator.createUser();
         const res = await request({
-            uri: '/login/',
+            path: '/login/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -71,7 +71,7 @@ describe('Authorization', () => {
     test('should fail if the email is not confirmed', async () => {
         const user = await generator.createUser({ password: 'testtest', mail_confirmed_at: null });
         const res = await request({
-            uri: '/login/',
+            path: '/login/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -90,7 +90,7 @@ describe('Authorization', () => {
     // test('should fail if user is not valid', async () => {
     //     const user = await generator.createUser({ password: 'testtest', address: null });
     //     const res = await request({
-    //         uri: '/login/',
+    //         path: '/login/',
     //         method: 'POST',
     //         headers: { 'X-Auth-Token': 'blablabla' },
     //         body: {
@@ -109,7 +109,7 @@ describe('Authorization', () => {
     test('should succeed if everything is okay', async () => {
         const user = await generator.createUser({ password: 'testtest' });
         const res = await request({
-            uri: '/login/',
+            path: '/login/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -128,7 +128,7 @@ describe('Authorization', () => {
     test('should find by username', async () => {
         await generator.createUser({ password: 'testtest', username: 'admin' });
         const res = await request({
-            uri: '/login/',
+            path: '/login/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -147,7 +147,7 @@ describe('Authorization', () => {
     test('should find user when trimming', async () => {
         const user = await generator.createUser({ password: 'testtest' });
         const res = await request({
-            uri: '/login/',
+            path: '/login/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -166,7 +166,7 @@ describe('Authorization', () => {
     test('should find by email case-insensitive', async () => {
         await generator.createUser({ password: 'testtest', email: 'admin@example.com' });
         const res = await request({
-            uri: '/login/',
+            path: '/login/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -185,7 +185,7 @@ describe('Authorization', () => {
     test('should find by username case-insensitive', async () => {
         await generator.createUser({ password: 'testtest', username: 'admin' });
         const res = await request({
-            uri: '/login/',
+            path: '/login/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {

--- a/core/test/api/bodies-creating.test.js
+++ b/core/test/api/bodies-creating.test.js
@@ -24,7 +24,7 @@ describe('Bodies creating', () => {
         const body = generator.generateBody({ code: null });
 
         const res = await request({
-            uri: '/bodies/',
+            path: '/bodies/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body
@@ -44,7 +44,7 @@ describe('Bodies creating', () => {
         const body = generator.generateBody();
 
         const res = await request({
-            uri: '/bodies/',
+            path: '/bodies/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body
@@ -65,7 +65,7 @@ describe('Bodies creating', () => {
         const body = generator.generateBody();
 
         const res = await request({
-            uri: '/bodies/',
+            path: '/bodies/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body
@@ -88,7 +88,7 @@ describe('Bodies creating', () => {
             const body = generator.generateBody({ type, founded_at: null });
 
             const res = await request({
-                uri: '/bodies/',
+                path: '/bodies/',
                 method: 'POST',
                 headers: { 'X-Auth-Token': token.value },
                 body
@@ -112,7 +112,7 @@ describe('Bodies creating', () => {
             const body = generator.generateBody({ type, founded_at: null });
 
             const res = await request({
-                uri: '/bodies/',
+                path: '/bodies/',
                 method: 'POST',
                 headers: { 'X-Auth-Token': token.value },
                 body

--- a/core/test/api/bodies-details.test.js
+++ b/core/test/api/bodies-details.test.js
@@ -20,7 +20,7 @@ describe('Body details', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/bodies/1337',
+            path: '/bodies/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -38,7 +38,7 @@ describe('Body details', () => {
         const body = await generator.createBody({ code: 'xxx' });
 
         const res = await request({
-            uri: '/bodies/xxx',
+            path: '/bodies/xxx',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -57,7 +57,7 @@ describe('Body details', () => {
         const body = await generator.createBody({ code: 'xxx' });
 
         const res = await request({
-            uri: '/bodies/XXX',
+            path: '/bodies/XXX',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -76,7 +76,7 @@ describe('Body details', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id,
+            path: '/bodies/' + body.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -92,7 +92,7 @@ describe('Body details', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id,
+            path: '/bodies/' + body.id,
             method: 'GET'
         });
 
@@ -107,7 +107,7 @@ describe('Body details', () => {
         const body = await generator.createBody({ status: 'deleted' });
 
         const res = await request({
-            uri: '/bodies/' + body.id,
+            path: '/bodies/' + body.id,
             method: 'GET'
         });
 
@@ -124,7 +124,7 @@ describe('Body details', () => {
         const body = await generator.createBody({ status: 'deleted' });
 
         const res = await request({
-            uri: '/bodies/' + body.id,
+            path: '/bodies/' + body.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -144,7 +144,7 @@ describe('Body details', () => {
         const body = await generator.createBody({ status: 'deleted' });
 
         const res = await request({
-            uri: '/bodies/' + body.id,
+            path: '/bodies/' + body.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/bodies-editing.test.js
+++ b/core/test/api/bodies-editing.test.js
@@ -22,7 +22,7 @@ describe('Bodies editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'body' });
 
         const res = await request({
-            uri: '/bodies/1337',
+            path: '/bodies/1337',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { email: 'test@test.io' }
@@ -43,7 +43,7 @@ describe('Bodies editing', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id,
+            path: '/bodies/' + body.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { code: null }
@@ -63,7 +63,7 @@ describe('Bodies editing', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id,
+            path: '/bodies/' + body.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { email: 'invalid' }
@@ -84,7 +84,7 @@ describe('Bodies editing', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id,
+            path: '/bodies/' + body.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { email: 'test@test.io' }
@@ -114,7 +114,7 @@ describe('Bodies editing', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/bodies/' + body.id,
+            path: '/bodies/' + body.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { email: 'test@test.io' }
@@ -145,7 +145,7 @@ describe('Bodies editing', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/bodies/' + body.id,
+            path: '/bodies/' + body.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { email: 'test@test.io', name: 'bbb' }
@@ -169,7 +169,7 @@ describe('Bodies editing', () => {
             const body = await generator.createBody({ type });
 
             const res = await request({
-                uri: '/bodies/' + body.id,
+                path: '/bodies/' + body.id,
                 method: 'PUT',
                 headers: { 'X-Auth-Token': token.value },
                 body: { founded_at: null }
@@ -193,7 +193,7 @@ describe('Bodies editing', () => {
             const body = await generator.createBody({ type });
 
             const res = await request({
-                uri: '/bodies/' + body.id,
+                path: '/bodies/' + body.id,
                 method: 'PUT',
                 headers: { 'X-Auth-Token': token.value },
                 body: { founded_at: null }

--- a/core/test/api/bodies-listing.test.js
+++ b/core/test/api/bodies-listing.test.js
@@ -22,7 +22,7 @@ describe('Bodies list', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies',
+            path: '/bodies',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -49,7 +49,7 @@ describe('Bodies list', () => {
         await generator.createBody({ name: 'CCC' });
 
         const res = await request({
-            uri: '/bodies?limit=1&offset=1', // second one should be returned
+            path: '/bodies?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -74,7 +74,7 @@ describe('Bodies list', () => {
         const secondBody = await generator.createBody({ code: 'BBB' });
 
         const res = await request({
-            uri: '/bodies?sort=code&direction=desc', // second one should be returned
+            path: '/bodies?sort=code&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -98,7 +98,7 @@ describe('Bodies list', () => {
         await generator.createBody({ name: 'BBB' });
 
         const res = await request({
-            uri: '/bodies?query=AAA', // first one should be returned
+            path: '/bodies?query=AAA', // first one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -121,7 +121,7 @@ describe('Bodies list', () => {
         await generator.createBody({ name: 'BBB' });
 
         const res = await request({
-            uri: '/bodies?query=aaa', // first one should be returned
+            path: '/bodies?query=aaa', // first one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -144,7 +144,7 @@ describe('Bodies list', () => {
         await generator.createBody({ name: 'ZZZ', code: 'BBB' });
 
         const res = await request({
-            uri: '/bodies?query=AAA', // first one should be returned
+            path: '/bodies?query=AAA', // first one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -167,7 +167,7 @@ describe('Bodies list', () => {
         await generator.createBody({ name: 'ZZZ', code: 'BBB' });
 
         const res = await request({
-            uri: '/bodies?query=aaa', // first one should be returned
+            path: '/bodies?query=aaa', // first one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -190,7 +190,7 @@ describe('Bodies list', () => {
         await generator.createBody({ name: 'bbb', code: 'bbb' });
 
         const res = await request({
-            uri: '/bodies?query=a', // first one should be returned
+            path: '/bodies?query=a', // first one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -212,7 +212,7 @@ describe('Bodies list', () => {
         await generator.createBody({ status: 'deleted' });
 
         const res = await request({
-            uri: '/bodies',
+            path: '/bodies',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -227,7 +227,7 @@ describe('Bodies list', () => {
 
     test('should return 401 if not authorized on /bodies?all=true', async () => {
         const res = await request({
-            uri: '/bodies?all=true',
+            path: '/bodies?all=true',
             method: 'GET'
         });
 
@@ -242,7 +242,7 @@ describe('Bodies list', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/bodies?all=true',
+            path: '/bodies?all=true',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -262,7 +262,7 @@ describe('Bodies list', () => {
         await generator.createBody({ status: 'deleted' });
 
         const res = await request({
-            uri: '/bodies?all=true',
+            path: '/bodies?all=true',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/bodies-status.test.js
+++ b/core/test/api/bodies-status.test.js
@@ -23,7 +23,7 @@ describe('Bodies status', () => {
         await generator.createPermission({ scope: 'global', action: 'delete', object: 'body' });
 
         const res = await request({
-            uri: '/bodies/1337/status',
+            path: '/bodies/1337/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { active: false }
@@ -44,7 +44,7 @@ describe('Bodies status', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/status',
+            path: '/bodies/' + body.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { status: 'aaa' }
@@ -64,7 +64,7 @@ describe('Bodies status', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/status',
+            path: '/bodies/' + body.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { status: 'aaa' }
@@ -85,7 +85,7 @@ describe('Bodies status', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/status',
+            path: '/bodies/' + body.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { status: 'deleted' }
@@ -107,7 +107,7 @@ describe('Bodies status', () => {
         const body = await generator.createBody({ status: 'deleted' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/status',
+            path: '/bodies/' + body.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { status: 'active' }
@@ -141,7 +141,7 @@ describe('Bodies status', () => {
         await generator.createPayment(body, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/status',
+            path: '/bodies/' + body.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { status: 'deleted' }

--- a/core/test/api/body-campaigns-creating.test.js
+++ b/core/test/api/body-campaigns-creating.test.js
@@ -25,7 +25,7 @@ describe('Campaigns creating', () => {
         const campaign = generator.generateCampaign({ name: '' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns',
+            path: '/bodies/' + body.id + '/campaigns',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: campaign
@@ -48,7 +48,7 @@ describe('Campaigns creating', () => {
         const campaign = generator.generateCampaign();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns',
+            path: '/bodies/' + body.id + '/campaigns',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: campaign
@@ -71,7 +71,7 @@ describe('Campaigns creating', () => {
         const campaign = generator.generateCampaign({ body_id: 1337 });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns',
+            path: '/bodies/' + body.id + '/campaigns',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: campaign
@@ -97,7 +97,7 @@ describe('Campaigns creating', () => {
         const campaign = generator.generateCampaign({ body_id: 1337 });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns',
+            path: '/bodies/' + body.id + '/campaigns',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: campaign
@@ -118,7 +118,7 @@ describe('Campaigns creating', () => {
         const campaign = generator.generateCampaign({ body_id: 1337 });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns',
+            path: '/bodies/' + body.id + '/campaigns',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: campaign

--- a/core/test/api/body-campaigns-deleting.test.js
+++ b/core/test/api/body-campaigns-deleting.test.js
@@ -24,7 +24,7 @@ describe('Body campaigns deleting', () => {
         await generator.createPermission({ scope: 'global', action: 'delete', object: 'campaign' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/1337',
+            path: '/bodies/' + body.id + '/campaigns/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -46,7 +46,7 @@ describe('Body campaigns deleting', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: otherBody.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id,
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -67,7 +67,7 @@ describe('Body campaigns deleting', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id,
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -94,7 +94,7 @@ describe('Body campaigns deleting', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id,
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -116,7 +116,7 @@ describe('Body campaigns deleting', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id,
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/body-campaigns-details.test.js
+++ b/core/test/api/body-campaigns-details.test.js
@@ -21,7 +21,7 @@ describe('Body campaign details', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/1337',
+            path: '/bodies/' + body.id + '/campaigns/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -38,7 +38,7 @@ describe('Body campaign details', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/xxx',
+            path: '/bodies/' + body.id + '/campaigns/xxx',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -58,7 +58,7 @@ describe('Body campaign details', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: otherBody.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id,
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -79,7 +79,7 @@ describe('Body campaign details', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id,
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -104,7 +104,7 @@ describe('Body campaign details', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id,
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -124,7 +124,7 @@ describe('Body campaign details', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id,
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/body-campaigns-editing.test.js
+++ b/core/test/api/body-campaigns-editing.test.js
@@ -23,7 +23,7 @@ describe('Body campaign editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'campaign' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/1337',
+            path: '/bodies/' + body.id + '/campaigns/1337',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { name: 'New name' }
@@ -45,7 +45,7 @@ describe('Body campaign editing', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id,
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { name: '' }
@@ -68,7 +68,7 @@ describe('Body campaign editing', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id,
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { name: 'New name' }
@@ -94,7 +94,7 @@ describe('Body campaign editing', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id,
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { name: 'New name' }
@@ -115,7 +115,7 @@ describe('Body campaign editing', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id,
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { name: 'New name' }

--- a/core/test/api/body-campaigns-listing.test.js
+++ b/core/test/api/body-campaigns-listing.test.js
@@ -23,7 +23,7 @@ describe('Body campaigns listing', () => {
         await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns',
+            path: '/bodies/' + body.id + '/campaigns',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -47,7 +47,7 @@ describe('Body campaigns listing', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns',
+            path: '/bodies/' + body.id + '/campaigns',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -71,7 +71,7 @@ describe('Body campaigns listing', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns',
+            path: '/bodies/' + body.id + '/campaigns',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -97,7 +97,7 @@ describe('Body campaigns listing', () => {
         await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns?limit=1&offset=1', // second one should be returned
+            path: '/bodies/' + body.id + '/campaigns?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -125,7 +125,7 @@ describe('Body campaigns listing', () => {
         const secondCampaign = await generator.createCampaign({ autojoin_body_id: body.id, url: 'bbb' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns?sort=url&direction=desc', // second one should be returned
+            path: '/bodies/' + body.id + '/campaigns?sort=url&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -164,7 +164,7 @@ describe('Body campaigns listing', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns?query=AAA',
+            path: '/bodies/' + body.id + '/campaigns?query=AAA',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -200,7 +200,7 @@ describe('Body campaigns listing', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns?query=aaa',
+            path: '/bodies/' + body.id + '/campaigns?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -236,7 +236,7 @@ describe('Body campaigns listing', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns?query=TEST1',
+            path: '/bodies/' + body.id + '/campaigns?query=TEST1',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -272,7 +272,7 @@ describe('Body campaigns listing', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns?query=test1',
+            path: '/bodies/' + body.id + '/campaigns?query=test1',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -308,7 +308,7 @@ describe('Body campaigns listing', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns?query=TEST1',
+            path: '/bodies/' + body.id + '/campaigns?query=TEST1',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -344,7 +344,7 @@ describe('Body campaigns listing', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns?query=test1',
+            path: '/bodies/' + body.id + '/campaigns?query=test1',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -380,7 +380,7 @@ describe('Body campaigns listing', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns?query=TEST1',
+            path: '/bodies/' + body.id + '/campaigns?query=TEST1',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -416,7 +416,7 @@ describe('Body campaigns listing', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns?query=test1',
+            path: '/bodies/' + body.id + '/campaigns?query=test1',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/body-campaigns-members.test.js
+++ b/core/test/api/body-campaigns-members.test.js
@@ -23,7 +23,7 @@ describe('Body campaign users list', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id + '/members',
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id + '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -45,7 +45,7 @@ describe('Body campaign users list', () => {
         const otherUser = await generator.createUser({ campaign_id: campaign.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id + '/members',
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id + '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -72,7 +72,7 @@ describe('Body campaign users list', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'member' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id + '/members?limit=1&offset=1', // second one should be returned
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id + '/members?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -106,7 +106,7 @@ describe('Body campaign users list', () => {
         const secondUser = await generator.createUser({ first_name: 'bbb', campaign_id: campaign.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/campaigns/' + campaign.id + '/members?sort=first_name&direction=desc', // second one should be returned
+            path: '/bodies/' + body.id + '/campaigns/' + campaign.id + '/members?sort=first_name&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/body-circles-creating.test.js
+++ b/core/test/api/body-circles-creating.test.js
@@ -26,7 +26,7 @@ describe('Body circles creating', () => {
         const circle = generator.generateCircle({ name: '' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/circles/',
+            path: '/bodies/' + body.id + '/circles/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: circle
@@ -50,7 +50,7 @@ describe('Body circles creating', () => {
         const circle = generator.generateCircle();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/circles/',
+            path: '/bodies/' + body.id + '/circles/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: circle
@@ -76,7 +76,7 @@ describe('Body circles creating', () => {
         const circle = generator.generateCircle();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/circles/',
+            path: '/bodies/' + body.id + '/circles/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: circle
@@ -97,7 +97,7 @@ describe('Body circles creating', () => {
         const circle = generator.generateCircle();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/circles/',
+            path: '/bodies/' + body.id + '/circles/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: circle
@@ -119,7 +119,7 @@ describe('Body circles creating', () => {
         const circle = generator.generateCircle({ body_id: 1337 });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/circles/',
+            path: '/bodies/' + body.id + '/circles/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: circle

--- a/core/test/api/body-members-creating.test.js
+++ b/core/test/api/body-members-creating.test.js
@@ -26,7 +26,7 @@ describe('Body members creating', () => {
         const member = generator.generateUser({ first_name: '   ' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/create-member',
+            path: '/bodies/' + body.id + '/create-member',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: member
@@ -49,7 +49,7 @@ describe('Body members creating', () => {
         const member = generator.generateUser();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/create-member',
+            path: '/bodies/' + body.id + '/create-member',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: member
@@ -74,7 +74,7 @@ describe('Body members creating', () => {
         const member = generator.generateUser();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/create-member',
+            path: '/bodies/' + body.id + '/create-member',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: member
@@ -94,7 +94,7 @@ describe('Body members creating', () => {
         const member = generator.generateUser();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/create-member',
+            path: '/bodies/' + body.id + '/create-member',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: member
@@ -116,7 +116,7 @@ describe('Body members creating', () => {
         const member = generator.generateUser({ superadmin: true });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/create-member',
+            path: '/bodies/' + body.id + '/create-member',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: member
@@ -141,7 +141,7 @@ describe('Body members creating', () => {
         const member = generator.generateUser({ superadmin: true });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/create-member',
+            path: '/bodies/' + body.id + '/create-member',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: member
@@ -171,7 +171,7 @@ describe('Body members creating', () => {
         const member = generator.generateUser({ superadmin: true });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/create-member',
+            path: '/bodies/' + body.id + '/create-member',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: member

--- a/core/test/api/body-memberships-creating.test.js
+++ b/core/test/api/body-memberships-creating.test.js
@@ -30,7 +30,7 @@ describe('Body membership creating', () => {
         await generator.createPermission({ scope: 'global', action: 'add_member', object: 'body' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { user_id: 1337 }
@@ -51,7 +51,7 @@ describe('Body membership creating', () => {
         await generator.createPermission({ scope: 'global', action: 'add_member', object: 'body' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { user_id: user.id }
@@ -76,7 +76,7 @@ describe('Body membership creating', () => {
         await generator.createPermission({ scope: 'global', action: 'add_member', object: 'body' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { user_id: user.id }
@@ -114,7 +114,7 @@ describe('Body membership creating', () => {
         const otherUser = await generator.createUser();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { user_id: otherUser.id }
@@ -133,7 +133,7 @@ describe('Body membership creating', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { user_id: user.id }

--- a/core/test/api/body-memberships-deleting-own.test.js
+++ b/core/test/api/body-memberships-deleting-own.test.js
@@ -22,7 +22,7 @@ describe('Body memberships deleting own', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -40,7 +40,7 @@ describe('Body memberships deleting own', () => {
         const membership = await generator.createBodyMembership(body, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -64,7 +64,7 @@ describe('Body memberships deleting own', () => {
         await generator.createBodyMembership(body, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -85,7 +85,7 @@ describe('Body memberships deleting own', () => {
         await generator.createBodyMembership(body, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/body-memberships-deleting.test.js
+++ b/core/test/api/body-memberships-deleting.test.js
@@ -34,7 +34,7 @@ describe('Body memberships deleting', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members/1337',
+            path: '/bodies/' + body.id + '/members/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value },
         });
@@ -58,7 +58,7 @@ describe('Body memberships deleting', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members/' + membership.id,
+            path: '/bodies/' + body.id + '/members/' + membership.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value },
         });
@@ -91,7 +91,7 @@ describe('Body memberships deleting', () => {
         const membership = await generator.createBodyMembership(body, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members/' + membership.id,
+            path: '/bodies/' + body.id + '/members/' + membership.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value },
         });
@@ -123,7 +123,7 @@ describe('Body memberships deleting', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members/' + membership.id,
+            path: '/bodies/' + body.id + '/members/' + membership.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value },
         });
@@ -153,7 +153,7 @@ describe('Body memberships deleting', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members/' + membership.id,
+            path: '/bodies/' + body.id + '/members/' + membership.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value },
         });
@@ -171,7 +171,7 @@ describe('Body memberships deleting', () => {
         const membership = await generator.createBodyMembership(body, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members/' + membership.id,
+            path: '/bodies/' + body.id + '/members/' + membership.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value },
         });

--- a/core/test/api/body-memberships-details.test.js
+++ b/core/test/api/body-memberships-details.test.js
@@ -24,7 +24,7 @@ describe('Body membership details', () => {
         await generator.createPermission({ scope: 'global', action: 'view_members', object: 'body' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members/1337',
+            path: '/bodies/' + body.id + '/members/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -43,7 +43,7 @@ describe('Body membership details', () => {
         await generator.createPermission({ scope: 'global', action: 'view_members', object: 'body' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members/nan',
+            path: '/bodies/' + body.id + '/members/nan',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -62,7 +62,7 @@ describe('Body membership details', () => {
         const membership = await generator.createBodyMembership(body, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members/' + membership.id,
+            path: '/bodies/' + body.id + '/members/' + membership.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -83,7 +83,7 @@ describe('Body membership details', () => {
         const membership = await generator.createBodyMembership(body, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members/' + membership.id,
+            path: '/bodies/' + body.id + '/members/' + membership.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/body-memberships-editing.test.js
+++ b/core/test/api/body-memberships-editing.test.js
@@ -23,7 +23,7 @@ describe('Body membership editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update_member', object: 'body' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members/lalala',
+            path: '/bodies/' + body.id + '/members/lalala',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { email: 'test@test.io' }
@@ -43,7 +43,7 @@ describe('Body membership editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update_member', object: 'body' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members/1337',
+            path: '/bodies/' + body.id + '/members/1337',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { email: 'test@test.io' }
@@ -65,7 +65,7 @@ describe('Body membership editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update_member', object: 'body' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members/' + membership.id,
+            path: '/bodies/' + body.id + '/members/' + membership.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { comment: 'test' }
@@ -91,7 +91,7 @@ describe('Body membership editing', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members/' + membership.id,
+            path: '/bodies/' + body.id + '/members/' + membership.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { comment: 'test' }
@@ -111,7 +111,7 @@ describe('Body membership editing', () => {
         const membership = await generator.createBodyMembership(body, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members/' + membership.id,
+            path: '/bodies/' + body.id + '/members/' + membership.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { comment: 'test' }

--- a/core/test/api/body-memberships-listing-with-permission.test.js
+++ b/core/test/api/body-memberships-listing-with-permission.test.js
@@ -23,9 +23,9 @@ describe('Body memberships list wth permission', () => {
         await generator.createBodyMembership(body, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'GET',
-            qs: { holds_permission: { action: 'action', object: 'object' } },
+            query: { holds_permission: { action: 'action', object: 'object' } },
             headers: { 'X-Auth-Token': token.value }
         });
 
@@ -45,9 +45,9 @@ describe('Body memberships list wth permission', () => {
         await generator.createPermission({ scope: 'global', action: 'view_members', object: 'body' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'GET',
-            qs: { holds_permission: { object: 'object' } },
+            query: { holds_permission: { object: 'object' } },
             headers: { 'X-Auth-Token': token.value }
         });
 
@@ -67,9 +67,9 @@ describe('Body memberships list wth permission', () => {
         await generator.createPermission({ scope: 'global', action: 'view_members', object: 'body' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'GET',
-            qs: { holds_permission: { action: 'action' } },
+            query: { holds_permission: { action: 'action' } },
             headers: { 'X-Auth-Token': token.value }
         });
 
@@ -89,9 +89,9 @@ describe('Body memberships list wth permission', () => {
         await generator.createPermission({ scope: 'global', action: 'view_members', object: 'body' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'GET',
-            qs: { holds_permission: { action: 'action', object: 'object' } },
+            query: { holds_permission: { action: 'action', object: 'object' } },
             headers: { 'X-Auth-Token': token.value }
         });
 
@@ -116,9 +116,9 @@ describe('Body memberships list wth permission', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'GET',
-            qs: { holds_permission: { action: 'action', object: 'object' } },
+            query: { holds_permission: { action: 'action', object: 'object' } },
             headers: { 'X-Auth-Token': token.value }
         });
 
@@ -150,9 +150,9 @@ describe('Body memberships list wth permission', () => {
         await generator.createCirclePermission(firstCircle, permission);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'GET',
-            qs: { holds_permission: { action: 'action', object: 'object' } },
+            query: { holds_permission: { action: 'action', object: 'object' } },
             headers: { 'X-Auth-Token': token.value }
         });
 
@@ -187,9 +187,9 @@ describe('Body memberships list wth permission', () => {
         await generator.createCircleMembership(otherCircle, otherUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'GET',
-            qs: { holds_permission: { action: 'action', object: 'object' } },
+            query: { holds_permission: { action: 'action', object: 'object' } },
             headers: { 'X-Auth-Token': token.value }
         });
 

--- a/core/test/api/body-memberships-listing.test.js
+++ b/core/test/api/body-memberships-listing.test.js
@@ -25,7 +25,7 @@ describe('Body memberships list', () => {
         await generator.createPermission({ scope: 'global', action: 'view_members', object: 'body' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -55,7 +55,7 @@ describe('Body memberships list', () => {
         await generator.createBodyMembership(body, thirdUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members?limit=1&offset=1', // second one should be returned
+            path: '/bodies/' + body.id + '/members?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -86,7 +86,7 @@ describe('Body memberships list', () => {
         await generator.createPermission({ scope: 'global', action: 'view_members', object: 'body' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members?sort=id&direction=desc', // second one should be returned
+            path: '/bodies/' + body.id + '/members?sort=id&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -115,7 +115,7 @@ describe('Body memberships list', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -134,7 +134,7 @@ describe('Body memberships list', () => {
         await generator.createBodyMembership(body, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members',
+            path: '/bodies/' + body.id + '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -167,7 +167,7 @@ describe('Body memberships list', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members?query=aaa',
+            path: '/bodies/' + body.id + '/members?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -203,7 +203,7 @@ describe('Body memberships list', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members?query=aaa',
+            path: '/bodies/' + body.id + '/members?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -239,7 +239,7 @@ describe('Body memberships list', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/members?query=aaa',
+            path: '/bodies/' + body.id + '/members?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/body-payments-creating.test.js
+++ b/core/test/api/body-payments-creating.test.js
@@ -28,7 +28,7 @@ describe('Body payments creating', () => {
         const payment = generator.generatePayment({}, {}, { user_id: 1337 });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments',
+            path: '/bodies/' + body.id + '/payments',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: payment
@@ -52,7 +52,7 @@ describe('Body payments creating', () => {
         const payment = generator.generatePayment(body, otherUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments',
+            path: '/bodies/' + body.id + '/payments',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: payment
@@ -75,7 +75,7 @@ describe('Body payments creating', () => {
         const payment = generator.generatePayment(body, otherUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments',
+            path: '/bodies/' + body.id + '/payments',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: payment
@@ -100,7 +100,7 @@ describe('Body payments creating', () => {
         const payment = generator.generatePayment(body, otherUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments',
+            path: '/bodies/' + body.id + '/payments',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: payment
@@ -130,7 +130,7 @@ describe('Body payments creating', () => {
         const payment = generator.generatePayment(body, otherUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments',
+            path: '/bodies/' + body.id + '/payments',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: payment
@@ -156,7 +156,7 @@ describe('Body payments creating', () => {
         const payment = generator.generatePayment(body, otherUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments',
+            path: '/bodies/' + body.id + '/payments',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: payment

--- a/core/test/api/body-payments-deleting.test.js
+++ b/core/test/api/body-payments-deleting.test.js
@@ -27,7 +27,7 @@ describe('Body payments deleting', () => {
         await generator.createPermission({ scope: 'global', action: 'delete', object: 'payment' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments/1337',
+            path: '/bodies/' + body.id + '/payments/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -49,7 +49,7 @@ describe('Body payments deleting', () => {
         const payment = await generator.createPayment(body, otherUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments/' + payment.id,
+            path: '/bodies/' + body.id + '/payments/' + payment.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -73,7 +73,7 @@ describe('Body payments deleting', () => {
         const payment = await generator.createPayment(body, otherUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments/' + payment.id,
+            path: '/bodies/' + body.id + '/payments/' + payment.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -104,7 +104,7 @@ describe('Body payments deleting', () => {
         const payment = await generator.createPayment(body, otherUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments/' + payment.id,
+            path: '/bodies/' + body.id + '/payments/' + payment.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/body-payments-editing.test.js
+++ b/core/test/api/body-payments-editing.test.js
@@ -26,7 +26,7 @@ describe('Body payments editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'payment' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments/1337',
+            path: '/bodies/' + body.id + '/payments/1337',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { amount: 1 }
@@ -49,7 +49,7 @@ describe('Body payments editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'payment' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments/lalala',
+            path: '/bodies/' + body.id + '/payments/lalala',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { amount: 1 }
@@ -72,7 +72,7 @@ describe('Body payments editing', () => {
         const payment = await generator.createPayment(body, otherUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments/' + payment.id,
+            path: '/bodies/' + body.id + '/payments/' + payment.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { amount: 1 }
@@ -97,7 +97,7 @@ describe('Body payments editing', () => {
         const payment = await generator.createPayment(body, otherUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments/' + payment.id,
+            path: '/bodies/' + body.id + '/payments/' + payment.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { amount: 1 }
@@ -127,7 +127,7 @@ describe('Body payments editing', () => {
         const payment = await generator.createPayment(body, otherUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments/' + payment.id,
+            path: '/bodies/' + body.id + '/payments/' + payment.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { amount: 1 }
@@ -153,7 +153,7 @@ describe('Body payments editing', () => {
         const payment = await generator.createPayment(body, otherUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments/' + payment.id,
+            path: '/bodies/' + body.id + '/payments/' + payment.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { amount: -1 }
@@ -179,7 +179,7 @@ describe('Body payments editing', () => {
         const payment = await generator.createPayment(body, otherUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments/' + payment.id,
+            path: '/bodies/' + body.id + '/payments/' + payment.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { body_id: 1337, user_id: 1337 }

--- a/core/test/api/body-payments-listing.test.js
+++ b/core/test/api/body-payments-listing.test.js
@@ -25,7 +25,7 @@ describe('Body payments list', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'payment' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments',
+            path: '/bodies/' + body.id + '/payments',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -55,7 +55,7 @@ describe('Body payments list', () => {
         await generator.createPayment(body, thirdUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments?limit=1&offset=1', // second one should be returned
+            path: '/bodies/' + body.id + '/payments?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -86,7 +86,7 @@ describe('Body payments list', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'payment' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments?sort=id&direction=desc', // second one should be returned
+            path: '/bodies/' + body.id + '/payments?sort=id&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -115,7 +115,7 @@ describe('Body payments list', () => {
         await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments',
+            path: '/bodies/' + body.id + '/payments',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -136,7 +136,7 @@ describe('Body payments list', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/payments',
+            path: '/bodies/' + body.id + '/payments',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/campaigns-creating.test.js
+++ b/core/test/api/campaigns-creating.test.js
@@ -24,7 +24,7 @@ describe('Campaigns creating', () => {
         const campaign = generator.generateCampaign({ name: '' });
 
         const res = await request({
-            uri: '/campaigns/',
+            path: '/campaigns/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: campaign
@@ -44,7 +44,7 @@ describe('Campaigns creating', () => {
         const campaign = generator.generateCampaign();
 
         const res = await request({
-            uri: '/campaigns/',
+            path: '/campaigns/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: campaign
@@ -65,7 +65,7 @@ describe('Campaigns creating', () => {
         const campaign = generator.generateCampaign();
 
         const res = await request({
-            uri: '/campaigns/',
+            path: '/campaigns/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: campaign

--- a/core/test/api/campaigns-deleting.test.js
+++ b/core/test/api/campaigns-deleting.test.js
@@ -23,7 +23,7 @@ describe('Campaigns deleting', () => {
         await generator.createPermission({ scope: 'global', action: 'delete', object: 'campaign' });
 
         const res = await request({
-            uri: '/campaigns/1337',
+            path: '/campaigns/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -41,7 +41,7 @@ describe('Campaigns deleting', () => {
         const campaign = await generator.createCampaign();
 
         const res = await request({
-            uri: '/campaigns/' + campaign.id,
+            path: '/campaigns/' + campaign.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -61,7 +61,7 @@ describe('Campaigns deleting', () => {
         await generator.createPermission({ scope: 'global', action: 'delete', object: 'campaign' });
 
         const res = await request({
-            uri: '/campaigns/' + campaign.id,
+            path: '/campaigns/' + campaign.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/campaigns-details.test.js
+++ b/core/test/api/campaigns-details.test.js
@@ -22,7 +22,7 @@ describe('Campaign details', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'campaign' });
 
         const res = await request({
-            uri: '/campaigns/1337',
+            path: '/campaigns/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -40,7 +40,7 @@ describe('Campaign details', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'campaign' });
 
         const res = await request({
-            uri: '/campaigns/xxx',
+            path: '/campaigns/xxx',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -58,7 +58,7 @@ describe('Campaign details', () => {
         const campaign = await generator.createCampaign();
 
         const res = await request({
-            uri: '/campaigns/' + campaign.id,
+            path: '/campaigns/' + campaign.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -77,7 +77,7 @@ describe('Campaign details', () => {
         const campaign = await generator.createCampaign({ autojoin_body_id: body.id });
 
         const res = await request({
-            uri: '/campaigns/' + campaign.id,
+            path: '/campaigns/' + campaign.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -99,7 +99,7 @@ describe('Campaign details', () => {
         const campaign = await generator.createCampaign();
 
         const res = await request({
-            uri: '/campaigns/' + campaign.id,
+            path: '/campaigns/' + campaign.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -120,7 +120,7 @@ describe('Campaign details', () => {
         const campaign = await generator.createCampaign();
 
         const res = await request({
-            uri: '/campaigns/' + campaign.url,
+            path: '/campaigns/' + campaign.url,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/campaigns-editing.test.js
+++ b/core/test/api/campaigns-editing.test.js
@@ -22,7 +22,7 @@ describe('Campaign editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'campaign' });
 
         const res = await request({
-            uri: '/campaigns/1337',
+            path: '/campaigns/1337',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { name: 'New name' }
@@ -43,7 +43,7 @@ describe('Campaign editing', () => {
         const campaign = await generator.createCampaign();
 
         const res = await request({
-            uri: '/campaigns/' + campaign.id,
+            path: '/campaigns/' + campaign.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { name: '' }
@@ -63,7 +63,7 @@ describe('Campaign editing', () => {
         const campaign = await generator.createCampaign();
 
         const res = await request({
-            uri: '/campaigns/' + campaign.id,
+            path: '/campaigns/' + campaign.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { name: 'New name' }
@@ -84,7 +84,7 @@ describe('Campaign editing', () => {
         const campaign = await generator.createCampaign();
 
         const res = await request({
-            uri: '/campaigns/' + campaign.id,
+            path: '/campaigns/' + campaign.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { name: 'New name' }

--- a/core/test/api/campaigns-listing.test.js
+++ b/core/test/api/campaigns-listing.test.js
@@ -22,7 +22,7 @@ describe('Campaigns list', () => {
         await generator.createCampaign();
 
         const res = await request({
-            uri: '/campaigns',
+            path: '/campaigns',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -42,7 +42,7 @@ describe('Campaigns list', () => {
         const campaign = await generator.createCampaign();
 
         const res = await request({
-            uri: '/campaigns',
+            path: '/campaigns',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -67,7 +67,7 @@ describe('Campaigns list', () => {
         await generator.createCampaign();
 
         const res = await request({
-            uri: '/campaigns?limit=1&offset=1', // second one should be returned
+            path: '/campaigns?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -94,7 +94,7 @@ describe('Campaigns list', () => {
         const secondCampaign = await generator.createCampaign({ url: 'bbb' });
 
         const res = await request({
-            uri: '/campaigns?sort=url&direction=desc', // second one should be returned
+            path: '/campaigns?sort=url&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -131,7 +131,7 @@ describe('Campaigns list', () => {
         });
 
         const res = await request({
-            uri: '/campaigns?query=AAA',
+            path: '/campaigns?query=AAA',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -166,7 +166,7 @@ describe('Campaigns list', () => {
         });
 
         const res = await request({
-            uri: '/campaigns?query=AAA',
+            path: '/campaigns?query=AAA',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -201,7 +201,7 @@ describe('Campaigns list', () => {
         });
 
         const res = await request({
-            uri: '/campaigns?query=AAA',
+            path: '/campaigns?query=AAA',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -236,7 +236,7 @@ describe('Campaigns list', () => {
         });
 
         const res = await request({
-            uri: '/campaigns?query=AAA',
+            path: '/campaigns?query=AAA',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -271,7 +271,7 @@ describe('Campaigns list', () => {
         });
 
         const res = await request({
-            uri: '/campaigns?query=AAA',
+            path: '/campaigns?query=AAA',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -306,7 +306,7 @@ describe('Campaigns list', () => {
         });
 
         const res = await request({
-            uri: '/campaigns?query=AAA',
+            path: '/campaigns?query=AAA',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -341,7 +341,7 @@ describe('Campaigns list', () => {
         });
 
         const res = await request({
-            uri: '/campaigns?query=AAA',
+            path: '/campaigns?query=AAA',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -376,7 +376,7 @@ describe('Campaigns list', () => {
         });
 
         const res = await request({
-            uri: '/campaigns?query=AAA',
+            path: '/campaigns?query=AAA',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/campaigns-members.test.js
+++ b/core/test/api/campaigns-members.test.js
@@ -22,7 +22,7 @@ describe('Campaign users list', () => {
         const campaign = await generator.createCampaign();
 
         const res = await request({
-            uri: '/campaigns/' + campaign.id + '/members',
+            path: '/campaigns/' + campaign.id + '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -43,7 +43,7 @@ describe('Campaign users list', () => {
         const otherUser = await generator.createUser({ campaign_id: campaign.id });
 
         const res = await request({
-            uri: '/campaigns/' + campaign.id + '/members',
+            path: '/campaigns/' + campaign.id + '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -69,7 +69,7 @@ describe('Campaign users list', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'member' });
 
         const res = await request({
-            uri: '/campaigns/' + campaign.id + '/members?limit=1&offset=1', // second one should be returned
+            path: '/campaigns/' + campaign.id + '/members?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -102,7 +102,7 @@ describe('Campaign users list', () => {
         const secondUser = await generator.createUser({ first_name: 'bbb', campaign_id: campaign.id });
 
         const res = await request({
-            uri: '/campaigns/' + campaign.id + '/members?sort=first_name&direction=desc', // second one should be returned
+            path: '/campaigns/' + campaign.id + '/members?sort=first_name&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/campaigns-submission.test.js
+++ b/core/test/api/campaigns-submission.test.js
@@ -26,7 +26,7 @@ describe('Campaign submission', () => {
         const user = generator.generateUser();
 
         const res = await request({
-            uri: '/signup/asdasdas',
+            path: '/signup/asdasdas',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: user
@@ -43,7 +43,7 @@ describe('Campaign submission', () => {
         const user = generator.generateUser();
 
         const res = await request({
-            uri: '/signup/' + campaign.url,
+            path: '/signup/' + campaign.url,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: user
@@ -60,7 +60,7 @@ describe('Campaign submission', () => {
         const user = generator.generateUser({ username: 'not valid username ' });
 
         const res = await request({
-            uri: '/signup/' + campaign.url,
+            path: '/signup/' + campaign.url,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: user
@@ -78,7 +78,7 @@ describe('Campaign submission', () => {
         const user = generator.generateUser({ username: '123' });
 
         const res = await request({
-            uri: '/signup/' + campaign.url,
+            path: '/signup/' + campaign.url,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: user
@@ -96,7 +96,7 @@ describe('Campaign submission', () => {
         const user = generator.generateUser({ first_name: '!@#!@#D' });
 
         const res = await request({
-            uri: '/signup/' + campaign.url,
+            path: '/signup/' + campaign.url,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: user
@@ -114,7 +114,7 @@ describe('Campaign submission', () => {
         const user = generator.generateUser({ last_name: '!@#!@#D' });
 
         const res = await request({
-            uri: '/signup/' + campaign.url,
+            path: '/signup/' + campaign.url,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: user
@@ -132,7 +132,7 @@ describe('Campaign submission', () => {
         const user = generator.generateUser({ email: null });
 
         const res = await request({
-            uri: '/signup/' + campaign.url,
+            path: '/signup/' + campaign.url,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: user
@@ -150,7 +150,7 @@ describe('Campaign submission', () => {
         const user = generator.generateUser({ password: null });
 
         const res = await request({
-            uri: '/signup/' + campaign.url,
+            path: '/signup/' + campaign.url,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: user
@@ -168,7 +168,7 @@ describe('Campaign submission', () => {
         const user = generator.generateUser({ username: null });
 
         const res = await request({
-            uri: '/signup/' + campaign.url,
+            path: '/signup/' + campaign.url,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: user
@@ -186,7 +186,7 @@ describe('Campaign submission', () => {
         const user = generator.generateUser();
 
         const res = await request({
-            uri: '/signup/' + campaign.url,
+            path: '/signup/' + campaign.url,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: user
@@ -204,7 +204,7 @@ describe('Campaign submission', () => {
         const user = generator.generateUser();
 
         const res = await request({
-            uri: '/signup/' + campaign.url,
+            path: '/signup/' + campaign.url,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: user
@@ -230,7 +230,7 @@ describe('Campaign submission', () => {
         const user = generator.generateUser({ superadmin: true });
 
         const res = await request({
-            uri: '/signup/' + campaign.url,
+            path: '/signup/' + campaign.url,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: user
@@ -254,7 +254,7 @@ describe('Campaign submission', () => {
         });
 
         const res = await request({
-            uri: '/signup/' + campaign.url,
+            path: '/signup/' + campaign.url,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: user
@@ -275,7 +275,7 @@ describe('Campaign submission', () => {
         const user = generator.generateUser();
 
         const res = await request({
-            uri: '/signup/' + campaign.url,
+            path: '/signup/' + campaign.url,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: user

--- a/core/test/api/circle-memberships-creating.test.js
+++ b/core/test/api/circle-memberships-creating.test.js
@@ -24,7 +24,7 @@ describe('Circle memberships creating', () => {
         const circle = await generator.createCircle();
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members',
+            path: '/circles/' + circle.id + '/members',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { user_id: 'lalala' }
@@ -45,7 +45,7 @@ describe('Circle memberships creating', () => {
         const circle = await generator.createCircle();
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members',
+            path: '/circles/' + circle.id + '/members',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { user_id: 1337 }
@@ -68,7 +68,7 @@ describe('Circle memberships creating', () => {
         const user = await generator.createUser();
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members',
+            path: '/circles/' + circle.id + '/members',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { user_id: user.id }
@@ -92,7 +92,7 @@ describe('Circle memberships creating', () => {
         await generator.createBodyMembership(body, user);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members',
+            path: '/circles/' + circle.id + '/members',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { user_id: user.id }
@@ -112,7 +112,7 @@ describe('Circle memberships creating', () => {
         const user = await generator.createUser();
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members',
+            path: '/circles/' + circle.id + '/members',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { user_id: user.id }
@@ -134,7 +134,7 @@ describe('Circle memberships creating', () => {
         const user = await generator.createUser();
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members',
+            path: '/circles/' + circle.id + '/members',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { user_id: user.id }
@@ -163,7 +163,7 @@ describe('Circle memberships creating', () => {
         await generator.createBodyMembership(body, user);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members',
+            path: '/circles/' + circle.id + '/members',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { user_id: user.id }

--- a/core/test/api/circle-memberships-deleting-own.test.js
+++ b/core/test/api/circle-memberships-deleting-own.test.js
@@ -22,7 +22,7 @@ describe('Circle memberships deleting own', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members',
+            path: '/circles/' + circle.id + '/members',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -40,7 +40,7 @@ describe('Circle memberships deleting own', () => {
         const membership = await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members',
+            path: '/circles/' + circle.id + '/members',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/circle-memberships-deleting.test.js
+++ b/core/test/api/circle-memberships-deleting.test.js
@@ -24,7 +24,7 @@ describe('Circle memberships deleting', () => {
         await generator.createPermission({ scope: 'global', action: 'delete_members', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members/1337',
+            path: '/circles/' + circle.id + '/members/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -44,7 +44,7 @@ describe('Circle memberships deleting', () => {
         await generator.createPermission({ scope: 'global', action: 'delete_members', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members/' + membership.id,
+            path: '/circles/' + circle.id + '/members/' + membership.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -75,7 +75,7 @@ describe('Circle memberships deleting', () => {
         await generator.createBodyMembership(body, otherUser);
 
         const res = await request({
-            uri: '/circles/' + otherCircle.id + '/members/' + membership.id,
+            path: '/circles/' + otherCircle.id + '/members/' + membership.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -93,7 +93,7 @@ describe('Circle memberships deleting', () => {
         const membership = await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members/' + membership.id,
+            path: '/circles/' + circle.id + '/members/' + membership.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/circle-memberships-details.test.js
+++ b/core/test/api/circle-memberships-details.test.js
@@ -24,7 +24,7 @@ describe('Circle membership details', () => {
         await generator.createPermission({ scope: 'global', action: 'view_members', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members/1337',
+            path: '/circles/' + circle.id + '/members/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -43,7 +43,7 @@ describe('Circle membership details', () => {
         await generator.createPermission({ scope: 'global', action: 'view_members', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members/nan',
+            path: '/circles/' + circle.id + '/members/nan',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -62,7 +62,7 @@ describe('Circle membership details', () => {
         const membership = await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members/' + membership.id,
+            path: '/circles/' + circle.id + '/members/' + membership.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -83,7 +83,7 @@ describe('Circle membership details', () => {
         const membership = await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members/' + membership.id,
+            path: '/circles/' + circle.id + '/members/' + membership.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/circle-memberships-editing.test.js
+++ b/core/test/api/circle-memberships-editing.test.js
@@ -23,7 +23,7 @@ describe('Circle membership editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update_members', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members/lalala',
+            path: '/circles/' + circle.id + '/members/lalala',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { email: 'test@test.io' }
@@ -43,7 +43,7 @@ describe('Circle membership editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update_members', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members/1337',
+            path: '/circles/' + circle.id + '/members/1337',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { email: 'test@test.io' }
@@ -65,7 +65,7 @@ describe('Circle membership editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update_members', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members/' + membership.id,
+            path: '/circles/' + circle.id + '/members/' + membership.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { position: 'test' }
@@ -90,7 +90,7 @@ describe('Circle membership editing', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members/' + membership.id,
+            path: '/circles/' + circle.id + '/members/' + membership.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { comment: 'test' }
@@ -110,7 +110,7 @@ describe('Circle membership editing', () => {
         const membership = await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members/' + membership.id,
+            path: '/circles/' + circle.id + '/members/' + membership.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { comment: 'test' }

--- a/core/test/api/circle-memberships-listing.test.js
+++ b/core/test/api/circle-memberships-listing.test.js
@@ -25,7 +25,7 @@ describe('Circle memberships list', () => {
         await generator.createPermission({ scope: 'global', action: 'view_members', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members',
+            path: '/circles/' + circle.id + '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -55,7 +55,7 @@ describe('Circle memberships list', () => {
         await generator.createCircleMembership(circle, thirdUser);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members?limit=1&offset=1', // second one should be returned
+            path: '/circles/' + circle.id + '/members?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -86,7 +86,7 @@ describe('Circle memberships list', () => {
         await generator.createPermission({ scope: 'global', action: 'view_members', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members?sort=id&direction=desc', // second one should be returned
+            path: '/circles/' + circle.id + '/members?sort=id&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -115,7 +115,7 @@ describe('Circle memberships list', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members',
+            path: '/circles/' + circle.id + '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -134,7 +134,7 @@ describe('Circle memberships list', () => {
         await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members',
+            path: '/circles/' + circle.id + '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -167,7 +167,7 @@ describe('Circle memberships list', () => {
         });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members?query=aaa',
+            path: '/circles/' + circle.id + '/members?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -203,7 +203,7 @@ describe('Circle memberships list', () => {
         });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members?query=aaa',
+            path: '/circles/' + circle.id + '/members?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -239,7 +239,7 @@ describe('Circle memberships list', () => {
         });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/members?query=aaa',
+            path: '/circles/' + circle.id + '/members?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/circles-creating.test.js
+++ b/core/test/api/circles-creating.test.js
@@ -24,7 +24,7 @@ describe('Circles creating', () => {
         const circle = generator.generateCircle({ name: '' });
 
         const res = await request({
-            uri: '/circles/',
+            path: '/circles/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: circle
@@ -46,7 +46,7 @@ describe('Circles creating', () => {
         const circle = generator.generateCircle();
 
         const res = await request({
-            uri: '/circles/',
+            path: '/circles/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: circle
@@ -72,7 +72,7 @@ describe('Circles creating', () => {
         const circle = generator.generateCircle();
 
         const res = await request({
-            uri: '/circles/',
+            path: '/circles/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: circle
@@ -91,7 +91,7 @@ describe('Circles creating', () => {
         const circle = generator.generateCircle();
 
         const res = await request({
-            uri: '/circles/',
+            path: '/circles/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: circle
@@ -113,7 +113,7 @@ describe('Circles creating', () => {
         const circle = generator.generateCircle({ body_id: body.id });
 
         const res = await request({
-            uri: '/circles/',
+            path: '/circles/',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: circle

--- a/core/test/api/circles-deleting.test.js
+++ b/core/test/api/circles-deleting.test.js
@@ -23,7 +23,7 @@ describe('Circles deleting', () => {
         await generator.createPermission({ scope: 'global', action: 'delete', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/1337',
+            path: '/circles/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -43,7 +43,7 @@ describe('Circles deleting', () => {
         await generator.createPermission({ scope: 'global', action: 'delete', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id,
+            path: '/circles/' + circle.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -71,7 +71,7 @@ describe('Circles deleting', () => {
         await generator.createCircleMembership(bodyCircle, user);
 
         const res = await request({
-            uri: '/circles/' + circle.id,
+            path: '/circles/' + circle.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -92,7 +92,7 @@ describe('Circles deleting', () => {
         const circle = await generator.createCircle();
 
         const res = await request({
-            uri: '/circles/' + circle.id,
+            path: '/circles/' + circle.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/circles-details.test.js
+++ b/core/test/api/circles-details.test.js
@@ -20,7 +20,7 @@ describe('Circle details', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/circles/1337',
+            path: '/circles/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -36,7 +36,7 @@ describe('Circle details', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/circles/xxx',
+            path: '/circles/xxx',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -54,7 +54,7 @@ describe('Circle details', () => {
         const circle = await generator.createCircle();
 
         const res = await request({
-            uri: '/circles/' + circle.id,
+            path: '/circles/' + circle.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/circles-editing.test.js
+++ b/core/test/api/circles-editing.test.js
@@ -22,7 +22,7 @@ describe('Circle editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/1337',
+            path: '/circles/1337',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { name: 'New name' }
@@ -43,7 +43,7 @@ describe('Circle editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id,
+            path: '/circles/' + circle.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { name: '' }
@@ -65,7 +65,7 @@ describe('Circle editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id,
+            path: '/circles/' + circle.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { name: 'New name' }
@@ -92,7 +92,7 @@ describe('Circle editing', () => {
         await generator.createCirclePermission(bodyCircle, permission);
 
         const res = await request({
-            uri: '/circles/' + circle.id,
+            path: '/circles/' + circle.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { name: 'New name' }
@@ -112,7 +112,7 @@ describe('Circle editing', () => {
         const circle = await generator.createCircle();
 
         const res = await request({
-            uri: '/circles/' + circle.id,
+            path: '/circles/' + circle.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { name: 'New name' }

--- a/core/test/api/circles-listing.test.js
+++ b/core/test/api/circles-listing.test.js
@@ -22,7 +22,7 @@ describe('Circles list', () => {
         const circle = await generator.createCircle();
 
         const res = await request({
-            uri: '/circles',
+            path: '/circles',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -45,7 +45,7 @@ describe('Circles list', () => {
         await generator.createCircle();
 
         const res = await request({
-            uri: '/circles?limit=1&offset=1', // second one should be returned
+            path: '/circles?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -70,7 +70,7 @@ describe('Circles list', () => {
         const secondCircle = await generator.createCircle({ name: 'bbb' });
 
         const res = await request({
-            uri: '/circles?sort=name&direction=desc', // second one should be returned
+            path: '/circles?sort=name&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -94,7 +94,7 @@ describe('Circles list', () => {
         await generator.createCircle({ name: 'bbb', description: 'zzz' });
 
         const res = await request({
-            uri: '/circles?query=aaa',
+            path: '/circles?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -116,7 +116,7 @@ describe('Circles list', () => {
         await generator.createCircle({ name: 'zzz', description: 'bbb' });
 
         const res = await request({
-            uri: '/circles?query=aaa',
+            path: '/circles?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -138,7 +138,7 @@ describe('Circles list', () => {
         await generator.createCircle({ body_id: body.id });
 
         const res = await request({
-            uri: '/circles',
+            path: '/circles',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -158,7 +158,7 @@ describe('Circles list', () => {
         const circle = await generator.createCircle({ body_id: body.id });
 
         const res = await request({
-            uri: '/circles?all=true',
+            path: '/circles?all=true',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/circles-parent-circle.test.js
+++ b/core/test/api/circles-parent-circle.test.js
@@ -24,7 +24,7 @@ describe('Circle setting parent circle', () => {
         await generator.createPermission({ scope: 'global', action: 'put_parent', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/parent',
+            path: '/circles/' + circle.id + '/parent',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { parent_circle_id: 1337 }
@@ -44,7 +44,7 @@ describe('Circle setting parent circle', () => {
         await generator.createPermission({ scope: 'global', action: 'put_parent', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/parent',
+            path: '/circles/' + circle.id + '/parent',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { parent_circle_id: 'nan' }
@@ -64,7 +64,7 @@ describe('Circle setting parent circle', () => {
         await generator.createPermission({ scope: 'global', action: 'put_parent', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/parent',
+            path: '/circles/' + circle.id + '/parent',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { parent_circle_id: circle.id }
@@ -90,7 +90,7 @@ describe('Circle setting parent circle', () => {
         await generator.createPermission({ scope: 'global', action: 'put_parent', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle1.id + '/parent',
+            path: '/circles/' + circle1.id + '/parent',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { parent_circle_id: circle3.id }
@@ -115,7 +115,7 @@ describe('Circle setting parent circle', () => {
         await generator.createPermission({ scope: 'global', action: 'put_parent', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/parent',
+            path: '/circles/' + circle.id + '/parent',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { parent_circle_id: otherCircle.id }
@@ -141,7 +141,7 @@ describe('Circle setting parent circle', () => {
         await generator.createPermission({ scope: 'global', action: 'put_parent', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + circle3.id + '/parent',
+            path: '/circles/' + circle3.id + '/parent',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { parent_circle_id: circle2.id }
@@ -165,7 +165,7 @@ describe('Circle setting parent circle', () => {
         const circle3 = await generator.createCircle({});
 
         const res = await request({
-            uri: '/circles/' + circle3.id + '/parent',
+            path: '/circles/' + circle3.id + '/parent',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { parent_circle_id: circle2.id }
@@ -187,7 +187,7 @@ describe('Circle setting parent circle', () => {
         await generator.createPermission({ scope: 'global', action: 'put_parent', object: 'circle' });
 
         const res = await request({
-            uri: '/circles/' + otherCircle.id + '/parent',
+            path: '/circles/' + otherCircle.id + '/parent',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { parent_circle_id: null }

--- a/core/test/api/circles-permissions-creating.test.js
+++ b/core/test/api/circles-permissions-creating.test.js
@@ -23,7 +23,7 @@ describe('Circle add permission', () => {
         const permission = await generator.createPermission();
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/permissions',
+            path: '/circles/' + circle.id + '/permissions',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { permission_id: permission.id }
@@ -44,7 +44,7 @@ describe('Circle add permission', () => {
         const circle = await generator.createCircle();
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/permissions',
+            path: '/circles/' + circle.id + '/permissions',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { permission_id: -1 }
@@ -67,7 +67,7 @@ describe('Circle add permission', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/permissions',
+            path: '/circles/' + circle.id + '/permissions',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { permission_id: permission.id }
@@ -89,7 +89,7 @@ describe('Circle add permission', () => {
         const permission = await generator.createPermission();
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/permissions',
+            path: '/circles/' + circle.id + '/permissions',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { permission_id: permission.id }

--- a/core/test/api/circles-permissions-deleting.test.js
+++ b/core/test/api/circles-permissions-deleting.test.js
@@ -24,7 +24,7 @@ describe('Circle add permission', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/permissions/' + permission.id,
+            path: '/circles/' + circle.id + '/permissions/' + permission.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -45,7 +45,7 @@ describe('Circle add permission', () => {
         const permission = await generator.createPermission();
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/permissions/' + permission.id,
+            path: '/circles/' + circle.id + '/permissions/' + permission.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -67,7 +67,7 @@ describe('Circle add permission', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/permissions/' + permission.id,
+            path: '/circles/' + circle.id + '/permissions/' + permission.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/circles-permissions-listing.test.js
+++ b/core/test/api/circles-permissions-listing.test.js
@@ -24,7 +24,7 @@ describe('Circle permissions', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/permissions',
+            path: '/circles/' + circle.id + '/permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -48,7 +48,7 @@ describe('Circle permissions', () => {
         await generator.createCirclePermission(thirdCircle, permission);
 
         const res = await request({
-            uri: '/circles/' + thirdCircle.id + '/permissions',
+            path: '/circles/' + thirdCircle.id + '/permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/join-requests-creating.test.js
+++ b/core/test/api/join-requests-creating.test.js
@@ -28,7 +28,7 @@ describe('Join request creating', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests',
+            path: '/bodies/' + body.id + '/join-requests',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { motivation: 'test' }
@@ -50,7 +50,7 @@ describe('Join request creating', () => {
         await generator.createJoinRequest(body, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests',
+            path: '/bodies/' + body.id + '/join-requests',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { motivation: 'test' }
@@ -78,7 +78,7 @@ describe('Join request creating', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests',
+            path: '/bodies/' + body.id + '/join-requests',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { motivation: 'test' }
@@ -99,7 +99,7 @@ describe('Join request creating', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests',
+            path: '/bodies/' + body.id + '/join-requests',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { motivation: 'test' }
@@ -126,7 +126,7 @@ describe('Join request creating', () => {
         await generator.createBodyMembership(body, otherUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests',
+            path: '/bodies/' + body.id + '/join-requests',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { motivation: 'test' }
@@ -155,7 +155,7 @@ describe('Join request creating', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests',
+            path: '/bodies/' + body.id + '/join-requests',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { motivation: 'test' }
@@ -189,7 +189,7 @@ describe('Join request creating', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests',
+            path: '/bodies/' + body.id + '/join-requests',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { motivation: 'test' }

--- a/core/test/api/join-requests-listing.test.js
+++ b/core/test/api/join-requests-listing.test.js
@@ -26,7 +26,7 @@ describe('Join requests list', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'join_request' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests',
+            path: '/bodies/' + body.id + '/join-requests',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -56,7 +56,7 @@ describe('Join requests list', () => {
         await generator.createJoinRequest(body, thirdUser);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests?limit=1&offset=1', // second one should be returned
+            path: '/bodies/' + body.id + '/join-requests?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -87,7 +87,7 @@ describe('Join requests list', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'join_request' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests?sort=id&direction=desc', // second one should be returned
+            path: '/bodies/' + body.id + '/join-requests?sort=id&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -116,7 +116,7 @@ describe('Join requests list', () => {
         await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests',
+            path: '/bodies/' + body.id + '/join-requests',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -137,7 +137,7 @@ describe('Join requests list', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests',
+            path: '/bodies/' + body.id + '/join-requests',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -163,7 +163,7 @@ describe('Join requests list', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'join_request' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests?query=aaa',
+            path: '/bodies/' + body.id + '/join-requests?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -192,7 +192,7 @@ describe('Join requests list', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'join_request' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests?query=aaa',
+            path: '/bodies/' + body.id + '/join-requests?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -221,7 +221,7 @@ describe('Join requests list', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'join_request' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests?query=aaa',
+            path: '/bodies/' + body.id + '/join-requests?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -257,7 +257,7 @@ describe('Join requests list', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'join_request' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests?status=approved',
+            path: '/bodies/' + body.id + '/join-requests?status=approved',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/join-requests-status.test.js
+++ b/core/test/api/join-requests-status.test.js
@@ -30,7 +30,7 @@ describe('Join request status', () => {
         await generator.createPermission({ scope: 'global', action: 'process', object: 'join_request' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests/lalala/status',
+            path: '/bodies/' + body.id + '/join-requests/lalala/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { status: 'approved' }
@@ -50,7 +50,7 @@ describe('Join request status', () => {
         await generator.createPermission({ scope: 'global', action: 'process', object: 'join_request' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests/1337/status',
+            path: '/bodies/' + body.id + '/join-requests/1337/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { status: 'approved' }
@@ -72,7 +72,7 @@ describe('Join request status', () => {
         await generator.createPermission({ scope: 'global', action: 'process', object: 'join_request' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests/' + joinRequest.id + '/status',
+            path: '/bodies/' + body.id + '/join-requests/' + joinRequest.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { status: 'unknown' }
@@ -98,7 +98,7 @@ describe('Join request status', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests/' + joinRequest.id + '/status',
+            path: '/bodies/' + body.id + '/join-requests/' + joinRequest.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { status: 'rejected' }
@@ -120,7 +120,7 @@ describe('Join request status', () => {
         await generator.createPermission({ scope: 'global', action: 'process', object: 'join_request' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests/' + joinRequest.id + '/status',
+            path: '/bodies/' + body.id + '/join-requests/' + joinRequest.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { status: 'rejected' }
@@ -145,7 +145,7 @@ describe('Join request status', () => {
         await generator.createPermission({ scope: 'global', action: 'process', object: 'join_request' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests/' + joinRequest.id + '/status',
+            path: '/bodies/' + body.id + '/join-requests/' + joinRequest.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { status: 'approved' }
@@ -179,7 +179,7 @@ describe('Join request status', () => {
         await generator.createPermission({ scope: 'global', action: 'process', object: 'join_request' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests/' + joinRequest.id + '/status',
+            path: '/bodies/' + body.id + '/join-requests/' + joinRequest.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { status: 'approved' }
@@ -212,7 +212,7 @@ describe('Join request status', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests/' + joinRequest.id + '/status',
+            path: '/bodies/' + body.id + '/join-requests/' + joinRequest.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { status: 'approved' }
@@ -232,7 +232,7 @@ describe('Join request status', () => {
         const joinRequest = await generator.createJoinRequest(body, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/join-requests/' + joinRequest.id + '/status',
+            path: '/bodies/' + body.id + '/join-requests/' + joinRequest.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { status: 'approved' }

--- a/core/test/api/logged-in.test.js
+++ b/core/test/api/logged-in.test.js
@@ -17,7 +17,7 @@ describe('Logged in middleware', () => {
 
     test('should fail if the token is not provided', async () => {
         const res = await request({
-            uri: '/members/me',
+            path: '/members/me',
             method: 'GET'
         });
 
@@ -29,7 +29,7 @@ describe('Logged in middleware', () => {
 
     test('should fail if the token is invalid', async () => {
         const res = await request({
-            uri: '/members/me',
+            path: '/members/me',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' },
         });
@@ -44,7 +44,7 @@ describe('Logged in middleware', () => {
         const user = await generator.createUser();
         const token = await generator.createAccessToken(user, { expires_at: new Date() });
         const res = await request({
-            uri: '/members/me',
+            path: '/members/me',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value },
         });
@@ -60,7 +60,7 @@ describe('Logged in middleware', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/me',
+            path: '/members/me',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/logout.test.js
+++ b/core/test/api/logout.test.js
@@ -17,7 +17,7 @@ describe('Logout', () => {
 
     test('should fail if the token is not found', async () => {
         const res = await request({
-            uri: '/logout',
+            path: '/logout',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -35,7 +35,7 @@ describe('Logout', () => {
         await generator.createUser();
 
         const res = await request({
-            uri: '/logout',
+            path: '/logout',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {}
@@ -52,7 +52,7 @@ describe('Logout', () => {
         const token = await generator.createRefreshToken(user);
 
         const res = await request({
-            uri: '/logout',
+            path: '/logout',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {

--- a/core/test/api/mail-change-confirmation.test.js
+++ b/core/test/api/mail-change-confirmation.test.js
@@ -19,7 +19,7 @@ describe('Mail change confirm', () => {
 
     test('should return 404 if the mail change is not found', async () => {
         const res = await request({
-            uri: '/confirm-email-change',
+            path: '/confirm-email-change',
             method: 'POST',
             body: { token: '1' }
         });
@@ -32,7 +32,7 @@ describe('Mail change confirm', () => {
 
     test('should return 404 if no token is provided', async () => {
         const res = await request({
-            uri: '/confirm-email-change',
+            path: '/confirm-email-change',
             method: 'POST',
             body: {}
         });
@@ -48,7 +48,7 @@ describe('Mail change confirm', () => {
         const mailChange = await generator.createMailChange(user, { expires_at: new Date() });
 
         const res = await request({
-            uri: '/confirm-email-change',
+            path: '/confirm-email-change',
             method: 'POST',
             body: { token: mailChange.value }
         });
@@ -64,7 +64,7 @@ describe('Mail change confirm', () => {
         const mailChange = await generator.createMailChange(user);
 
         const res = await request({
-            uri: '/confirm-email-change',
+            path: '/confirm-email-change',
             method: 'POST',
             body: { token: mailChange.value }
         });
@@ -86,7 +86,7 @@ describe('Mail change confirm', () => {
         const mailChange = await generator.createMailChange(user);
 
         const res = await request({
-            uri: '/confirm-email-change',
+            path: '/confirm-email-change',
             method: 'POST',
             body: { token: '\t\t\t   \t' + mailChange.value + '\t     \t' }
         });

--- a/core/test/api/mail-confirmation.test.js
+++ b/core/test/api/mail-confirmation.test.js
@@ -20,7 +20,7 @@ describe('Mail confirmation', () => {
 
     test('should fail if the token is not provided', async () => {
         const res = await request({
-            uri: '/confirm-email',
+            path: '/confirm-email',
             method: 'POST',
             body: {}
         });
@@ -33,7 +33,7 @@ describe('Mail confirmation', () => {
 
     test('should fail if the confirmation is not found', async () => {
         const res = await request({
-            uri: '/confirm-email',
+            path: '/confirm-email',
             method: 'POST',
             body: { token: 'test' }
         });
@@ -49,7 +49,7 @@ describe('Mail confirmation', () => {
         const confirmation = await generator.createMailConfirmation(user, { expires_at: moment().subtract(1, 'day').toDate() });
 
         const res = await request({
-            uri: '/confirm-email',
+            path: '/confirm-email',
             method: 'POST',
             body: { token: confirmation.value }
         });
@@ -65,7 +65,7 @@ describe('Mail confirmation', () => {
         const confirmation = await generator.createMailConfirmation(user, { expires_at: moment().add(1, 'day').toDate() });
 
         const res = await request({
-            uri: '/confirm-email',
+            path: '/confirm-email',
             method: 'POST',
             body: { token: confirmation.value }
         });

--- a/core/test/api/metrics.test.js
+++ b/core/test/api/metrics.test.js
@@ -16,9 +16,9 @@ describe('Metrics requests', () => {
         await generator.createBody();
 
         const res = await request({
-            uri: '/metrics',
+            path: '/metrics',
             method: 'GET',
-            json: false
+            responseType: 'text'
         });
 
         expect(res.statusCode).toEqual(200);
@@ -26,9 +26,9 @@ describe('Metrics requests', () => {
 
     test('should return data correctly on /metrics/requests', async () => {
         const res = await request({
-            uri: '/metrics/requests',
+            path: '/metrics/requests',
             method: 'GET',
-            json: false
+            responseType: 'text'
         });
 
         expect(res.statusCode).toEqual(200);

--- a/core/test/api/my-permissions-body.test.js
+++ b/core/test/api/my-permissions-body.test.js
@@ -27,7 +27,7 @@ describe('My permissions for body', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/my_permissions',
+            path: '/bodies/' + body.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -52,7 +52,7 @@ describe('My permissions for body', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/my_permissions',
+            path: '/bodies/' + body.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -79,7 +79,7 @@ describe('My permissions for body', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/my_permissions',
+            path: '/bodies/' + body.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -103,7 +103,7 @@ describe('My permissions for body', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/my_permissions',
+            path: '/bodies/' + body.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -126,7 +126,7 @@ describe('My permissions for body', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/my_permissions',
+            path: '/bodies/' + body.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -152,7 +152,7 @@ describe('My permissions for body', () => {
         await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/my_permissions',
+            path: '/bodies/' + body.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -181,7 +181,7 @@ describe('My permissions for body', () => {
         await generator.createBodyMembership(body, user);
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/my_permissions',
+            path: '/bodies/' + body.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/my-permissions-circles.test.js
+++ b/core/test/api/my-permissions-circles.test.js
@@ -25,7 +25,7 @@ describe('My permissions for circle', () => {
         await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/my_permissions',
+            path: '/circles/' + circle.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -48,7 +48,7 @@ describe('My permissions for circle', () => {
         await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/my_permissions',
+            path: '/circles/' + circle.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -73,7 +73,7 @@ describe('My permissions for circle', () => {
         await generator.createCircleMembership(thirdCircle, user);
 
         const res = await request({
-            uri: '/circles/' + thirdCircle.id + '/my_permissions',
+            path: '/circles/' + thirdCircle.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -95,7 +95,7 @@ describe('My permissions for circle', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/my_permissions',
+            path: '/circles/' + circle.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -116,7 +116,7 @@ describe('My permissions for circle', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/my_permissions',
+            path: '/circles/' + circle.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -142,7 +142,7 @@ describe('My permissions for circle', () => {
         await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/circles/' + circle.id + '/my_permissions',
+            path: '/circles/' + circle.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -171,7 +171,7 @@ describe('My permissions for circle', () => {
         await generator.createBodyMembership(body, user);
 
         const res = await request({
-            uri: '/circles/' + thirdCircle.id + '/my_permissions',
+            path: '/circles/' + thirdCircle.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/my-permissions-global.test.js
+++ b/core/test/api/my-permissions-global.test.js
@@ -25,7 +25,7 @@ describe('My permissions global', () => {
         await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/my_permissions',
+            path: '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -48,7 +48,7 @@ describe('My permissions global', () => {
         await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/my_permissions',
+            path: '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -73,7 +73,7 @@ describe('My permissions global', () => {
         await generator.createCircleMembership(thirdCircle, user);
 
         const res = await request({
-            uri: '/my_permissions',
+            path: '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -95,7 +95,7 @@ describe('My permissions global', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/my_permissions',
+            path: '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -116,7 +116,7 @@ describe('My permissions global', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/my_permissions',
+            path: '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/my-permissions-my-circles.test.js
+++ b/core/test/api/my-permissions-my-circles.test.js
@@ -20,7 +20,7 @@ describe('Listing my circles for permission', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/my_permissions',
+            path: '/my_permissions',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { action: 'action', object: 'object' }
@@ -37,7 +37,7 @@ describe('Listing my circles for permission', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/my_permissions',
+            path: '/my_permissions',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { object: 'object' }
@@ -54,7 +54,7 @@ describe('Listing my circles for permission', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/my_permissions',
+            path: '/my_permissions',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { action: 'action' }
@@ -73,7 +73,7 @@ describe('Listing my circles for permission', () => {
         await generator.createPermission({ scope: 'local', action: 'action', object: 'object' });
 
         const res = await request({
-            uri: '/my_permissions',
+            path: '/my_permissions',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { action: 'action', object: 'object' }
@@ -96,7 +96,7 @@ describe('Listing my circles for permission', () => {
         await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/my_permissions',
+            path: '/my_permissions',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { action: 'action', object: 'object' }
@@ -121,7 +121,7 @@ describe('Listing my circles for permission', () => {
         await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/my_permissions',
+            path: '/my_permissions',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { action: 'action', object: 'object' }
@@ -150,7 +150,7 @@ describe('Listing my circles for permission', () => {
         await generator.createCircleMembership(thirdCircle, user);
 
         const res = await request({
-            uri: '/my_permissions',
+            path: '/my_permissions',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { action: 'action', object: 'object' }
@@ -180,7 +180,7 @@ describe('Listing my circles for permission', () => {
         await generator.createCircleMembership(otherChildCircle, otherUser);
 
         const res = await request({
-            uri: '/my_permissions',
+            path: '/my_permissions',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { action: 'action', object: 'object' }

--- a/core/test/api/my-permissions-user.test.js
+++ b/core/test/api/my-permissions-user.test.js
@@ -27,7 +27,7 @@ describe('My permissions for user', () => {
         const otherUser = await generator.createUser();
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/my_permissions',
+            path: '/members/' + otherUser.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -52,7 +52,7 @@ describe('My permissions for user', () => {
         const otherUser = await generator.createUser();
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/my_permissions',
+            path: '/members/' + otherUser.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -79,7 +79,7 @@ describe('My permissions for user', () => {
         const otherUser = await generator.createUser();
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/my_permissions',
+            path: '/members/' + otherUser.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -103,7 +103,7 @@ describe('My permissions for user', () => {
         const otherUser = await generator.createUser();
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/my_permissions',
+            path: '/members/' + otherUser.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -130,7 +130,7 @@ describe('My permissions for user', () => {
         await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/my_permissions',
+            path: '/members/' + otherUser.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -161,7 +161,7 @@ describe('My permissions for user', () => {
         await generator.createBodyMembership(body, otherUser);
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/my_permissions',
+            path: '/members/' + otherUser.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -189,7 +189,7 @@ describe('My permissions for user', () => {
         await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/my_permissions',
+            path: '/members/' + otherUser.id + '/my_permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/password-confirm.test.js
+++ b/core/test/api/password-confirm.test.js
@@ -19,7 +19,7 @@ describe('Password confirm', () => {
 
     test('should return 404 if the password reset is not found', async () => {
         const res = await request({
-            uri: '/password_confirm',
+            path: '/password_confirm',
             method: 'POST',
             body: { token: '1', password: 'testtest' }
         });
@@ -32,7 +32,7 @@ describe('Password confirm', () => {
 
     test('should return 404 if no token is provided', async () => {
         const res = await request({
-            uri: '/password_confirm',
+            path: '/password_confirm',
             method: 'POST',
             body: {}
         });
@@ -48,7 +48,7 @@ describe('Password confirm', () => {
         const reset = await generator.createPasswordReset(user);
 
         const res = await request({
-            uri: '/password_confirm',
+            path: '/password_confirm',
             method: 'POST',
             body: { token: reset.value }
         });
@@ -65,7 +65,7 @@ describe('Password confirm', () => {
         const reset = await generator.createPasswordReset(user);
 
         const res = await request({
-            uri: '/password_confirm',
+            path: '/password_confirm',
             method: 'POST',
             body: { token: reset.value, password: 'short' }
         });
@@ -82,7 +82,7 @@ describe('Password confirm', () => {
         const reset = await generator.createPasswordReset(user, { expires_at: new Date() });
 
         const res = await request({
-            uri: '/password_confirm',
+            path: '/password_confirm',
             method: 'POST',
             body: { token: reset.value, password: 'short' }
         });
@@ -98,7 +98,7 @@ describe('Password confirm', () => {
         const reset = await generator.createPasswordReset(user);
 
         const res = await request({
-            uri: '/password_confirm',
+            path: '/password_confirm',
             method: 'POST',
             body: { token: reset.value, password: 'testtest' }
         });
@@ -126,7 +126,7 @@ describe('Password confirm', () => {
         const reset = await generator.createPasswordReset(user);
 
         const res = await request({
-            uri: '/password_confirm',
+            path: '/password_confirm',
             method: 'POST',
             body: { token: '\t\t\t   \t' + reset.value + '\t     \t', password: 'testtest' }
         });

--- a/core/test/api/password-reset.test.js
+++ b/core/test/api/password-reset.test.js
@@ -25,7 +25,7 @@ describe('Password reset', () => {
 
     test('should return 404 if the user is not found', async () => {
         const res = await request({
-            uri: '/password_reset',
+            path: '/password_reset',
             method: 'POST',
             body: { email: 'test@test.io' }
         });
@@ -38,7 +38,7 @@ describe('Password reset', () => {
 
     test('should return 404 if no email is provided', async () => {
         const res = await request({
-            uri: '/password_reset',
+            path: '/password_reset',
             method: 'POST',
             body: {}
         });
@@ -53,7 +53,7 @@ describe('Password reset', () => {
         const user = await generator.createUser();
 
         const res = await request({
-            uri: '/password_reset',
+            path: '/password_reset',
             method: 'POST',
             body: { email: user.email }
         });
@@ -71,7 +71,7 @@ describe('Password reset', () => {
         const user = await generator.createUser();
 
         const res = await request({
-            uri: '/password_reset',
+            path: '/password_reset',
             method: 'POST',
             body: { email: '\t\t\t   \t' + user.email + '\t     \t' }
         });
@@ -89,7 +89,7 @@ describe('Password reset', () => {
         const user = await generator.createUser();
 
         const res = await request({
-            uri: '/password_reset',
+            path: '/password_reset',
             method: 'POST',
             body: { email: user.email.toUpperCase() }
         });
@@ -108,7 +108,7 @@ describe('Password reset', () => {
         const existingReset = await generator.createPasswordReset(user);
 
         const res = await request({
-            uri: '/password_reset',
+            path: '/password_reset',
             method: 'POST',
             body: { email: user.email }
         });
@@ -133,7 +133,7 @@ describe('Password reset', () => {
         });
 
         const res = await request({
-            uri: '/password_reset',
+            path: '/password_reset',
             method: 'POST',
             body: { email: user.email }
         });
@@ -151,7 +151,7 @@ describe('Password reset', () => {
         const user = await generator.createUser();
 
         const res = await request({
-            uri: '/password_reset',
+            path: '/password_reset',
             method: 'POST',
             body: { email: user.email }
         });

--- a/core/test/api/permissions-creating.test.js
+++ b/core/test/api/permissions-creating.test.js
@@ -24,7 +24,7 @@ describe('Permissions creating', () => {
         const permission = generator.generatePermission({ scope: '' });
 
         const res = await request({
-            uri: '/permissions',
+            path: '/permissions',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: permission
@@ -44,7 +44,7 @@ describe('Permissions creating', () => {
         const permission = generator.generatePermission();
 
         const res = await request({
-            uri: '/permissions',
+            path: '/permissions',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: permission
@@ -65,7 +65,7 @@ describe('Permissions creating', () => {
         const permission = generator.generatePermission();
 
         const res = await request({
-            uri: '/permissions',
+            path: '/permissions',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: permission

--- a/core/test/api/permissions-deleting.test.js
+++ b/core/test/api/permissions-deleting.test.js
@@ -23,7 +23,7 @@ describe('Permissions deleting', () => {
         await generator.createPermission({ scope: 'global', action: 'delete', object: 'permission' });
 
         const res = await request({
-            uri: '/permissions/1337',
+            path: '/permissions/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -41,7 +41,7 @@ describe('Permissions deleting', () => {
         const permission = await generator.createPermission();
 
         const res = await request({
-            uri: '/permissions/' + permission.id,
+            path: '/permissions/' + permission.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -61,7 +61,7 @@ describe('Permissions deleting', () => {
         const permission = await generator.createPermission();
 
         const res = await request({
-            uri: '/permissions/' + permission.id,
+            path: '/permissions/' + permission.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/permissions-details.test.js
+++ b/core/test/api/permissions-details.test.js
@@ -20,7 +20,7 @@ describe('Permission details', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/permissions/1337',
+            path: '/permissions/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -36,7 +36,7 @@ describe('Permission details', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/permissions/xxx',
+            path: '/permissions/xxx',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -54,7 +54,7 @@ describe('Permission details', () => {
         const permission = await generator.createPermission();
 
         const res = await request({
-            uri: '/permissions/' + permission.id,
+            path: '/permissions/' + permission.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/permissions-editing.test.js
+++ b/core/test/api/permissions-editing.test.js
@@ -22,7 +22,7 @@ describe('Permissions details', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'permission' });
 
         const res = await request({
-            uri: '/permissions/1337',
+            path: '/permissions/1337',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { name: 'New name' }
@@ -43,7 +43,7 @@ describe('Permissions details', () => {
         const permission = await generator.createPermission();
 
         const res = await request({
-            uri: '/permissions/' + permission.id,
+            path: '/permissions/' + permission.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { scope: '' }
@@ -63,7 +63,7 @@ describe('Permissions details', () => {
         const permission = await generator.createPermission();
 
         const res = await request({
-            uri: '/permissions/' + permission.id,
+            path: '/permissions/' + permission.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { scope: 'local' }
@@ -84,7 +84,7 @@ describe('Permissions details', () => {
         const permission = await generator.createPermission();
 
         const res = await request({
-            uri: '/permissions/' + permission.id,
+            path: '/permissions/' + permission.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { scope: 'local' }

--- a/core/test/api/permissions-listing.test.js
+++ b/core/test/api/permissions-listing.test.js
@@ -22,7 +22,7 @@ describe('Permission list', () => {
         const permissions = await generator.createPermission();
 
         const res = await request({
-            uri: '/permissions',
+            path: '/permissions',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -45,7 +45,7 @@ describe('Permission list', () => {
         await generator.createPermission();
 
         const res = await request({
-            uri: '/permissions?limit=1&offset=1', // second one should be returned
+            path: '/permissions?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -70,7 +70,7 @@ describe('Permission list', () => {
         const secondPermission = await generator.createPermission({ action: 'bbb' });
 
         const res = await request({
-            uri: '/permissions?sort=action&direction=desc', // second one should be returned
+            path: '/permissions?sort=action&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -94,7 +94,7 @@ describe('Permission list', () => {
         await generator.createPermission({ scope: 'global', action: 'action2', object: 'object2' });
 
         const res = await request({
-            uri: '/permissions?query=global:action:object',
+            path: '/permissions?query=global:action:object',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -116,7 +116,7 @@ describe('Permission list', () => {
         await generator.createPermission({ description: 'zzz' });
 
         const res = await request({
-            uri: '/permissions?query=test',
+            path: '/permissions?query=test',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/permissions-members.test.js
+++ b/core/test/api/permissions-members.test.js
@@ -20,7 +20,7 @@ describe('Permission members', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/permissions/1337/members',
+            path: '/permissions/1337/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -36,7 +36,7 @@ describe('Permission members', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/permissions/xxx/members',
+            path: '/permissions/xxx/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -54,7 +54,7 @@ describe('Permission members', () => {
         const permission = await generator.createPermission();
 
         const res = await request({
-            uri: '/permissions/' + permission.id + '/members',
+            path: '/permissions/' + permission.id + '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -74,7 +74,7 @@ describe('Permission members', () => {
         const permission = await generator.createPermission();
 
         const res = await request({
-            uri: '/permissions/' + permission.id + '/members',
+            path: '/permissions/' + permission.id + '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -103,7 +103,7 @@ describe('Permission members', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/permissions/' + permission.id + '/members',
+            path: '/permissions/' + permission.id + '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -133,7 +133,7 @@ describe('Permission members', () => {
         await generator.createCirclePermission(circle, permission);
 
         const res = await request({
-            uri: '/permissions/' + permission.id + '/members',
+            path: '/permissions/' + permission.id + '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -166,7 +166,7 @@ describe('Permission members', () => {
         await generator.createCirclePermission(firstCircle, permission);
 
         const res = await request({
-            uri: '/permissions/' + permission.id + '/members',
+            path: '/permissions/' + permission.id + '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/renew.test.js
+++ b/core/test/api/renew.test.js
@@ -17,7 +17,7 @@ describe('Tokens renewal', () => {
 
     test('should fail if the token is not found', async () => {
         const res = await request({
-            uri: '/renew',
+            path: '/renew',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -35,7 +35,7 @@ describe('Tokens renewal', () => {
         const user = await generator.createUser({ mail_confirmed_at: new Date() });
         const refreshToken = await generator.createRefreshToken(user);
         const res = await request({
-            uri: '/renew',
+            path: '/renew',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {

--- a/core/test/api/users-activation.test.js
+++ b/core/test/api/users-activation.test.js
@@ -22,7 +22,7 @@ describe('User activation', () => {
         await generator.createPermission({ scope: 'global', action: 'update_active', object: 'member' });
 
         const res = await request({
-            uri: '/members/1337/active',
+            path: '/members/1337/active',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { active: false }
@@ -41,7 +41,7 @@ describe('User activation', () => {
         await generator.createPermission({ scope: 'global', action: 'update_active', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/active',
+            path: '/members/' + user.id + '/active',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { active: 'aaa' }
@@ -61,7 +61,7 @@ describe('User activation', () => {
         await generator.createPermission({ scope: 'local', action: 'update_active', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/active',
+            path: '/members/' + user.id + '/active',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { active: false }
@@ -79,7 +79,7 @@ describe('User activation', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id + '/active',
+            path: '/members/' + user.id + '/active',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { active: false }
@@ -104,7 +104,7 @@ describe('User activation', () => {
         await generator.createBodyMembership(body, otherUser);
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/active',
+            path: '/members/' + otherUser.id + '/active',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { active: false }
@@ -124,7 +124,7 @@ describe('User activation', () => {
         const otherUser = await generator.createUser();
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/active',
+            path: '/members/' + otherUser.id + '/active',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { active: false }

--- a/core/test/api/users-confirmation.test.js
+++ b/core/test/api/users-confirmation.test.js
@@ -22,7 +22,7 @@ describe('User confirmation', () => {
         await generator.createPermission({ scope: 'global', action: 'confirm', object: 'member' });
 
         const res = await request({
-            uri: '/members/1337/confirm',
+            path: '/members/1337/confirm',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -41,7 +41,7 @@ describe('User confirmation', () => {
         await generator.createMailConfirmation(null, { user_id: user.id });
 
         const res = await request({
-            uri: '/members/' + user.id + '/confirm',
+            path: '/members/' + user.id + '/confirm',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -58,7 +58,7 @@ describe('User confirmation', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id + '/confirm',
+            path: '/members/' + user.id + '/confirm',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/users-deleting.test.js
+++ b/core/test/api/users-deleting.test.js
@@ -23,7 +23,7 @@ describe('User deleting', () => {
         await generator.createPermission({ scope: 'global', action: 'delete', object: 'member' });
 
         const res = await request({
-            uri: '/members/1337',
+            path: '/members/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -41,7 +41,7 @@ describe('User deleting', () => {
         await generator.createPermission({ scope: 'global', action: 'delete', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id,
+            path: '/members/' + user.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -62,7 +62,7 @@ describe('User deleting', () => {
         const otherUser = await generator.createUser();
 
         const res = await request({
-            uri: '/members/' + otherUser.id,
+            path: '/members/' + otherUser.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -85,7 +85,7 @@ describe('User deleting', () => {
         await generator.createCircleMembership(circle, user);
 
         const res = await request({
-            uri: '/members/' + user.id,
+            path: '/members/' + user.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/users-details.test.js
+++ b/core/test/api/users-details.test.js
@@ -22,7 +22,7 @@ describe('User details', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'member' });
 
         const res = await request({
-            uri: '/members/1337',
+            path: '/members/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -40,7 +40,7 @@ describe('User details', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'member' });
 
         const res = await request({
-            uri: '/members/test',
+            path: '/members/test',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -59,7 +59,7 @@ describe('User details', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'member' });
 
         const res = await request({
-            uri: '/members/TEST',
+            path: '/members/TEST',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -78,7 +78,7 @@ describe('User details', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id,
+            path: '/members/' + user.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -95,7 +95,7 @@ describe('User details', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/me',
+            path: '/members/me',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -112,7 +112,7 @@ describe('User details', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id,
+            path: '/members/' + user.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -137,7 +137,7 @@ describe('User details', () => {
         await generator.createJoinRequest(body, otherUser);
 
         const res = await request({
-            uri: '/members/' + otherUser.id,
+            path: '/members/' + otherUser.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -162,7 +162,7 @@ describe('User details', () => {
         await generator.createBodyMembership(body, otherUser);
 
         const res = await request({
-            uri: '/members/' + otherUser.id,
+            path: '/members/' + otherUser.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -183,7 +183,7 @@ describe('User details', () => {
         const otherUser = await generator.createUser();
 
         const res = await request({
-            uri: '/members/' + otherUser.id,
+            path: '/members/' + otherUser.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -202,7 +202,7 @@ describe('User details', () => {
         const otherUser = await generator.createUser();
 
         const res = await request({
-            uri: '/members/' + otherUser.id,
+            path: '/members/' + otherUser.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/users-editing.test.js
+++ b/core/test/api/users-editing.test.js
@@ -22,7 +22,7 @@ describe('User editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/1337',
+            path: '/members/1337',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { username: 'test2' }
@@ -41,7 +41,7 @@ describe('User editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id,
+            path: '/members/' + user.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { username: 'username with spaces' }
@@ -61,7 +61,7 @@ describe('User editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id,
+            path: '/members/' + user.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { username: 'test2' }
@@ -81,7 +81,7 @@ describe('User editing', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id,
+            path: '/members/' + user.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { email: 'test@test.io' }
@@ -99,7 +99,7 @@ describe('User editing', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id,
+            path: '/members/' + user.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { username: 'test2' }
@@ -117,7 +117,7 @@ describe('User editing', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id,
+            path: '/members/' + user.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { username: 'test2' }
@@ -143,7 +143,7 @@ describe('User editing', () => {
         await generator.createBodyMembership(body, otherUser);
 
         const res = await request({
-            uri: '/members/' + otherUser.id,
+            path: '/members/' + otherUser.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { username: 'test2' }
@@ -163,7 +163,7 @@ describe('User editing', () => {
         const otherUser = await generator.createUser();
 
         const res = await request({
-            uri: '/members/' + otherUser.id,
+            path: '/members/' + otherUser.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { username: 'test2' }

--- a/core/test/api/users-email.test.js
+++ b/core/test/api/users-email.test.js
@@ -20,7 +20,7 @@ describe('Users list', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members_email',
+            path: '/members_email',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -37,7 +37,7 @@ describe('Users list', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members_email?query=' + secondUser.id,
+            path: '/members_email?query=' + secondUser.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -53,7 +53,7 @@ describe('Users list', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members_email?query=' + user.id,
+            path: '/members_email?query=' + user.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -75,7 +75,7 @@ describe('Users list', () => {
         await generator.createPermission({ scope: 'global', action: 'mail', object: 'member' });
 
         const res = await request({
-            uri: '/members_email?query=' + secondUser.id,
+            path: '/members_email?query=' + secondUser.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -97,7 +97,7 @@ describe('Users list', () => {
         await generator.createPermission({ scope: 'global', action: 'mail', object: 'member' });
 
         const res = await request({
-            uri: '/members_email?query=' + user.id + ',' + secondUser.id,
+            path: '/members_email?query=' + user.id + ',' + secondUser.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -119,7 +119,7 @@ describe('Users list', () => {
         await generator.createPermission({ scope: 'global', action: 'mail', object: 'member' });
 
         const res = await request({
-            uri: '/members_email?query=a,b',
+            path: '/members_email?query=a,b',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -137,7 +137,7 @@ describe('Users list', () => {
         await generator.createPermission({ scope: 'global', action: 'mail', object: 'member' });
 
         const res = await request({
-            uri: '/members_email?query=' + user.id,
+            path: '/members_email?query=' + user.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/users-image-remove.test.js
+++ b/core/test/api/users-image-remove.test.js
@@ -27,7 +27,7 @@ describe('Users image remove', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id + '/image',
+            path: '/members/' + user.id + '/image',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -43,11 +43,13 @@ describe('Users image remove', () => {
 
         // Uploading
         const firstRequest = await request({
-            uri: '/members/' + user.id + '/upload',
+            path: '/members/' + user.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                head_image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -56,7 +58,7 @@ describe('Users image remove', () => {
         let userFromDb = await User.findByPk(user.id);
 
         const res = await request({
-            uri: '/members/' + user.id + '/image',
+            path: '/members/' + user.id + '/image',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -79,11 +81,13 @@ describe('Users image remove', () => {
         const user = await generator.createUser();
 
         const firstRequest = await request({
-            uri: '/members/' + admin.id + '/upload',
+            path: '/members/' + admin.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                head_image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -92,11 +96,13 @@ describe('Users image remove', () => {
         const adminFromDbBeforeChange = await User.findByPk(admin.id);
 
         const secondRequest = await request({
-            uri: '/members/' + user.id + '/upload',
+            path: '/members/' + user.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/valid_second_image.PNG')
+            files: {
+                head_image: {
+                    path: './test/assets/valid_second_image.PNG'
+                }
             }
         });
 
@@ -105,7 +111,7 @@ describe('Users image remove', () => {
         let userFromDb = await User.findByPk(user.id);
 
         const res = await request({
-            uri: '/members/' + user.id + '/image',
+            path: '/members/' + user.id + '/image',
             method: 'DELETE',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/users-image-upload.test.js
+++ b/core/test/api/users-image-upload.test.js
@@ -27,11 +27,13 @@ describe('Users image upload', () => {
         const token = await generator.createAccessToken(user);
 
         await request({
-            uri: '/members/' + user.id + '/upload',
+            path: '/members/' + user.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                head_image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -43,11 +45,13 @@ describe('Users image upload', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id + '/upload',
+            path: '/members/' + user.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/invalid_image.txt')
+            files: {
+                head_image: {
+                    path: './test/assets/invalid_image.txt'
+                }
             }
         });
 
@@ -62,15 +66,13 @@ describe('Users image upload', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id + '/upload',
+            path: '/members/' + user.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
-            formData: {
+            files: {
                 head_image: {
-                    value: fs.createReadStream('./test/assets/invalid_image.txt'),
-                    options: {
-                        filename: 'image.jpg'
-                    }
+                    path: './test/assets/invalid_image.txt',
+                    filename: 'image.jpg'
                 }
             }
         });
@@ -86,10 +88,10 @@ describe('Users image upload', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id + '/upload',
+            path: '/members/' + user.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
-            formData: {}
+            files: {}
         });
 
         expect(res.statusCode).toEqual(422);
@@ -103,11 +105,13 @@ describe('Users image upload', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id + '/upload',
+            path: '/members/' + user.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                head_image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -126,11 +130,13 @@ describe('Users image upload', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id + '/upload',
+            path: '/members/' + user.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/valid_second_image.PNG')
+            files: {
+                head_image: {
+                    path: './test/assets/valid_second_image.PNG'
+                }
             }
         });
 
@@ -150,11 +156,13 @@ describe('Users image upload', () => {
 
         // Uploading
         const firstRequest = await request({
-            uri: '/members/' + user.id + '/upload',
+            path: '/members/' + user.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                head_image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -163,11 +171,13 @@ describe('Users image upload', () => {
         const userFromDb = await User.findByPk(user.id);
 
         const res = await request({
-            uri: '/members/' + user.id + '/upload',
+            path: '/members/' + user.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                head_image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -186,11 +196,13 @@ describe('Users image upload', () => {
         const user = await generator.createUser();
 
         const firstRequest = await request({
-            uri: '/members/' + admin.id + '/upload',
+            path: '/members/' + admin.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                head_image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -199,11 +211,13 @@ describe('Users image upload', () => {
         const adminFromDbBeforeChange = await User.findByPk(admin.id);
 
         const res = await request({
-            uri: '/members/' + user.id + '/upload',
+            path: '/members/' + user.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/valid_second_image.PNG')
+            files: {
+                head_image: {
+                    path: './test/assets/valid_second_image.PNG'
+                }
             }
         });
 

--- a/core/test/api/users-listing.test.js
+++ b/core/test/api/users-listing.test.js
@@ -20,7 +20,7 @@ describe('Users list', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members',
+            path: '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -38,7 +38,7 @@ describe('Users list', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'member' });
 
         const res = await request({
-            uri: '/members',
+            path: '/members',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -62,7 +62,7 @@ describe('Users list', () => {
         await generator.createPermission({ scope: 'global', action: 'view', object: 'member' });
 
         const res = await request({
-            uri: '/members?limit=1&offset=1', // second one should be returned
+            path: '/members?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -92,7 +92,7 @@ describe('Users list', () => {
         const secondUser = await generator.createUser({ first_name: 'bbb' });
 
         const res = await request({
-            uri: '/members?sort=first_name&direction=desc', // second one should be returned
+            path: '/members?sort=first_name&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -116,7 +116,7 @@ describe('Users list', () => {
         await generator.createUser({ superadmin: true, first_name: 'zzz', last_name: 'zzz', email: 'zzz@test.io' });
 
         const res = await request({
-            uri: '/members?query=aaa',
+            path: '/members?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -138,7 +138,7 @@ describe('Users list', () => {
         await generator.createUser({ superadmin: true, first_name: 'zzz', last_name: 'zzz', email: 'zzz@test.io' });
 
         const res = await request({
-            uri: '/members?query=aaa',
+            path: '/members?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -160,7 +160,7 @@ describe('Users list', () => {
         await generator.createUser({ superadmin: true, first_name: 'zzz', last_name: 'zzz', email: 'zzz@test.io' });
 
         const res = await request({
-            uri: '/members?query=aaa',
+            path: '/members?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/users-listserv.test.js
+++ b/core/test/api/users-listserv.test.js
@@ -28,7 +28,7 @@ describe('User subscribe listserv', () => {
         await generator.createPermission({ scope: 'global', action: 'subscribe', object: 'listserv' });
 
         const res = await request({
-            uri: '/members/1337/listserv',
+            path: '/members/1337/listserv',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { mailinglists: ['ANNOUNCE-L'] }
@@ -47,7 +47,7 @@ describe('User subscribe listserv', () => {
         await generator.createPermission({ scope: 'global', action: 'subscribe', object: 'listserv' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/listserv',
+            path: '/members/' + user.id + '/listserv',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: {}
@@ -66,7 +66,7 @@ describe('User subscribe listserv', () => {
         await generator.createPermission({ scope: 'global', action: 'subscribe', object: 'listserv' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/listserv',
+            path: '/members/' + user.id + '/listserv',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { mailinglists: 'not-valid' }
@@ -85,7 +85,7 @@ describe('User subscribe listserv', () => {
         await generator.createPermission({ scope: 'global', action: 'subscribe', object: 'listserv' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/listserv',
+            path: '/members/' + user.id + '/listserv',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { mailinglists: [] }
@@ -104,7 +104,7 @@ describe('User subscribe listserv', () => {
         await generator.createPermission({ scope: 'global', action: 'subscribe', object: 'listserv' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/listserv',
+            path: '/members/' + user.id + '/listserv',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { mailinglists: ['ANNOUNCE-L', 'BOARDINF-L'] }
@@ -125,7 +125,7 @@ describe('User subscribe listserv', () => {
     //     await generator.createPermission({ scope: 'global', action: 'subscribe', object: 'listserv' });
 
     //     const res = await request({
-    //         uri: '/members/' + user.id + '/listserv',
+    //         path: '/members/' + user.id + '/listserv',
     //         method: 'POST',
     //         headers: { 'X-Auth-Token': token.value },
     //         body: { mailinglists: ['ANNOUNCE-L'] }
@@ -144,7 +144,7 @@ describe('User subscribe listserv', () => {
     //     await generator.createPermission({ scope: 'global', action: 'subscribe', object: 'listserv' });
 
     //     const res = await request({
-    //         uri: '/members/' + user.id + '/listserv',
+    //         path: '/members/' + user.id + '/listserv',
     //         method: 'POST',
     //         headers: { 'X-Auth-Token': token.value },
     //         body: { mailinglists: ['ANNOUNCE-L'] }
@@ -164,7 +164,7 @@ describe('User subscribe listserv', () => {
     //     await generator.createPermission({ scope: 'global', action: 'subscribe', object: 'listserv' });
 
     //     const res = await request({
-    //         uri: '/members/' + user.id + '/listserv',
+    //         path: '/members/' + user.id + '/listserv',
     //         method: 'POST',
     //         headers: { 'X-Auth-Token': token.value },
     //         body: { mailinglists: ['announce-l, AEGEE-L, AeGeEnEwS-l'] }
@@ -182,7 +182,7 @@ describe('User subscribe listserv', () => {
     //     const token = await generator.createAccessToken(user);
 
     //     const res = await request({
-    //         uri: '/members/' + user.id + '/listserv',
+    //         path: '/members/' + user.id + '/listserv',
     //         method: 'POST',
     //         headers: { 'X-Auth-Token': token.value },
     //         body: { mailinglists: ['ANNOUNCE-L'] }
@@ -199,7 +199,7 @@ describe('User subscribe listserv', () => {
     //     const token = await generator.createAccessToken(user);
 
     //     const res = await request({
-    //         uri: '/members/' + user.id + '/listserv',
+    //         path: '/members/' + user.id + '/listserv',
     //         method: 'POST',
     //         headers: { 'X-Auth-Token': token.value },
     //         body: { mailinglists: ['ANNOUNCE-L'] }
@@ -224,7 +224,7 @@ describe('User subscribe listserv', () => {
         await generator.createBodyMembership(body, otherUser);
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/listserv',
+            path: '/members/' + otherUser.id + '/listserv',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { mailinglists: ['ANNOUNCE-L'] }
@@ -243,7 +243,7 @@ describe('User subscribe listserv', () => {
         const otherUser = await generator.createUser();
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/listserv',
+            path: '/members/' + otherUser.id + '/listserv',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
             body: { mailinglists: ['ANNOUNCE-L'] }

--- a/core/test/api/users-mail-change.test.js
+++ b/core/test/api/users-mail-change.test.js
@@ -29,7 +29,7 @@ describe('User mail change', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/1337/email',
+            path: '/members/1337/email',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { new_email: 'test@test.io' }
@@ -48,7 +48,7 @@ describe('User mail change', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/email',
+            path: '/members/' + user.id + '/email',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: {}
@@ -67,7 +67,7 @@ describe('User mail change', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/email',
+            path: '/members/' + user.id + '/email',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { new_email: 'not-valid' }
@@ -89,7 +89,7 @@ describe('User mail change', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/email',
+            path: '/members/' + user.id + '/email',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { new_email: 'test@example.com' }
@@ -108,7 +108,7 @@ describe('User mail change', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/email',
+            path: '/members/' + user.id + '/email',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { new_email: 'test@aegee.eu' }
@@ -127,7 +127,7 @@ describe('User mail change', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/email',
+            path: '/members/' + user.id + '/email',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { new_email: 'test@aegee.org' }
@@ -148,7 +148,7 @@ describe('User mail change', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/email',
+            path: '/members/' + user.id + '/email',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { new_email: 'test@test.io' }
@@ -167,7 +167,7 @@ describe('User mail change', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/email',
+            path: '/members/' + user.id + '/email',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { new_email: 'test@test.io' }
@@ -187,7 +187,7 @@ describe('User mail change', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id + '/email',
+            path: '/members/' + user.id + '/email',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { new_email: 'test@test.io' }
@@ -204,7 +204,7 @@ describe('User mail change', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id + '/email',
+            path: '/members/' + user.id + '/email',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { new_email: 'test@test.io' }
@@ -229,7 +229,7 @@ describe('User mail change', () => {
         await generator.createBodyMembership(body, otherUser);
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/email',
+            path: '/members/' + otherUser.id + '/email',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { new_email: 'test@test.io' }
@@ -248,7 +248,7 @@ describe('User mail change', () => {
         const otherUser = await generator.createUser();
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/email',
+            path: '/members/' + otherUser.id + '/email',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { new_email: 'test@test.io' }

--- a/core/test/api/users-password.test.js
+++ b/core/test/api/users-password.test.js
@@ -23,7 +23,7 @@ describe('User activation', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/1337/password',
+            path: '/members/1337/password',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { old_password: 'testtest', password: 'testtest2' }
@@ -42,7 +42,7 @@ describe('User activation', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/password',
+            path: '/members/' + user.id + '/password',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { old_password: 'not right', password: 'short' }
@@ -61,7 +61,7 @@ describe('User activation', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/password',
+            path: '/members/' + user.id + '/password',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { old_password: 'testtest', password: 'short' }
@@ -81,7 +81,7 @@ describe('User activation', () => {
         await generator.createPermission({ scope: 'local', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/password',
+            path: '/members/' + user.id + '/password',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { old_password: 'testtest', password: 'testtest2' }
@@ -101,7 +101,7 @@ describe('User activation', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id + '/password',
+            path: '/members/' + user.id + '/password',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { old_password: 'testtest', password: 'testtest2' }
@@ -130,7 +130,7 @@ describe('User activation', () => {
         await generator.createBodyMembership(body, otherUser);
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/password',
+            path: '/members/' + otherUser.id + '/password',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { old_password: 'testtest', password: 'testtest2' }
@@ -152,7 +152,7 @@ describe('User activation', () => {
         const otherUser = await generator.createUser({ password: 'testtest', superadmin: true });
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/password',
+            path: '/members/' + otherUser.id + '/password',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { old_password: 'testtest', password: 'testtest2' }

--- a/core/test/api/users-primary-body.test.js
+++ b/core/test/api/users-primary-body.test.js
@@ -23,7 +23,7 @@ describe('User primary body setting', () => {
         await generator.createPermission({ scope: 'global', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/1337/primary-body',
+            path: '/members/1337/primary-body',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { primary_body_id: null }
@@ -43,7 +43,7 @@ describe('User primary body setting', () => {
         await generator.createPermission({ scope: 'local', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/primary-body',
+            path: '/members/' + user.id + '/primary-body',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { primary_body_id: null }
@@ -63,7 +63,7 @@ describe('User primary body setting', () => {
         await generator.createPermission({ scope: 'local', action: 'update', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/primary-body',
+            path: '/members/' + user.id + '/primary-body',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { primary_body_id: 1337 }
@@ -84,7 +84,7 @@ describe('User primary body setting', () => {
         const body = await generator.createBody();
 
         const res = await request({
-            uri: '/members/' + user.id + '/primary-body',
+            path: '/members/' + user.id + '/primary-body',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { primary_body_id: body.id }
@@ -106,7 +106,7 @@ describe('User primary body setting', () => {
         await generator.createBodyMembership(body, user);
 
         const res = await request({
-            uri: '/members/' + user.id + '/primary-body',
+            path: '/members/' + user.id + '/primary-body',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { primary_body_id: body.id }
@@ -125,7 +125,7 @@ describe('User primary body setting', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id + '/primary-body',
+            path: '/members/' + user.id + '/primary-body',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { primary_body_id: null }
@@ -150,7 +150,7 @@ describe('User primary body setting', () => {
         await generator.createBodyMembership(body, otherUser);
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/primary-body',
+            path: '/members/' + otherUser.id + '/primary-body',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { primary_body_id: null }
@@ -171,7 +171,7 @@ describe('User primary body setting', () => {
         const otherUser = await generator.createUser({ primary_body_id: body.id });
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/primary-body',
+            path: '/members/' + otherUser.id + '/primary-body',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { primary_body_id: null }

--- a/core/test/api/users-searching.test.js
+++ b/core/test/api/users-searching.test.js
@@ -20,7 +20,7 @@ describe('Users list', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members_search',
+            path: '/members_search',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -38,7 +38,7 @@ describe('Users list', () => {
         await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
 
         const res = await request({
-            uri: '/members_search',
+            path: '/members_search',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -62,7 +62,7 @@ describe('Users list', () => {
         await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
 
         const res = await request({
-            uri: '/members_search?limit=1&offset=1', // second one should be returned
+            path: '/members_search?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -92,7 +92,7 @@ describe('Users list', () => {
         const secondUser = await generator.createUser({ first_name: 'bbb' });
 
         const res = await request({
-            uri: '/members_search?sort=first_name&direction=desc', // second one should be returned
+            path: '/members_search?sort=first_name&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -116,7 +116,7 @@ describe('Users list', () => {
         await generator.createUser({ superadmin: true, first_name: 'zzz', last_name: 'zzz', email: 'zzz@test.io' });
 
         const res = await request({
-            uri: '/members_search?query=aaa',
+            path: '/members_search?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -138,7 +138,7 @@ describe('Users list', () => {
         await generator.createUser({ superadmin: true, first_name: 'zzz', last_name: 'zzz', email: 'zzz@test.io' });
 
         const res = await request({
-            uri: '/members_search?query=aaa',
+            path: '/members_search?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -160,7 +160,7 @@ describe('Users list', () => {
         await generator.createUser({ superadmin: true, first_name: 'zzz', last_name: 'zzz', email: 'zzz@test.io' });
 
         const res = await request({
-            uri: '/members_search?query=aaa',
+            path: '/members_search?query=aaa',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -181,7 +181,7 @@ describe('Users list', () => {
         await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
 
         const res = await request({
-            uri: '/members_search',
+            path: '/members_search',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -211,7 +211,7 @@ describe('Users list', () => {
         await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
 
         const res = await request({
-            uri: '/members_search',
+            path: '/members_search',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -247,7 +247,7 @@ describe('Users list', () => {
         const memberNotInBody = await generator.createUser();
 
         const res = await request({
-            uri: '/members_search?body_id=' + body.id,
+            path: '/members_search?body_id=' + body.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -278,7 +278,7 @@ describe('Users list', () => {
         const memberNotInAnyBody = await generator.createUser();
 
         const res = await request({
-            uri: '/members_search?body_id=' + body1.id + ',' + body2.id,
+            path: '/members_search?body_id=' + body1.id + ',' + body2.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -305,7 +305,7 @@ describe('Users list', () => {
         await generator.createBodyMembership(body2, memberInBothBodies);
 
         const res = await request({
-            uri: '/members_search?body_id=' + body1.id + ',' + body2.id,
+            path: '/members_search?body_id=' + body1.id + ',' + body2.id,
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -331,7 +331,7 @@ describe('Users list', () => {
         await generator.createBodyMembership(body, nonMatchingMember);
 
         const res = await request({
-            uri: '/members_search?body_id=' + body.id + '&query=TestSearchName',
+            path: '/members_search?body_id=' + body.id + '&query=TestSearchName',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -350,7 +350,7 @@ describe('Users list', () => {
         await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
 
         const res = await request({
-            uri: '/members_search?body_id=invalid,nonsense',
+            path: '/members_search?body_id=invalid,nonsense',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/api/users-superadmin.test.js
+++ b/core/test/api/users-superadmin.test.js
@@ -22,7 +22,7 @@ describe('User superadmin', () => {
         await generator.createPermission({ scope: 'global', action: 'update_superadmin', object: 'member' });
 
         const res = await request({
-            uri: '/members/1337/superadmin',
+            path: '/members/1337/superadmin',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { superadmin: false }
@@ -41,7 +41,7 @@ describe('User superadmin', () => {
         await generator.createPermission({ scope: 'global', action: 'update_superadmin', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/superadmin',
+            path: '/members/' + user.id + '/superadmin',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { superadmin: 'aaa' }
@@ -61,7 +61,7 @@ describe('User superadmin', () => {
         await generator.createPermission({ scope: 'global', action: 'update_superadmin', object: 'member' });
 
         const res = await request({
-            uri: '/members/' + user.id + '/superadmin',
+            path: '/members/' + user.id + '/superadmin',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { superadmin: false }
@@ -79,7 +79,7 @@ describe('User superadmin', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/' + user.id + '/superadmin',
+            path: '/members/' + user.id + '/superadmin',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { superadmin: true }
@@ -104,7 +104,7 @@ describe('User superadmin', () => {
         await generator.createBodyMembership(body, otherUser);
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/superadmin',
+            path: '/members/' + otherUser.id + '/superadmin',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { superadmin: true }
@@ -123,7 +123,7 @@ describe('User superadmin', () => {
         const otherUser = await generator.createUser();
 
         const res = await request({
-            uri: '/members/' + otherUser.id + '/superadmin',
+            path: '/members/' + otherUser.id + '/superadmin',
             method: 'PUT',
             headers: { 'X-Auth-Token': token.value },
             body: { superadmin: true }

--- a/core/test/api/users-unconfirmed-listing.test.js
+++ b/core/test/api/users-unconfirmed-listing.test.js
@@ -20,7 +20,7 @@ describe('Users list', () => {
         const token = await generator.createAccessToken(user);
 
         const res = await request({
-            uri: '/members/unconfirmed',
+            path: '/members/unconfirmed',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });
@@ -40,7 +40,7 @@ describe('Users list', () => {
         const otherUser = await generator.createUser({ mail_confirmed_at: null });
 
         const res = await request({
-            uri: '/members/unconfirmed',
+            path: '/members/unconfirmed',
             method: 'GET',
             headers: { 'X-Auth-Token': token.value }
         });

--- a/core/test/scripts/helpers.js
+++ b/core/test/scripts/helpers.js
@@ -25,28 +25,21 @@ const appendQuery = (url, query) => {
 };
 
 const request = async (options) => {
-    const parseJson = options.json !== false;
+    const responseType = options.responseType || 'json';
     const headers = { ...(options.headers || {}) };
     const fetchOptions = { method: options.method || 'GET', headers };
 
     if (options.body !== undefined) {
-        if (parseJson) {
-            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
-            fetchOptions.body = JSON.stringify(options.body);
-        } else {
-            fetchOptions.body = options.body;
-        }
+        headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+        fetchOptions.body = JSON.stringify(options.body);
     }
 
-    if (options.formData) {
-        const entries = Object.entries(options.formData);
+    if (options.files) {
+        const entries = Object.entries(options.files);
         const formData = new FormData();
         for (const [key, item] of entries) {
-            const value = item && item.value ? item.value : item;
-            const filename = item && item.options && item.options.filename
-                ? item.options.filename
-                : path.basename(value.path);
-            const buffer = fs.readFileSync(value.path);
+            const filename = item.filename || path.basename(item.path);
+            const buffer = fs.readFileSync(item.path);
             formData.append(key, new Blob([buffer]), filename);
         }
         if (entries.length > 0) {
@@ -57,8 +50,8 @@ const request = async (options) => {
         }
     }
 
-    const response = await fetch(appendQuery(new URL(options.uri, baseUrl + '/').toString(), options.qs), fetchOptions);
-    if (options.encoding === null) {
+    const response = await fetch(appendQuery(new URL(options.path, baseUrl + '/').toString(), options.query), fetchOptions);
+    if (responseType === 'buffer') {
         return {
             statusCode: response.status,
             statusMessage: response.statusText,
@@ -70,7 +63,7 @@ const request = async (options) => {
     const text = await response.text();
     let body = text;
 
-    if (parseJson && text) {
+    if (responseType === 'json' && text) {
         try {
             body = JSON.parse(text);
         } catch (err) { // eslint-disable-line no-unused-vars

--- a/core/test/scripts/helpers.js
+++ b/core/test/scripts/helpers.js
@@ -1,12 +1,89 @@
-const requestPromise = require('request-promise-native');
+const fs = require('fs');
+const path = require('path');
 
 const config = require('../../config');
 
-const request = requestPromise.defaults({
-    json: true,
-    resolveWithFullResponse: true,
-    simple: false,
-    baseUrl: 'http://localhost:' + config.port
-});
+const baseUrl = 'http://localhost:' + config.port;
+
+const appendQuery = (url, query) => {
+    if (!query) return url;
+
+    const requestUrl = new URL(url);
+    for (const [key, value] of Object.entries(query)) {
+        if (Array.isArray(value)) {
+            value.forEach((item) => requestUrl.searchParams.append(key, item));
+        } else if (typeof value === 'object' && value !== null) {
+            for (const [nestedKey, nestedValue] of Object.entries(value)) {
+                requestUrl.searchParams.append(`${key}[${nestedKey}]`, nestedValue);
+            }
+        } else {
+            requestUrl.searchParams.append(key, value);
+        }
+    }
+
+    return requestUrl.toString();
+};
+
+const request = async (options) => {
+    const parseJson = options.json !== false;
+    const headers = { ...(options.headers || {}) };
+    const fetchOptions = { method: options.method || 'GET', headers };
+
+    if (options.body !== undefined) {
+        if (parseJson) {
+            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+            fetchOptions.body = JSON.stringify(options.body);
+        } else {
+            fetchOptions.body = options.body;
+        }
+    }
+
+    if (options.formData) {
+        const entries = Object.entries(options.formData);
+        const formData = new FormData();
+        for (const [key, item] of entries) {
+            const value = item && item.value ? item.value : item;
+            const filename = item && item.options && item.options.filename
+                ? item.options.filename
+                : path.basename(value.path);
+            const buffer = fs.readFileSync(value.path);
+            formData.append(key, new Blob([buffer]), filename);
+        }
+        if (entries.length > 0) {
+            fetchOptions.body = formData;
+        } else {
+            headers['Content-Type'] = 'multipart/form-data; boundary=empty-form';
+            fetchOptions.body = '--empty-form\r\n';
+        }
+    }
+
+    const response = await fetch(appendQuery(new URL(options.uri, baseUrl + '/').toString(), options.qs), fetchOptions);
+    if (options.encoding === null) {
+        return {
+            statusCode: response.status,
+            statusMessage: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body: Buffer.from(await response.arrayBuffer())
+        };
+    }
+
+    const text = await response.text();
+    let body = text;
+
+    if (parseJson && text) {
+        try {
+            body = JSON.parse(text);
+        } catch (err) { // eslint-disable-line no-unused-vars
+            body = text;
+        }
+    }
+
+    return {
+        statusCode: response.status,
+        statusMessage: response.statusText,
+        headers: Object.fromEntries(response.headers.entries()),
+        body
+    };
+};
 
 exports.request = request;

--- a/discounts/lib/core.js
+++ b/discounts/lib/core.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const { request } = require('./http');
 
 const config = require('../config');
 

--- a/discounts/lib/core.js
+++ b/discounts/lib/core.js
@@ -11,8 +11,6 @@ module.exports.getMyProfile = async (req) => {
             'X-Auth-Token': req.headers['x-auth-token'],
             'X-Service': 'discounts'
         },
-        simple: false,
-        json: true,
     });
 
     return myProfileBody;
@@ -27,8 +25,6 @@ module.exports.getMyPermissions = async (req) => {
             'X-Auth-Token': req.headers['x-auth-token'],
             'X-Service': 'discounts'
         },
-        simple: false,
-        json: true,
     });
 
     return permissionsBody;

--- a/discounts/lib/http.js
+++ b/discounts/lib/http.js
@@ -1,0 +1,49 @@
+const parseBody = async (response, parseJson) => {
+    const text = await response.text();
+
+    if (!parseJson) {
+        return text;
+    }
+
+    if (!text) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch (err) { // eslint-disable-line no-unused-vars
+        return text;
+    }
+};
+
+module.exports.request = async (options) => {
+    const parseJson = options.json !== false;
+    const headers = { ...(options.headers || {}) };
+    const fetchOptions = {
+        method: options.method || 'GET',
+        headers
+    };
+
+    if (options.body !== undefined) {
+        if (parseJson) {
+            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+            fetchOptions.body = JSON.stringify(options.body);
+        } else {
+            fetchOptions.body = options.body;
+        }
+    }
+
+    const response = await fetch(options.url, fetchOptions);
+    const body = await parseBody(response, parseJson);
+
+    if (options.resolveWithFullResponse) {
+        return {
+            statusCode: response.status,
+            statusMessage: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body
+        };
+    }
+
+    return body;
+};

--- a/discounts/lib/http.js
+++ b/discounts/lib/http.js
@@ -1,9 +1,5 @@
-const parseBody = async (response, parseJson) => {
+const parseBody = async (response) => {
     const text = await response.text();
-
-    if (!parseJson) {
-        return text;
-    }
 
     if (!text) {
         return null;
@@ -17,7 +13,6 @@ const parseBody = async (response, parseJson) => {
 };
 
 module.exports.request = async (options) => {
-    const parseJson = options.json !== false;
     const headers = { ...(options.headers || {}) };
     const fetchOptions = {
         method: options.method || 'GET',
@@ -25,18 +20,14 @@ module.exports.request = async (options) => {
     };
 
     if (options.body !== undefined) {
-        if (parseJson) {
-            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
-            fetchOptions.body = JSON.stringify(options.body);
-        } else {
-            fetchOptions.body = options.body;
-        }
+        headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+        fetchOptions.body = JSON.stringify(options.body);
     }
 
     const response = await fetch(options.url, fetchOptions);
-    const body = await parseBody(response, parseJson);
+    const body = await parseBody(response);
 
-    if (options.resolveWithFullResponse) {
+    if (options.fullResponse) {
         return {
             statusCode: response.status,
             statusMessage: response.statusText,

--- a/discounts/lib/mailer.js
+++ b/discounts/lib/mailer.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const { request } = require('./http');
 
 const config = require('../config');
 

--- a/discounts/lib/mailer.js
+++ b/discounts/lib/mailer.js
@@ -6,8 +6,6 @@ module.exports.sendMail = async (options) => {
     const mailerBody = await request({
         url: config.mailer.url + ':' + config.mailer.port + '/',
         method: 'POST',
-        simple: false,
-        json: true,
         body: {
             from: options.from,
             to: options.to,

--- a/discounts/package-lock.json
+++ b/discounts/package-lock.json
@@ -21,8 +21,6 @@
         "on-finished": "^2.4.1",
         "pg": "^8.20.0",
         "prom-client": "^15.1.3",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "sequelize": "^6.37.8",
         "sequelize-cli": "^6.6.3"
       },
@@ -1990,6 +1988,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2217,24 +2216,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2244,12 +2225,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2275,21 +2250,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "license": "MIT"
     },
     "node_modules/babel-jest": {
       "version": "30.3.0",
@@ -2426,15 +2386,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "node_modules/bintrees": {
       "version": "1.0.2",
@@ -2658,12 +2609,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2902,18 +2847,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -2991,12 +2924,6 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "license": "MIT"
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3009,18 +2936,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/data-view-buffer": {
@@ -3162,15 +3077,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3253,16 +3159,6 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/editorconfig": {
       "version": "1.0.7",
@@ -4136,31 +4032,18 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -4344,29 +4227,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/forwarded": {
@@ -4584,15 +4444,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -4708,29 +4559,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -4849,21 +4677,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/human-signals": {
@@ -5410,12 +5223,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -5480,12 +5287,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6257,12 +6058,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6290,16 +6085,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -6313,6 +6103,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -6338,21 +6129,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/keyv": {
@@ -7154,15 +6930,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -7516,12 +7283,6 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT"
-    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
@@ -7838,18 +7599,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -7864,6 +7613,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7995,90 +7745,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "license": "ISC",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "license": "ISC",
-      "dependencies": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
-      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-directory": {
@@ -8931,31 +8597,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stack-generator": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
@@ -9001,15 +8642,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -9374,19 +9006,6 @@
       "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==",
       "license": "MIT"
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -9430,24 +9049,6 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -9727,6 +9328,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -9782,20 +9384,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/walker": {

--- a/discounts/package.json
+++ b/discounts/package.json
@@ -65,8 +65,6 @@
     "on-finished": "^2.4.1",
     "pg": "^8.20.0",
     "prom-client": "^15.1.3",
-    "request": "^2.88.2",
-    "request-promise-native": "^1.0.9",
     "sequelize": "^6.37.8",
     "sequelize-cli": "^6.6.3"
   }

--- a/discounts/test/api/api-requests.test.js
+++ b/discounts/test/api/api-requests.test.js
@@ -15,7 +15,7 @@ describe('API requests', () => {
 
     test('should fail if X-Auth-Token is not specified', async () => {
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'GET'
         });
 
@@ -27,7 +27,7 @@ describe('API requests', () => {
         mock.mockAll({ core: { netError: true } });
 
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -42,7 +42,7 @@ describe('API requests', () => {
         mock.mockAll({ core: { badResponse: true } });
 
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -57,7 +57,7 @@ describe('API requests', () => {
         mock.mockAll({ core: { unauthorized: true } });
 
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -72,7 +72,7 @@ describe('API requests', () => {
         mock.mockAll({ mainPermissions: { netError: true } });
 
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -87,7 +87,7 @@ describe('API requests', () => {
         mock.mockAll({ mainPermissions: { badResponse: true } });
 
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -102,7 +102,7 @@ describe('API requests', () => {
         mock.mockAll({ mainPermissions: { unauthorized: true } });
 
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -115,7 +115,7 @@ describe('API requests', () => {
 
     test('should fail if body is not JSON', async () => {
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'POST',
             headers: {
                 'X-Auth-Token': 'blablabla',
@@ -130,7 +130,7 @@ describe('API requests', () => {
 
     test('should fail on accessing non-existant endpoint', async () => {
         const res = await request({
-            uri: '/nonexistant',
+            path: '/nonexistant',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/discounts/test/api/categories-creation.test.js
+++ b/discounts/test/api/categories-creation.test.js
@@ -20,7 +20,7 @@ describe('Categories creation', () => {
     test('should fail if user does not have rights', async () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
         const res = await request({
-            uri: '/categories',
+            path: '/categories',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateCategory()
@@ -43,7 +43,7 @@ describe('Categories creation', () => {
             ]
         });
         const res = await request({
-            uri: '/categories',
+            path: '/categories',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: category
@@ -74,7 +74,7 @@ describe('Categories creation', () => {
 
     test('should fail if name is not set', async () => {
         const res = await request({
-            uri: '/categories',
+            path: '/categories',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateCategory({ name: null })
@@ -88,7 +88,7 @@ describe('Categories creation', () => {
 
     test('should fail if discounts is not an array', async () => {
         const res = await request({
-            uri: '/categories',
+            path: '/categories',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateCategory({ discounts: false })
@@ -102,7 +102,7 @@ describe('Categories creation', () => {
 
     test('should fail if discounts is an empty array', async () => {
         const res = await request({
-            uri: '/categories',
+            path: '/categories',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateCategory({ discounts: [] })
@@ -116,7 +116,7 @@ describe('Categories creation', () => {
 
     test('should fail if discount is not an object', async () => {
         const res = await request({
-            uri: '/categories',
+            path: '/categories',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateCategory({ discounts: [false] })
@@ -130,7 +130,7 @@ describe('Categories creation', () => {
 
     test('should fail if discount\'s name is not set', async () => {
         const res = await request({
-            uri: '/categories',
+            path: '/categories',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateCategory({ discounts: [
@@ -146,7 +146,7 @@ describe('Categories creation', () => {
 
     test('should fail if discount\'s icon is not set', async () => {
         const res = await request({
-            uri: '/categories',
+            path: '/categories',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateCategory({ discounts: [
@@ -162,7 +162,7 @@ describe('Categories creation', () => {
 
     test('should fail if discount\'s shortDescription is not set', async () => {
         const res = await request({
-            uri: '/categories',
+            path: '/categories',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateCategory({ discounts: [
@@ -178,7 +178,7 @@ describe('Categories creation', () => {
 
     test('should fail if discount\'s longDescription is not set', async () => {
         const res = await request({
-            uri: '/categories',
+            path: '/categories',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateCategory({ discounts: [

--- a/discounts/test/api/categories-deletion.test.js
+++ b/discounts/test/api/categories-deletion.test.js
@@ -23,7 +23,7 @@ describe('Categories deletion', () => {
         const category = await generator.createCategory();
 
         const res = await request({
-            uri: '/categories/' + category.id,
+            path: '/categories/' + category.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -35,7 +35,7 @@ describe('Categories deletion', () => {
     test('should succeed if everything is okay', async () => {
         const category = await generator.createCategory();
         const res = await request({
-            uri: '/categories/' + category.id,
+            path: '/categories/' + category.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -51,7 +51,7 @@ describe('Categories deletion', () => {
 
     test('should return 404 if the integration is not found', async () => {
         const res = await request({
-            uri: '/categories/1337',
+            path: '/categories/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/discounts/test/api/categories-display.test.js
+++ b/discounts/test/api/categories-display.test.js
@@ -19,7 +19,7 @@ describe('Categories displaying', () => {
     test('should succeed if everything is okay', async () => {
         const category = await generator.createCategory();
         const res = await request({
-            uri: '/categories/' + category.id,
+            path: '/categories/' + category.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -34,7 +34,7 @@ describe('Categories displaying', () => {
 
     test('should return 404 if the category is not found', async () => {
         const res = await request({
-            uri: '/categories/1337',
+            path: '/categories/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -47,7 +47,7 @@ describe('Categories displaying', () => {
 
     test('should return 400 if category ID is NaN', async () => {
         const res = await request({
-            uri: '/categories/false',
+            path: '/categories/false',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/discounts/test/api/categories-edition.test.js
+++ b/discounts/test/api/categories-edition.test.js
@@ -22,7 +22,7 @@ describe('Categories edition', () => {
         const category = await generator.createCategory();
 
         const res = await request({
-            uri: '/categories/' + category.id,
+            path: '/categories/' + category.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: 'test' }
@@ -35,7 +35,7 @@ describe('Categories edition', () => {
     test('should succeed if everything is okay', async () => {
         const category = await generator.createCategory();
         const res = await request({
-            uri: '/categories/' + category.id,
+            path: '/categories/' + category.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: 'test' }
@@ -52,7 +52,7 @@ describe('Categories edition', () => {
     test('should fail on validation errors', async () => {
         const category = await generator.createCategory();
         const res = await request({
-            uri: '/categories/' + category.id,
+            path: '/categories/' + category.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: null }
@@ -66,7 +66,7 @@ describe('Categories edition', () => {
 
     test('should return 404 if the integration is not found', async () => {
         const res = await request({
-            uri: '/categories/1337',
+            path: '/categories/1337',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: 'test' }
@@ -80,7 +80,7 @@ describe('Categories edition', () => {
 
     test('should return 400 if the integration ID is NaN', async () => {
         const res = await request({
-            uri: '/categories/false',
+            path: '/categories/false',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: 'test' }

--- a/discounts/test/api/categories-listing.test.js
+++ b/discounts/test/api/categories-listing.test.js
@@ -19,7 +19,7 @@ describe('Categories listing', () => {
     test('should succeed and list categories', async () => {
         const category = await generator.createCategory();
         const res = await request({
-            uri: '/categories',
+            path: '/categories',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/discounts/test/api/codes-claiming.test.js
+++ b/discounts/test/api/codes-claiming.test.js
@@ -20,7 +20,7 @@ describe('Codes claiming', () => {
 
     test('should fail if the integration is not found', async () => {
         const res = await request({
-            uri: '/integrations/1337/claim',
+            path: '/integrations/1337/claim',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -41,7 +41,7 @@ describe('Codes claiming', () => {
         await generator.createCode({ claimed_by: user.id }, integration);
 
         const res = await request({
-            uri: '/integrations/' + integration.id + '/claim',
+            path: '/integrations/' + integration.id + '/claim',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -60,7 +60,7 @@ describe('Codes claiming', () => {
         // no codes
 
         const res = await request({
-            uri: '/integrations/' + integration.id + '/claim',
+            path: '/integrations/' + integration.id + '/claim',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -81,7 +81,7 @@ describe('Codes claiming', () => {
         const code = await generator.createCode({}, integration);
 
         const res = await request({
-            uri: '/integrations/' + integration.id + '/claim',
+            path: '/integrations/' + integration.id + '/claim',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -109,7 +109,7 @@ describe('Codes claiming', () => {
         await generator.createCode({}, integration);
 
         const res = await request({
-            uri: '/integrations/' + integration.id + '/claim',
+            path: '/integrations/' + integration.id + '/claim',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -131,7 +131,7 @@ describe('Codes claiming', () => {
         await generator.createCode({}, integration);
 
         const res = await request({
-            uri: '/integrations/' + integration.id + '/claim',
+            path: '/integrations/' + integration.id + '/claim',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -153,7 +153,7 @@ describe('Codes claiming', () => {
         await generator.createCode({}, integration);
 
         const res = await request({
-            uri: '/integrations/' + integration.id + '/claim',
+            path: '/integrations/' + integration.id + '/claim',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/discounts/test/api/codes-displaying.test.js
+++ b/discounts/test/api/codes-displaying.test.js
@@ -24,7 +24,7 @@ describe('Codes displaying', () => {
         const code = await generator.createCode({ claimed_by: user.id }, integration);
 
         const res = await request({
-            uri: '/codes/mine',
+            path: '/codes/mine',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -46,7 +46,7 @@ describe('Codes displaying', () => {
         await generator.createCode({ claimed_by: 1337 }, integration);
 
         const res = await request({
-            uri: '/codes/mine',
+            path: '/codes/mine',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/discounts/test/api/integrations-creation.test.js
+++ b/discounts/test/api/integrations-creation.test.js
@@ -20,7 +20,7 @@ describe('Integrations creation', () => {
     test('should fail if user does not have rights', async () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateIntegration()
@@ -33,7 +33,7 @@ describe('Integrations creation', () => {
     test('should succeed if everything is okay', async () => {
         const integration = generator.generateIntegration();
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: integration
@@ -60,7 +60,7 @@ describe('Integrations creation', () => {
 
     test('should fail if code is not set', async () => {
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateIntegration({ code: null })
@@ -74,7 +74,7 @@ describe('Integrations creation', () => {
 
     test('should fail if amount quota is not set', async () => {
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateIntegration({ quota_amount: null })
@@ -88,7 +88,7 @@ describe('Integrations creation', () => {
 
     test('should fail if amount quota is not a number', async () => {
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateIntegration({ quota_amount: false })
@@ -102,7 +102,7 @@ describe('Integrations creation', () => {
 
     test('should fail if amount quota is negative', async () => {
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateIntegration({ quota_amount: -1 })
@@ -116,7 +116,7 @@ describe('Integrations creation', () => {
 
     test('should fail if amount period is negative', async () => {
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateIntegration({ quota_period: null })
@@ -131,7 +131,7 @@ describe('Integrations creation', () => {
     test('should fail if the code is taken already', async () => {
         await generator.createIntegration({ code: 'test' });
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateIntegration({ code: 'test' })
@@ -145,7 +145,7 @@ describe('Integrations creation', () => {
 
     test('should fail if the quota period is invalid', async () => {
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateIntegration({ quota_period: 'bullshit' })

--- a/discounts/test/api/integrations-deletion.test.js
+++ b/discounts/test/api/integrations-deletion.test.js
@@ -23,7 +23,7 @@ describe('Integrations deletion', () => {
         const integration = await generator.createIntegration({ code: 'first' });
 
         const res = await request({
-            uri: '/integrations/' + integration.id,
+            path: '/integrations/' + integration.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -35,7 +35,7 @@ describe('Integrations deletion', () => {
     test('should succeed if everything is okay', async () => {
         const integration = await generator.createIntegration({ code: 'first' });
         const res = await request({
-            uri: '/integrations/' + integration.id,
+            path: '/integrations/' + integration.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -51,7 +51,7 @@ describe('Integrations deletion', () => {
 
     test('should return 404 if the integration is not found', async () => {
         const res = await request({
-            uri: '/integrations/random',
+            path: '/integrations/random',
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -65,7 +65,7 @@ describe('Integrations deletion', () => {
     test('should find integration by code', async () => {
         const integration = await generator.createIntegration({ code: 'first' });
         const res = await request({
-            uri: '/integrations/first',
+            path: '/integrations/first',
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/discounts/test/api/integrations-display.test.js
+++ b/discounts/test/api/integrations-display.test.js
@@ -19,7 +19,7 @@ describe('Integrations displaying', () => {
     test('should succeed if everything is okay', async () => {
         const integration = await generator.createIntegration({ code: 'first' });
         const res = await request({
-            uri: '/integrations/' + integration.id,
+            path: '/integrations/' + integration.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -34,7 +34,7 @@ describe('Integrations displaying', () => {
 
     test('should return 404 if the integration is not found', async () => {
         const res = await request({
-            uri: '/integrations/random',
+            path: '/integrations/random',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -48,7 +48,7 @@ describe('Integrations displaying', () => {
     test('should find integration by code', async () => {
         const integration = await generator.createIntegration({ code: 'first' });
         const res = await request({
-            uri: '/integrations/first',
+            path: '/integrations/first',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/discounts/test/api/integrations-edition.test.js
+++ b/discounts/test/api/integrations-edition.test.js
@@ -22,7 +22,7 @@ describe('Integrations edition', () => {
         const integration = await generator.createIntegration({ code: 'first' });
 
         const res = await request({
-            uri: '/integrations/' + integration.id,
+            path: '/integrations/' + integration.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { code: 'test' }
@@ -35,7 +35,7 @@ describe('Integrations edition', () => {
     test('should succeed if everything is okay', async () => {
         const integration = await generator.createIntegration({ code: 'first' });
         const res = await request({
-            uri: '/integrations/' + integration.id,
+            path: '/integrations/' + integration.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { code: 'test' }
@@ -52,7 +52,7 @@ describe('Integrations edition', () => {
     test('should fail on validation errors', async () => {
         const integration = await generator.createIntegration({ code: 'first' });
         const res = await request({
-            uri: '/integrations/' + integration.id,
+            path: '/integrations/' + integration.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { code: null }
@@ -66,7 +66,7 @@ describe('Integrations edition', () => {
 
     test('should return 404 if the integration is not found', async () => {
         const res = await request({
-            uri: '/integrations/random',
+            path: '/integrations/random',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { code: 'test' }
@@ -81,7 +81,7 @@ describe('Integrations edition', () => {
     test('should find integration by code', async () => {
         await generator.createIntegration({ code: 'first' });
         const res = await request({
-            uri: '/integrations/first',
+            path: '/integrations/first',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { code: 'test' }

--- a/discounts/test/api/integrations-listing.test.js
+++ b/discounts/test/api/integrations-listing.test.js
@@ -19,7 +19,7 @@ describe('Integrations listing', () => {
     test('should succeed and list integrations', async () => {
         const integration = await generator.createIntegration({ code: 'first' });
         const res = await request({
-            uri: '/integrations',
+            path: '/integrations',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/discounts/test/api/integrations-population.test.js
+++ b/discounts/test/api/integrations-population.test.js
@@ -24,7 +24,7 @@ describe('Integrations codes population', () => {
         const integration = await generator.createIntegration({ code: 'first' });
 
         const res = await request({
-            uri: '/integrations/' + integration.id + '/codes',
+            path: '/integrations/' + integration.id + '/codes',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: ['first', 'second', 'third']
@@ -37,7 +37,7 @@ describe('Integrations codes population', () => {
     test('should succeed if everything is okay', async () => {
         const integration = await generator.createIntegration({ code: 'first' });
         const res = await request({
-            uri: '/integrations/' + integration.id + '/codes',
+            path: '/integrations/' + integration.id + '/codes',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: ['first', 'second', 'third']
@@ -55,7 +55,7 @@ describe('Integrations codes population', () => {
     test('should fail if body is not an array', async () => {
         const integration = await generator.createIntegration({ code: 'first' });
         const res = await request({
-            uri: '/integrations/' + integration.id + '/codes',
+            path: '/integrations/' + integration.id + '/codes',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {}
@@ -70,7 +70,7 @@ describe('Integrations codes population', () => {
     test('should fail if body is empty array', async () => {
         const integration = await generator.createIntegration({ code: 'first' });
         const res = await request({
-            uri: '/integrations/' + integration.id + '/codes',
+            path: '/integrations/' + integration.id + '/codes',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: []

--- a/discounts/test/api/metrics.test.js
+++ b/discounts/test/api/metrics.test.js
@@ -24,9 +24,9 @@ describe('Metrics requests', () => {
         await generator.createCode({ claimed_by: 1337 }, integration);
 
         const res = await request({
-            uri: '/metrics',
+            path: '/metrics',
             method: 'GET',
-            json: false
+            responseType: 'text'
         });
 
         expect(res.statusCode).toEqual(200);
@@ -34,9 +34,9 @@ describe('Metrics requests', () => {
 
     test('should return data correctly on /metrics/requests', async () => {
         const res = await request({
-            uri: '/metrics/requests',
+            path: '/metrics/requests',
             method: 'GET',
-            json: false
+            responseType: 'text'
         });
 
         expect(res.statusCode).toEqual(200);

--- a/discounts/test/scripts/helpers.js
+++ b/discounts/test/scripts/helpers.js
@@ -22,24 +22,20 @@ const appendQuery = (url, query) => {
 };
 
 const request = async (options) => {
-    const parseJson = options.json !== false;
+    const responseType = options.responseType || 'json';
     const headers = { ...(options.headers || {}) };
     const fetchOptions = { method: options.method || 'GET', headers };
 
     if (options.body !== undefined) {
-        if (parseJson) {
-            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
-            fetchOptions.body = JSON.stringify(options.body);
-        } else {
-            fetchOptions.body = options.body;
-        }
+        headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+        fetchOptions.body = JSON.stringify(options.body);
     }
 
-    const response = await fetch(appendQuery(new URL(options.uri, baseUrl + '/').toString(), options.qs), fetchOptions);
+    const response = await fetch(appendQuery(new URL(options.path, baseUrl + '/').toString(), options.query), fetchOptions);
     const text = await response.text();
     let body = text;
 
-    if (parseJson && text) {
+    if (responseType === 'json' && text) {
         try {
             body = JSON.parse(text);
         } catch (err) { // eslint-disable-line no-unused-vars

--- a/discounts/test/scripts/helpers.js
+++ b/discounts/test/scripts/helpers.js
@@ -1,13 +1,58 @@
-const requestPromise = require('request-promise-native');
-
 const config = require('../../config');
 
-const request = requestPromise.defaults({
-    json: true,
-    resolveWithFullResponse: true,
-    simple: false,
-    baseUrl: 'http://localhost:' + config.port,
-    qsStringifyOptions: { arrayFormat: 'brackets' }
-});
+const baseUrl = 'http://localhost:' + config.port;
+
+const appendQuery = (url, query) => {
+    if (!query) return url;
+
+    const requestUrl = new URL(url);
+    for (const [key, value] of Object.entries(query)) {
+        if (Array.isArray(value)) {
+            value.forEach((item) => requestUrl.searchParams.append(key, item));
+        } else if (typeof value === 'object' && value !== null) {
+            for (const [nestedKey, nestedValue] of Object.entries(value)) {
+                requestUrl.searchParams.append(`${key}[${nestedKey}]`, nestedValue);
+            }
+        } else {
+            requestUrl.searchParams.append(key, value);
+        }
+    }
+
+    return requestUrl.toString();
+};
+
+const request = async (options) => {
+    const parseJson = options.json !== false;
+    const headers = { ...(options.headers || {}) };
+    const fetchOptions = { method: options.method || 'GET', headers };
+
+    if (options.body !== undefined) {
+        if (parseJson) {
+            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+            fetchOptions.body = JSON.stringify(options.body);
+        } else {
+            fetchOptions.body = options.body;
+        }
+    }
+
+    const response = await fetch(appendQuery(new URL(options.uri, baseUrl + '/').toString(), options.qs), fetchOptions);
+    const text = await response.text();
+    let body = text;
+
+    if (parseJson && text) {
+        try {
+            body = JSON.parse(text);
+        } catch (err) { // eslint-disable-line no-unused-vars
+            body = text;
+        }
+    }
+
+    return {
+        statusCode: response.status,
+        statusMessage: response.statusText,
+        headers: Object.fromEntries(response.headers.entries()),
+        body
+    };
+};
 
 exports.request = request;

--- a/events/lib/core.js
+++ b/events/lib/core.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const { request } = require('./http');
 
 const config = require('../config');
 

--- a/events/lib/core.js
+++ b/events/lib/core.js
@@ -11,9 +11,7 @@ const makeRequest = (options) => {
             'X-Auth-Token': options.token,
             'X-Service': 'events'
         },
-        simple: false,
-        json: true,
-        resolveWithFullResponse: options.resolveWithFullResponse || false
+        fullResponse: options.fullResponse || false
     };
 
     if (options.body) {

--- a/events/lib/http.js
+++ b/events/lib/http.js
@@ -1,0 +1,49 @@
+const parseBody = async (response, parseJson) => {
+    const text = await response.text();
+
+    if (!parseJson) {
+        return text;
+    }
+
+    if (!text) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch (err) { // eslint-disable-line no-unused-vars
+        return text;
+    }
+};
+
+module.exports.request = async (options) => {
+    const parseJson = options.json !== false;
+    const headers = { ...(options.headers || {}) };
+    const fetchOptions = {
+        method: options.method || 'GET',
+        headers
+    };
+
+    if (options.body !== undefined) {
+        if (parseJson) {
+            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+            fetchOptions.body = JSON.stringify(options.body);
+        } else {
+            fetchOptions.body = options.body;
+        }
+    }
+
+    const response = await fetch(options.url, fetchOptions);
+    const body = await parseBody(response, parseJson);
+
+    if (options.resolveWithFullResponse) {
+        return {
+            statusCode: response.status,
+            statusMessage: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body
+        };
+    }
+
+    return body;
+};

--- a/events/lib/http.js
+++ b/events/lib/http.js
@@ -1,9 +1,5 @@
-const parseBody = async (response, parseJson) => {
+const parseBody = async (response) => {
     const text = await response.text();
-
-    if (!parseJson) {
-        return text;
-    }
 
     if (!text) {
         return null;
@@ -17,7 +13,6 @@ const parseBody = async (response, parseJson) => {
 };
 
 module.exports.request = async (options) => {
-    const parseJson = options.json !== false;
     const headers = { ...(options.headers || {}) };
     const fetchOptions = {
         method: options.method || 'GET',
@@ -25,18 +20,14 @@ module.exports.request = async (options) => {
     };
 
     if (options.body !== undefined) {
-        if (parseJson) {
-            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
-            fetchOptions.body = JSON.stringify(options.body);
-        } else {
-            fetchOptions.body = options.body;
-        }
+        headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+        fetchOptions.body = JSON.stringify(options.body);
     }
 
     const response = await fetch(options.url, fetchOptions);
-    const body = await parseBody(response, parseJson);
+    const body = await parseBody(response);
 
-    if (options.resolveWithFullResponse) {
+    if (options.fullResponse) {
         return {
             statusCode: response.status,
             statusMessage: response.statusText,

--- a/events/lib/mailer.js
+++ b/events/lib/mailer.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const { request } = require('./http');
 
 const config = require('../config');
 

--- a/events/lib/mailer.js
+++ b/events/lib/mailer.js
@@ -6,8 +6,6 @@ module.exports.sendMail = async (options) => {
     const mailerBody = await request({
         url: config.mailer.url + ':' + config.mailer.port + '/',
         method: 'POST',
-        simple: false,
-        json: true,
         body: {
             from: options.from,
             to: options.to,

--- a/events/lib/middlewares.js
+++ b/events/lib/middlewares.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const { request } = require('./http');
 
 const Bugsnag = require('./bugsnag');
 const core = require('./core');

--- a/events/lib/middlewares.js
+++ b/events/lib/middlewares.js
@@ -20,9 +20,7 @@ exports.authenticateUser = async (req, res, next) => {
             'X-Requested-With': 'XMLHttpRequest',
             'X-Auth-Token': req.headers['x-auth-token'],
         },
-        simple: false,
-        json: true,
-        resolveWithFullResponse: true
+        fullResponse: true
     })));
 
     // Fetching permissions for members approval, the list of bodies
@@ -34,13 +32,11 @@ exports.authenticateUser = async (req, res, next) => {
             'X-Requested-With': 'XMLHttpRequest',
             'X-Auth-Token': req.headers['x-auth-token'],
         },
-        simple: false,
-        json: true,
         body: {
             action: 'approve_members',
             object: 'events'
         },
-        resolveWithFullResponse: true
+        fullResponse: true
     });
 
     req.userRequest = userBody;

--- a/events/package-lock.json
+++ b/events/package-lock.json
@@ -28,8 +28,6 @@
         "pg": "^8.20.0",
         "prom-client": "^15.1.3",
         "read-chunk": "^3.2.0",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "sequelize": "^6.37.8",
         "sequelize-cli": "^6.6.3"
       },
@@ -1978,6 +1976,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2211,24 +2210,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2238,12 +2219,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2269,21 +2244,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "license": "MIT"
     },
     "node_modules/babel-jest": {
       "version": "30.3.0",
@@ -2440,15 +2400,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "node_modules/bintrees": {
       "version": "1.0.2",
@@ -2707,12 +2658,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2950,18 +2895,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -3054,12 +2987,6 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "license": "MIT"
-    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -3101,18 +3028,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/data-view-buffer": {
@@ -3254,15 +3169,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3345,16 +3251,6 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/editorconfig": {
       "version": "1.0.7",
@@ -4252,31 +4148,18 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -4477,29 +4360,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/forwarded": {
@@ -4717,15 +4577,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -4841,29 +4692,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -4982,21 +4810,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/human-signals": {
@@ -5563,12 +5376,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -5633,12 +5440,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6397,12 +6198,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6430,16 +6225,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -6453,6 +6243,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -6478,21 +6269,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/keyv": {
@@ -7379,15 +7155,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7771,12 +7538,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT"
-    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
@@ -8111,18 +7872,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -8137,6 +7886,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8327,90 +8077,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "license": "ISC",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "license": "ISC",
-      "dependencies": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
-      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-directory": {
@@ -9269,31 +8935,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stack-generator": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
@@ -9339,15 +8980,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -9770,19 +9402,6 @@
       "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==",
       "license": "MIT"
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -9826,24 +9445,6 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10129,6 +9730,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -10190,20 +9792,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/walker": {

--- a/events/package.json
+++ b/events/package.json
@@ -65,8 +65,6 @@
     "pg": "^8.20.0",
     "prom-client": "^15.1.3",
     "read-chunk": "^3.2.0",
-    "request": "^2.88.2",
-    "request-promise-native": "^1.0.9",
     "sequelize": "^6.37.8",
     "sequelize-cli": "^6.6.3"
   },

--- a/events/test/api/api-requests.test.js
+++ b/events/test/api/api-requests.test.js
@@ -24,7 +24,7 @@ describe('API requests', () => {
             ]
         });
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             method: 'GET'
         });
 
@@ -36,7 +36,7 @@ describe('API requests', () => {
         mock.mockAll({ core: { netError: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -49,7 +49,7 @@ describe('API requests', () => {
         mock.mockAll({ core: { badResponse: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -62,7 +62,7 @@ describe('API requests', () => {
         mock.mockAll({ core: { unsuccessfulResponse: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -75,7 +75,7 @@ describe('API requests', () => {
         mock.mockAll({ mainPermissions: { netError: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -88,7 +88,7 @@ describe('API requests', () => {
         mock.mockAll({ mainPermissions: { badResponse: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -101,7 +101,7 @@ describe('API requests', () => {
         mock.mockAll({ mainPermissions: { unsuccessfulResponse: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -114,7 +114,7 @@ describe('API requests', () => {
         mock.mockAll({ approvePermissions: { netError: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -127,7 +127,7 @@ describe('API requests', () => {
         mock.mockAll({ approvePermissions: { badResponse: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -140,7 +140,7 @@ describe('API requests', () => {
         mock.mockAll({ approvePermissions: { unsuccessfulResponse: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -151,7 +151,7 @@ describe('API requests', () => {
 
     it('should fail if body is not JSON', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: 'Some random string'
@@ -163,7 +163,7 @@ describe('API requests', () => {
 
     it('should fail on accessing non-existant endpoint', async () => {
         const res = await request({
-            uri: '/nonexistant',
+            path: '/nonexistant',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/events/test/api/applications-attendance.test.js
+++ b/events/test/api/applications-attendance.test.js
@@ -26,7 +26,7 @@ describe('Applications attendance', () => {
         const application = await generator.createApplication(event, { confirmed: true });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/' + application.id + '/attended',
+            path: '/single/' + event.id + '/applications/' + application.id + '/attended',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { attended: true }
@@ -45,7 +45,7 @@ describe('Applications attendance', () => {
         const application = await generator.createApplication(event, { confirmed: false });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/' + application.id + '/attended',
+            path: '/single/' + event.id + '/applications/' + application.id + '/attended',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { attended: true }
@@ -67,7 +67,7 @@ describe('Applications attendance', () => {
         const application = await generator.createApplication(event, { confirmed: true });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/' + application.id + '/attended',
+            path: '/single/' + event.id + '/applications/' + application.id + '/attended',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { attended: true }
@@ -83,7 +83,7 @@ describe('Applications attendance', () => {
         const event = await generator.createEvent({ applications: [] });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/333/attended',
+            path: '/single/' + event.id + '/applications/333/attended',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { attended: true }
@@ -100,7 +100,7 @@ describe('Applications attendance', () => {
         const application = await generator.createApplication(event, { confirmed: true });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/' + application.id + '/attended',
+            path: '/single/' + event.id + '/applications/' + application.id + '/attended',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { attended: 'lalala' }

--- a/events/test/api/applications-boardview.test.js
+++ b/events/test/api/applications-boardview.test.js
@@ -19,7 +19,7 @@ describe('Events application boardview', () => {
 
     it('should return an error if you are not a boardmember of this body', async () => {
         const res = await request({
-            uri: '/boardview/1337',
+            path: '/boardview/1337',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });
@@ -32,7 +32,7 @@ describe('Events application boardview', () => {
 
     it('should return an error if bodyId is not a number', async () => {
         const res = await request({
-            uri: '/boardview/nan',
+            path: '/boardview/nan',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });
@@ -49,7 +49,7 @@ describe('Events application boardview', () => {
         const application = await generator.createApplication(event, { body_id: body.id });
 
         const res = await request({
-            uri: '/boardview/' + body.id,
+            path: '/boardview/' + body.id,
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });
@@ -69,7 +69,7 @@ describe('Events application boardview', () => {
         await generator.createApplication(event, { body_id: 1337 });
 
         const res = await request({
-            uri: '/boardview/' + body.id,
+            path: '/boardview/' + body.id,
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });

--- a/events/test/api/applications-comment.test.js
+++ b/events/test/api/applications-comment.test.js
@@ -25,7 +25,7 @@ describe('Events application comments', () => {
         const application = await generator.createApplication(event);
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/' + application.id + '/comment',
+            path: '/single/' + event.id + '/applications/' + application.id + '/comment',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'PUT',
             body: { board_comment: 'Not good.' }
@@ -44,7 +44,7 @@ describe('Events application comments', () => {
         await generator.createApplication(event);
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/1337/comment',
+            path: '/single/' + event.id + '/applications/1337/comment',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'PUT',
             body: { board_comment: 'Not good.' }
@@ -63,7 +63,7 @@ describe('Events application comments', () => {
         await generator.createApplication(event);
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/false/comment',
+            path: '/single/' + event.id + '/applications/false/comment',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'PUT',
             body: { board_comment: 'Not good.' }
@@ -83,7 +83,7 @@ describe('Events application comments', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/' + application.id + '/comment',
+            path: '/single/' + event.id + '/applications/' + application.id + '/comment',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'PUT',
             body: { board_comment: 'Not good.' }

--- a/events/test/api/applications-confirmed.test.js
+++ b/events/test/api/applications-confirmed.test.js
@@ -26,7 +26,7 @@ describe('Applications confirmation', () => {
         const application = await generator.createApplication(event);
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/' + application.id + '/confirmed',
+            path: '/single/' + event.id + '/applications/' + application.id + '/confirmed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { confirmed: true }
@@ -49,7 +49,7 @@ describe('Applications confirmation', () => {
         const application = await generator.createApplication(event);
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/' + application.id + '/confirmed',
+            path: '/single/' + event.id + '/applications/' + application.id + '/confirmed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { confirmed: true }
@@ -65,7 +65,7 @@ describe('Applications confirmation', () => {
         const event = await generator.createEvent({ applications: [] });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/333/confirmed',
+            path: '/single/' + event.id + '/applications/333/confirmed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { confirmed: true }
@@ -82,7 +82,7 @@ describe('Applications confirmation', () => {
         const application = await generator.createApplication(event);
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/' + application.id + '/confirmed',
+            path: '/single/' + event.id + '/applications/' + application.id + '/confirmed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { confirmed: 'lalala' }
@@ -99,7 +99,7 @@ describe('Applications confirmation', () => {
         const application = await generator.createApplication(event, { confirmed: true, attended: true });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/' + application.id + '/confirmed',
+            path: '/single/' + event.id + '/applications/' + application.id + '/confirmed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { confirmed: false }

--- a/events/test/api/applications-creating.test.js
+++ b/events/test/api/applications-creating.test.js
@@ -29,7 +29,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: { body_id: user.bodies[0].id }
@@ -49,7 +49,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: { body_id: user.bodies[0].id }
@@ -76,7 +76,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -102,7 +102,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -133,7 +133,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -163,7 +163,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -193,7 +193,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -223,7 +223,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -253,7 +253,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -283,7 +283,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -313,7 +313,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -343,7 +343,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -373,7 +373,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -404,7 +404,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -433,7 +433,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -463,7 +463,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -493,7 +493,7 @@ describe('Events application creating', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {

--- a/events/test/api/applications-editing.test.js
+++ b/events/test/api/applications-editing.test.js
@@ -39,7 +39,7 @@ describe('Events application editing', () => {
         await generator.createApplication(event, { user_id: user.id });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/me',
+            path: '/single/' + event.id + '/applications/me',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'PUT',
             body: { body_id: user.bodies[0].id }
@@ -75,7 +75,7 @@ describe('Events application editing', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/' + application.id,
+            path: '/single/' + event.id + '/applications/' + application.id,
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'PUT',
             body: { answers: [2] }
@@ -115,7 +115,7 @@ describe('Events application editing', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/me',
+            path: '/single/' + event.id + '/applications/me',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'PUT',
             body: { answers: [2] }
@@ -155,7 +155,7 @@ describe('Events application editing', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/me',
+            path: '/single/' + event.id + '/applications/me',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'PUT',
             body: { body_id: user.bodies[1].id }
@@ -196,7 +196,7 @@ describe('Events application editing', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/me',
+            path: '/single/' + event.id + '/applications/me',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'PUT',
             body: { body_id: 1337 }

--- a/events/test/api/applications-info.test.js
+++ b/events/test/api/applications-info.test.js
@@ -21,7 +21,7 @@ describe('Events application info', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/me',
+            path: '/single/' + event.id + '/applications/me',
             headers: { 'X-Auth-Token': 'foobar' },
         });
 
@@ -44,7 +44,7 @@ describe('Events application info', () => {
         const application = await generator.createApplication(event, { user_id: 1337 });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/' + application.id,
+            path: '/single/' + event.id + '/applications/' + application.id,
             headers: { 'X-Auth-Token': 'foobar' },
         });
 
@@ -61,7 +61,7 @@ describe('Events application info', () => {
         await generator.createApplication(event, { user_id: user.id });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/me',
+            path: '/single/' + event.id + '/applications/me',
             headers: { 'X-Auth-Token': 'foobar' },
         });
 
@@ -76,7 +76,7 @@ describe('Events application info', () => {
         const application = await generator.createApplication(event, { user_id: user.id });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/' + application.id,
+            path: '/single/' + event.id + '/applications/' + application.id,
             headers: { 'X-Auth-Token': 'foobar' },
         });
 

--- a/events/test/api/applications-list.test.js
+++ b/events/test/api/applications-list.test.js
@@ -26,7 +26,7 @@ describe('Events application listing', () => {
         }] });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });
@@ -46,7 +46,7 @@ describe('Events application listing', () => {
 
         const application = await generator.createApplication(event);
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });
@@ -73,7 +73,7 @@ describe('Events application listing', () => {
         await first.update({ user_id: 4 });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications',
+            path: '/single/' + event.id + '/applications',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });
@@ -94,7 +94,7 @@ describe('Events application listing', () => {
         await generator.createApplication(event, { user_id: 1337 });
 
         const res = await request({
-            uri: '/mine/participating',
+            path: '/mine/participating',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });
@@ -111,7 +111,7 @@ describe('Events application listing', () => {
         await generator.createApplication(event, { user_id: user.id });
 
         const res = await request({
-            uri: '/mine/participating',
+            path: '/mine/participating',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });

--- a/events/test/api/applications-status.test.js
+++ b/events/test/api/applications-status.test.js
@@ -25,7 +25,7 @@ describe('Events application status', () => {
         const application = await generator.createApplication(event);
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/' + application.id + '/status',
+            path: '/single/' + event.id + '/applications/' + application.id + '/status',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'PUT',
             body: { status: 'accepted' }
@@ -43,7 +43,7 @@ describe('Events application status', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/1337/status',
+            path: '/single/' + event.id + '/applications/1337/status',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'PUT',
             body: { status: 'acceptedd' }
@@ -60,7 +60,7 @@ describe('Events application status', () => {
         const application = await generator.createApplication(event);
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/' + application.id + '/status',
+            path: '/single/' + event.id + '/applications/' + application.id + '/status',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'PUT',
             body: { status: 'accepted' }

--- a/events/test/api/events-approval.test.js
+++ b/events/test/api/events-approval.test.js
@@ -24,7 +24,7 @@ describe('Events status change', () => {
         });
 
         const res = await request({
-            uri: '/mine/approvable',
+            path: '/mine/approvable',
             headers: { 'X-Auth-Token': 'foobar' }
         });
 
@@ -42,7 +42,7 @@ describe('Events status change', () => {
         });
 
         const res = await request({
-            uri: '/mine/approvable',
+            path: '/mine/approvable',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });
@@ -61,7 +61,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'submitted' }
@@ -82,7 +82,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'submitted' }
@@ -104,7 +104,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'submitted' }
@@ -125,7 +125,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'submitted' }
@@ -148,7 +148,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'published' }
@@ -172,7 +172,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'published' }
@@ -193,7 +193,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'published' }
@@ -215,7 +215,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'published' }
@@ -236,7 +236,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'published' }
@@ -260,7 +260,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'draft' }
@@ -281,7 +281,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'draft' }
@@ -303,7 +303,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'draft' }
@@ -327,7 +327,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'submitted' }
@@ -348,7 +348,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'submitted' }
@@ -370,7 +370,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'submitted' }
@@ -393,7 +393,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'draft' }
@@ -416,7 +416,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'submitted' }
@@ -435,7 +435,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'submitted' }
@@ -454,7 +454,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'submitted' }
@@ -473,7 +473,7 @@ describe('Events status change', () => {
             });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'submitted' }
@@ -493,7 +493,7 @@ describe('Events status change', () => {
             const event = await generator.createEvent({ status: 'draft' });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'submitted' }
@@ -510,7 +510,7 @@ describe('Events status change', () => {
             const event = await generator.createEvent({ status: 'draft' });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'submitted' }
@@ -527,7 +527,7 @@ describe('Events status change', () => {
             const event = await generator.createEvent({ status: 'draft' });
 
             const res = await request({
-                uri: '/single/' + event.id + '/status',
+                path: '/single/' + event.id + '/status',
                 headers: { 'X-Auth-Token': 'foobar' },
                 method: 'PUT',
                 body: { status: 'submitted' }

--- a/events/test/api/events-creation.test.js
+++ b/events/test/api/events-creation.test.js
@@ -21,7 +21,7 @@ describe('Events creation', () => {
 
     it('should create a new event on minimal sane / POST', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -69,7 +69,7 @@ describe('Events creation', () => {
 
     it('should create a new online event on minimal sane / POST', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -115,7 +115,7 @@ describe('Events creation', () => {
 
     it('should create a new online event without application process on minimal sane / POST', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -161,7 +161,7 @@ describe('Events creation', () => {
 
     it('should create a new event on exhaustive sane / POST', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -226,7 +226,7 @@ describe('Events creation', () => {
 
     it('should discart superflous fields on overly detailed / POST', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -254,7 +254,7 @@ describe('Events creation', () => {
 
     it('should return validation errors on malformed / POST', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: {
@@ -289,7 +289,7 @@ describe('Events creation', () => {
         event.locations = false;
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -306,7 +306,7 @@ describe('Events creation', () => {
         event.locations = false;
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -323,7 +323,7 @@ describe('Events creation', () => {
         event.locations = false;
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -340,7 +340,7 @@ describe('Events creation', () => {
         event.locations = false;
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -357,7 +357,7 @@ describe('Events creation', () => {
         event.locations = false;
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -373,7 +373,7 @@ describe('Events creation', () => {
         event.locations = [false];
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -390,7 +390,7 @@ describe('Events creation', () => {
         event.locations = [null];
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -407,7 +407,7 @@ describe('Events creation', () => {
         event.locations = [{ name: null, position: { lat: 1, lng: 1 } }];
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -424,7 +424,7 @@ describe('Events creation', () => {
         event.locations = [{ name: '', position: { lat: 1, lng: 1 } }];
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -441,7 +441,7 @@ describe('Events creation', () => {
         event.locations = [{ name: 'test', position: false }];
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -458,7 +458,7 @@ describe('Events creation', () => {
         event.locations = [{ name: 'test', position: null }];
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -475,7 +475,7 @@ describe('Events creation', () => {
         event.locations = [{ name: 'test', position: { lat: false, lng: 1 } }];
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -492,7 +492,7 @@ describe('Events creation', () => {
         event.locations = [{ name: 'test', position: { lat: 1, lng: false } }];
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -509,7 +509,7 @@ describe('Events creation', () => {
         event.locations = [{ name: 'test', position: { lat: 1, lng: 1 } }];
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -529,7 +529,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -551,7 +551,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -573,7 +573,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -592,7 +592,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -611,7 +611,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -630,7 +630,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -649,7 +649,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -668,7 +668,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -687,7 +687,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -706,7 +706,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -725,7 +725,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -744,7 +744,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -763,7 +763,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -782,7 +782,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -799,7 +799,7 @@ describe('Events creation', () => {
         event.body_id = user.bodies[0].id;
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -816,7 +816,7 @@ describe('Events creation', () => {
         event.body_id = user.bodies[0].id;
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -833,7 +833,7 @@ describe('Events creation', () => {
         event.body_id = user.bodies[0].id;
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -849,7 +849,7 @@ describe('Events creation', () => {
         event.body_id = user.bodies[0].id;
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -865,7 +865,7 @@ describe('Events creation', () => {
         event.body_id = user.bodies[0].id;
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -881,7 +881,7 @@ describe('Events creation', () => {
         event.body_id = user.bodies[0].id;
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -897,7 +897,7 @@ describe('Events creation', () => {
         event.body_id = user.bodies[0].id;
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -913,7 +913,7 @@ describe('Events creation', () => {
         event.body_id = user.bodies[0].id;
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -931,7 +931,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -950,7 +950,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -971,7 +971,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -990,7 +990,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1008,7 +1008,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1026,7 +1026,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1044,7 +1044,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1062,7 +1062,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1079,7 +1079,7 @@ describe('Events creation', () => {
         const event = generator.generateEvent();
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1094,7 +1094,7 @@ describe('Events creation', () => {
         const event = generator.generateEvent();
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1109,7 +1109,7 @@ describe('Events creation', () => {
         const event = generator.generateEvent();
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1124,7 +1124,7 @@ describe('Events creation', () => {
         event.locations = false;
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event

--- a/events/test/api/events-details.test.js
+++ b/events/test/api/events-details.test.js
@@ -19,7 +19,7 @@ describe('Events details', () => {
     it('should return a single event on /single/<eventid> GET by ID', async () => {
         const event = await generator.createEvent();
         const res = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });
@@ -51,7 +51,7 @@ describe('Events details', () => {
     it('should return a single event on /single/<eventid> GET by URL', async () => {
         const event = await generator.createEvent({ url: 'test' });
         const res = await request({
-            uri: '/single/' + event.url,
+            path: '/single/' + event.url,
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });
@@ -82,7 +82,7 @@ describe('Events details', () => {
 
     it('should return a 404 on arbitrary eventids on /single/id GET', async () => {
         const res = await request({
-            uri: '/single/1337',
+            path: '/single/1337',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });
@@ -98,7 +98,7 @@ describe('Events details', () => {
             organizers: [{ user_id: 1337, first_name: 'test', last_name: 'test' }]
         });
         const res = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });
@@ -120,7 +120,7 @@ describe('Events details', () => {
             organizers: [{ user_id: 1337, first_name: 'test', last_name: 'test' }]
         });
         const res = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });
@@ -139,7 +139,7 @@ describe('Events details', () => {
             organizers: [{ user_id: 1337, first_name: 'test', last_name: 'test' }]
         });
         const res = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'GET'
         });

--- a/events/test/api/events-editing.test.js
+++ b/events/test/api/events-editing.test.js
@@ -25,7 +25,7 @@ describe('Events editing', () => {
         const notMineEvent = await generator.createEvent({ organizers: [{ first_name: 'test', last_name: 'test', user_id: 333 }] });
 
         const res = await request({
-            uri: '/single/' + notMineEvent.id,
+            path: '/single/' + notMineEvent.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -40,7 +40,7 @@ describe('Events editing', () => {
 
     it('should update an event on a sane /single/<eventid> PUT', async () => {
         const res = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -53,7 +53,7 @@ describe('Events editing', () => {
 
     it('should update the organizers if requested', async () => {
         const res = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -66,7 +66,7 @@ describe('Events editing', () => {
 
     it('should store the changes on update after a sane /single/<eventid> PUT', async () => {
         await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -75,7 +75,7 @@ describe('Events editing', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -85,7 +85,7 @@ describe('Events editing', () => {
 
     it('should ignore superflous fields on overly detailed /single/<eventid> PUT', async () => {
         await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -94,7 +94,7 @@ describe('Events editing', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -105,7 +105,7 @@ describe('Events editing', () => {
 
     it('should return a validation error on malformed /single/<eventid> PUT', async () => {
         const res = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -119,7 +119,7 @@ describe('Events editing', () => {
 
     it('should fail if no organizers are set', async () => {
         const res = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -135,7 +135,7 @@ describe('Events editing', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -147,7 +147,7 @@ describe('Events editing', () => {
 
     it('should hide an event from / GET but keep it for /single GET after /single DELETE', async () => {
         const deleteRequest = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -155,7 +155,7 @@ describe('Events editing', () => {
         expect(deleteRequest.statusCode).toEqual(200);
 
         const res = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -174,7 +174,7 @@ describe('Events editing', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -189,7 +189,7 @@ describe('Events editing', () => {
 
     it('should not change the European Event status on normal edit request', async () => {
         const res = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -201,7 +201,7 @@ describe('Events editing', () => {
         expect(res.statusCode).toEqual(200);
 
         const response = await request({
-            uri: '/single/' + event.id,
+            path: '/single/' + event.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/events/test/api/events-listing.test.js
+++ b/events/test/api/events-listing.test.js
@@ -29,7 +29,7 @@ describe('Events listing', () => {
         await generator.createEvent({ status: 'draft' });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET'
         });
 
@@ -62,7 +62,7 @@ describe('Events listing', () => {
         await generator.createEvent({ status: 'draft' });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -93,7 +93,7 @@ describe('Events listing', () => {
 
     it('should use the default limit if limit is NaN', async () => {
         const res = await request({
-            uri: '/?limit=nan',
+            path: '/?limit=nan',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -111,7 +111,7 @@ describe('Events listing', () => {
         await generator.createEvent({ status: 'published' });
 
         const res = await request({
-            uri: '/?limit=-1',
+            path: '/?limit=-1',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -130,7 +130,7 @@ describe('Events listing', () => {
         await generator.createEvent({ status: 'published' });
 
         const res = await request({
-            uri: '/?limit=1',
+            path: '/?limit=1',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -146,7 +146,7 @@ describe('Events listing', () => {
 
     it('should use the default offset if offset is NaN', async () => {
         const res = await request({
-            uri: '/?offset=nan',
+            path: '/?offset=nan',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -162,7 +162,7 @@ describe('Events listing', () => {
 
     it('should use the default offset if offset is < 0', async () => {
         const res = await request({
-            uri: '/?offset=-1',
+            path: '/?offset=-1',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -181,7 +181,7 @@ describe('Events listing', () => {
         await generator.createEvent({ status: 'published' });
 
         const res = await request({
-            uri: '/?offset=100',
+            path: '/?offset=100',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -200,7 +200,7 @@ describe('Events listing', () => {
         const event = await generator.createEvent({ status: 'published', type: 'training' });
 
         const res = await request({
-            uri: '/?type[]=training',
+            path: '/?type[]=training',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -218,7 +218,7 @@ describe('Events listing', () => {
         const event = await generator.createEvent({ status: 'published', type: 'training' });
 
         const res = await request({
-            uri: '/?type=training',
+            path: '/?type=training',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -248,7 +248,7 @@ describe('Events listing', () => {
         });
 
         const res = await request({
-            uri: '/?starts=' + moment().format('YYYY-MM-DD'),
+            path: '/?starts=' + moment().format('YYYY-MM-DD'),
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -279,7 +279,7 @@ describe('Events listing', () => {
         });
 
         const res = await request({
-            uri: '/?ends=' + moment().format('YYYY-MM-DD'),
+            path: '/?ends=' + moment().format('YYYY-MM-DD'),
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -299,7 +299,7 @@ describe('Events listing', () => {
         });
 
         const res = await request({
-            uri: '/?search=nwm',
+            path: '/?search=nwm',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -320,7 +320,7 @@ describe('Events listing', () => {
         });
 
         const res = await request({
-            uri: '/?search=action agenda',
+            path: '/?search=action agenda',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -358,7 +358,7 @@ describe('Events listing', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -395,7 +395,7 @@ describe('Events listing', () => {
         });
 
         const res = await request({
-            uri: '/recents',
+            path: '/recents',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -430,7 +430,7 @@ describe('Events listing', () => {
         const ends = moment().subtract(10, 'days').toISOString();
 
         const res = await request({
-            uri: '/recents?ends=' + ends,
+            path: '/recents?ends=' + ends,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -463,7 +463,7 @@ describe('Events listing', () => {
         });
 
         const res = await request({
-            uri: '/recents',
+            path: '/recents',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/events/test/api/events-set-european-event.test.js
+++ b/events/test/api/events-set-european-event.test.js
@@ -28,7 +28,7 @@ describe('Events set European Event', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/single/' + event.id + '/status/european_event',
+            path: '/single/' + event.id + '/status/european_event',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -43,7 +43,7 @@ describe('Events set European Event', () => {
 
     it('should return a validation error on malformed body for changing European Event status', async () => {
         const res = await request({
-            uri: '/single/' + event.id + '/status/european_event',
+            path: '/single/' + event.id + '/status/european_event',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -57,7 +57,7 @@ describe('Events set European Event', () => {
 
     it('should succeed changing European Event status on sane request', async () => {
         const res = await request({
-            uri: '/single/' + event.id + '/status/european_event',
+            path: '/single/' + event.id + '/status/european_event',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -78,7 +78,7 @@ describe('Events set European Event', () => {
         });
 
         const res = await request({
-            uri: '/single/' + europeanEvent.id + '/status/european_event',
+            path: '/single/' + europeanEvent.id + '/status/european_event',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {

--- a/events/test/api/export.test.js
+++ b/events/test/api/export.test.js
@@ -28,8 +28,7 @@ describe('Export all', () => {
         const res = await request({
             path: '/single/' + event.id + '/applications/export',
             method: 'GET',
-            responseType: 'text',
-            responseType: 'buffer', // make response body to Buffer.
+            responseType: 'buffer',
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' }
         });
 
@@ -61,8 +60,7 @@ describe('Export all', () => {
         const res = await request({
             path: '/single/' + event.id + '/applications/export',
             method: 'GET',
-            responseType: 'text',
-            responseType: 'buffer', // make response body to Buffer.
+            responseType: 'buffer',
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' }
         });
 
@@ -95,8 +93,7 @@ describe('Export all', () => {
         const res = await request({
             path: '/single/' + event.id + '/applications/export',
             method: 'GET',
-            responseType: 'text',
-            responseType: 'buffer', // make response body to Buffer.
+            responseType: 'buffer',
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' }
         });
 

--- a/events/test/api/export.test.js
+++ b/events/test/api/export.test.js
@@ -26,10 +26,10 @@ describe('Export all', () => {
             ]
         });
         const res = await request({
-            uri: '/single/' + event.id + '/applications/export',
+            path: '/single/' + event.id + '/applications/export',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'text',
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' }
         });
 
@@ -59,10 +59,10 @@ describe('Export all', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/export',
+            path: '/single/' + event.id + '/applications/export',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'text',
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' }
         });
 
@@ -93,10 +93,10 @@ describe('Export all', () => {
         });
 
         const res = await request({
-            uri: '/single/' + event.id + '/applications/export',
+            path: '/single/' + event.id + '/applications/export',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'text',
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' }
         });
 

--- a/events/test/api/file-upload.test.js
+++ b/events/test/api/file-upload.test.js
@@ -31,11 +31,13 @@ describe('File upload', () => {
         rimraf(config.media_dir);
 
         await request({
-            uri: '/single/' + event.id + '/upload',
+            path: '/single/' + event.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                head_image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -44,11 +46,13 @@ describe('File upload', () => {
 
     it('should fail if the uploaded file is not an image (by extension)', async () => {
         const res = await request({
-            uri: '/single/' + event.id + '/upload',
+            path: '/single/' + event.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/invalid_image.txt')
+            files: {
+                head_image: {
+                    path: './test/assets/invalid_image.txt'
+                }
             }
         });
 
@@ -60,15 +64,13 @@ describe('File upload', () => {
 
     it('should fail if the uploaded file is not an image (by content)', async () => {
         const res = await request({
-            uri: '/single/' + event.id + '/upload',
+            path: '/single/' + event.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
+            files: {
                 head_image: {
-                    value: fs.createReadStream('./test/assets/invalid_image.txt'),
-                    options: {
-                        filename: 'image.jpg'
-                    }
+                    path: './test/assets/invalid_image.txt',
+                    filename: 'image.jpg'
                 }
             }
         });
@@ -81,10 +83,10 @@ describe('File upload', () => {
 
     it('should fail the \'head_image\' field is not specified', async () => {
         const res = await request({
-            uri: '/single/' + event.id + '/upload',
+            path: '/single/' + event.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {}
+            files: {}
         });
 
         expect(res.statusCode).toEqual(422);
@@ -95,11 +97,13 @@ describe('File upload', () => {
 
     it('should upload a file if it\'s valid', async () => {
         const res = await request({
-            uri: '/single/' + event.id + '/upload',
+            path: '/single/' + event.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                head_image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -115,11 +119,13 @@ describe('File upload', () => {
 
     it('should upload a file if it\'s valid, but has extension in capital letters', async () => {
         const res = await request({
-            uri: '/single/' + event.id + '/upload',
+            path: '/single/' + event.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/valid_second_image.PNG')
+            files: {
+                head_image: {
+                    path: './test/assets/valid_second_image.PNG'
+                }
             }
         });
 
@@ -136,11 +142,13 @@ describe('File upload', () => {
     it('should remove the old file', async () => {
         // Uploading
         const firstRequest = await request({
-            uri: '/single/' + event.id + '/upload',
+            path: '/single/' + event.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                head_image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -149,11 +157,13 @@ describe('File upload', () => {
         const eventFromDb = await Event.findByPk(event.id);
 
         const res = await request({
-            uri: '/single/' + event.id + '/upload',
+            path: '/single/' + event.id + '/upload',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                head_image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                head_image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 

--- a/events/test/api/metrics.test.js
+++ b/events/test/api/metrics.test.js
@@ -25,9 +25,9 @@ describe('Metrics requests', () => {
         await generator.createApplication(event, { user_id: 5, body_name: 1, status: 'pending' });
 
         const res = await request({
-            uri: '/metrics',
+            path: '/metrics',
             method: 'GET',
-            json: false
+            responseType: 'text'
         });
 
         expect(res.statusCode).toEqual(200);
@@ -35,9 +35,9 @@ describe('Metrics requests', () => {
 
     test('should return data correctly on /metrics/requests', async () => {
         const res = await request({
-            uri: '/metrics/requests',
+            path: '/metrics/requests',
             method: 'GET',
-            json: false
+            responseType: 'text'
         });
 
         expect(res.statusCode).toEqual(200);

--- a/events/test/api/organizers-listing.test.js
+++ b/events/test/api/organizers-listing.test.js
@@ -20,7 +20,7 @@ describe('Event organizing listing', () => {
     it('should list events where the user is organizer on /mine/organizing GET', async () => {
         const event = await generator.createEvent({ organizers: [{ first_name: 'test', last_name: 'test', user_id: user.id }] });
         const res = await request({
-            uri: '/mine/organizing',
+            path: '/mine/organizing',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -35,7 +35,7 @@ describe('Event organizing listing', () => {
     it('should not include events where the user is not organizer on /mine/organizing GET', async () => {
         await generator.createEvent({ organizers: [{ first_name: 'test', last_name: 'test', user_id: 1337 }] });
         const res = await request({
-            uri: '/mine/organizing',
+            path: '/mine/organizing',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/events/test/scripts/helpers.js
+++ b/events/test/scripts/helpers.js
@@ -1,12 +1,86 @@
-const requestPromise = require('request-promise-native');
+const fs = require('fs');
+const path = require('path');
 
 const config = require('../../config');
 
-const request = requestPromise.defaults({
-    json: true,
-    resolveWithFullResponse: true,
-    simple: false,
-    baseUrl: 'http://localhost:' + config.port
-});
+const baseUrl = 'http://localhost:' + config.port;
+
+const appendQuery = (url, query) => {
+    if (!query) return url;
+
+    const requestUrl = new URL(url);
+    for (const [key, value] of Object.entries(query)) {
+        if (Array.isArray(value)) {
+            value.forEach((item) => requestUrl.searchParams.append(key, item));
+        } else if (typeof value === 'object' && value !== null) {
+            for (const [nestedKey, nestedValue] of Object.entries(value)) {
+                requestUrl.searchParams.append(`${key}[${nestedKey}]`, nestedValue);
+            }
+        } else {
+            requestUrl.searchParams.append(key, value);
+        }
+    }
+
+    return requestUrl.toString();
+};
+
+const request = async (options) => {
+    const parseJson = options.json !== false;
+    const headers = { ...(options.headers || {}) };
+    const fetchOptions = { method: options.method || 'GET', headers };
+
+    if (options.body !== undefined) {
+        if (parseJson) {
+            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+            fetchOptions.body = JSON.stringify(options.body);
+        } else {
+            fetchOptions.body = options.body;
+        }
+    }
+
+    if (options.formData) {
+        const entries = Object.entries(options.formData);
+        const formData = new FormData();
+        for (const [key, item] of entries) {
+            const value = item && item.value ? item.value : item;
+            const filename = item && item.options && item.options.filename
+                ? item.options.filename
+                : path.basename(value.path);
+            const buffer = fs.readFileSync(value.path);
+            formData.append(key, new Blob([buffer]), filename);
+        }
+        if (entries.length > 0) {
+            fetchOptions.body = formData;
+        }
+    }
+
+    const response = await fetch(appendQuery(new URL(options.uri, baseUrl + '/').toString(), options.qs), fetchOptions);
+    if (options.encoding === null) {
+        return {
+            statusCode: response.status,
+            statusMessage: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body: Buffer.from(await response.arrayBuffer())
+        };
+    }
+
+    const text = await response.text();
+    let body = text;
+
+    if (parseJson && text) {
+        try {
+            body = JSON.parse(text);
+        } catch (err) { // eslint-disable-line no-unused-vars
+            body = text;
+        }
+    }
+
+    return {
+        statusCode: response.status,
+        statusMessage: response.statusText,
+        headers: Object.fromEntries(response.headers.entries()),
+        body
+    };
+};
 
 exports.request = request;

--- a/events/test/scripts/helpers.js
+++ b/events/test/scripts/helpers.js
@@ -25,37 +25,33 @@ const appendQuery = (url, query) => {
 };
 
 const request = async (options) => {
-    const parseJson = options.json !== false;
+    const responseType = options.responseType || 'json';
     const headers = { ...(options.headers || {}) };
     const fetchOptions = { method: options.method || 'GET', headers };
 
     if (options.body !== undefined) {
-        if (parseJson) {
-            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
-            fetchOptions.body = JSON.stringify(options.body);
-        } else {
-            fetchOptions.body = options.body;
-        }
+        headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+        fetchOptions.body = JSON.stringify(options.body);
     }
 
-    if (options.formData) {
-        const entries = Object.entries(options.formData);
+    if (options.files) {
+        const entries = Object.entries(options.files);
         const formData = new FormData();
         for (const [key, item] of entries) {
-            const value = item && item.value ? item.value : item;
-            const filename = item && item.options && item.options.filename
-                ? item.options.filename
-                : path.basename(value.path);
-            const buffer = fs.readFileSync(value.path);
+            const filename = item.filename || path.basename(item.path);
+            const buffer = fs.readFileSync(item.path);
             formData.append(key, new Blob([buffer]), filename);
         }
         if (entries.length > 0) {
             fetchOptions.body = formData;
+        } else {
+            headers['Content-Type'] = 'multipart/form-data; boundary=empty-form';
+            fetchOptions.body = '--empty-form\r\n';
         }
     }
 
-    const response = await fetch(appendQuery(new URL(options.uri, baseUrl + '/').toString(), options.qs), fetchOptions);
-    if (options.encoding === null) {
+    const response = await fetch(appendQuery(new URL(options.path, baseUrl + '/').toString(), options.query), fetchOptions);
+    if (responseType === 'buffer') {
         return {
             statusCode: response.status,
             statusMessage: response.statusText,
@@ -67,7 +63,7 @@ const request = async (options) => {
     const text = await response.text();
     let body = text;
 
-    if (parseJson && text) {
+    if (responseType === 'json' && text) {
         try {
             body = JSON.parse(text);
         } catch (err) { // eslint-disable-line no-unused-vars

--- a/knowledge/lib/core.js
+++ b/knowledge/lib/core.js
@@ -11,8 +11,6 @@ module.exports.getMyProfile = async (req) => {
             'X-Auth-Token': req.headers['x-auth-token'],
             'X-Service': 'knowledge'
         },
-        simple: false,
-        json: true,
     });
 
     return myProfileBody;
@@ -27,8 +25,6 @@ module.exports.getMyPermissions = async (req) => {
             'X-Auth-Token': req.headers['x-auth-token'],
             'X-Service': 'knowledge'
         },
-        simple: false,
-        json: true,
     });
 
     return permissionsBody;

--- a/knowledge/lib/core.js
+++ b/knowledge/lib/core.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const { request } = require('./http');
 
 const config = require('../config');
 

--- a/knowledge/lib/http.js
+++ b/knowledge/lib/http.js
@@ -1,9 +1,5 @@
-const parseBody = async (response, parseJson) => {
+const parseBody = async (response) => {
     const text = await response.text();
-
-    if (!parseJson) {
-        return text;
-    }
 
     if (!text) {
         return null;
@@ -17,7 +13,6 @@ const parseBody = async (response, parseJson) => {
 };
 
 module.exports.request = async (options) => {
-    const parseJson = options.json !== false;
     const headers = { ...(options.headers || {}) };
     const fetchOptions = {
         method: options.method || 'GET',
@@ -26,13 +21,13 @@ module.exports.request = async (options) => {
 
     if (options.body !== undefined) {
         headers['Content-Type'] = headers['Content-Type'] || 'application/json';
-        fetchOptions.body = parseJson ? JSON.stringify(options.body) : options.body;
+        fetchOptions.body = JSON.stringify(options.body);
     }
 
     const response = await fetch(options.url, fetchOptions);
-    const body = await parseBody(response, parseJson);
+    const body = await parseBody(response);
 
-    if (options.resolveWithFullResponse) {
+    if (options.fullResponse) {
         return {
             statusCode: response.status,
             statusMessage: response.statusText,

--- a/knowledge/lib/http.js
+++ b/knowledge/lib/http.js
@@ -1,0 +1,45 @@
+const parseBody = async (response, parseJson) => {
+    const text = await response.text();
+
+    if (!parseJson) {
+        return text;
+    }
+
+    if (!text) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch (err) { // eslint-disable-line no-unused-vars
+        return text;
+    }
+};
+
+module.exports.request = async (options) => {
+    const parseJson = options.json !== false;
+    const headers = { ...(options.headers || {}) };
+    const fetchOptions = {
+        method: options.method || 'GET',
+        headers
+    };
+
+    if (options.body !== undefined) {
+        headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+        fetchOptions.body = parseJson ? JSON.stringify(options.body) : options.body;
+    }
+
+    const response = await fetch(options.url, fetchOptions);
+    const body = await parseBody(response, parseJson);
+
+    if (options.resolveWithFullResponse) {
+        return {
+            statusCode: response.status,
+            statusMessage: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body
+        };
+    }
+
+    return body;
+};

--- a/knowledge/package-lock.json
+++ b/knowledge/package-lock.json
@@ -21,8 +21,6 @@
         "on-finished": "^2.4.1",
         "pg": "^8.20.0",
         "prom-client": "^15.1.3",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "sequelize": "^6.37.8",
         "sequelize-cli": "^6.6.3"
       },
@@ -1990,6 +1988,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2217,24 +2216,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2244,12 +2225,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2275,21 +2250,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "license": "MIT"
     },
     "node_modules/babel-jest": {
       "version": "30.3.0",
@@ -2426,15 +2386,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "node_modules/bintrees": {
       "version": "1.0.2",
@@ -2658,12 +2609,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2902,18 +2847,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -2991,12 +2924,6 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "license": "MIT"
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3009,18 +2936,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/data-view-buffer": {
@@ -3162,15 +3077,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3253,16 +3159,6 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/editorconfig": {
       "version": "1.0.7",
@@ -4136,31 +4032,18 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -4344,29 +4227,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/forwarded": {
@@ -4584,15 +4444,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -4708,29 +4559,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -4849,21 +4677,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/human-signals": {
@@ -5410,12 +5223,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -5480,12 +5287,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6257,12 +6058,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6290,16 +6085,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -6313,6 +6103,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -6338,21 +6129,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/keyv": {
@@ -7154,15 +6930,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -7516,12 +7283,6 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT"
-    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
@@ -7838,18 +7599,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -7864,6 +7613,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7995,90 +7745,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "license": "ISC",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "license": "ISC",
-      "dependencies": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
-      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-directory": {
@@ -8931,31 +8597,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stack-generator": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
@@ -9001,15 +8642,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -9374,19 +9006,6 @@
       "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==",
       "license": "MIT"
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -9430,24 +9049,6 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -9727,6 +9328,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -9782,20 +9384,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/walker": {

--- a/knowledge/package.json
+++ b/knowledge/package.json
@@ -65,8 +65,6 @@
     "on-finished": "^2.4.1",
     "pg": "^8.20.0",
     "prom-client": "^15.1.3",
-    "request": "^2.88.2",
-    "request-promise-native": "^1.0.9",
     "sequelize": "^6.37.8",
     "sequelize-cli": "^6.6.3"
   }

--- a/knowledge/test/api/api-requests.test.js
+++ b/knowledge/test/api/api-requests.test.js
@@ -15,7 +15,7 @@ describe('API requests', () => {
 
     test('should fail if X-Auth-Token is not specified', async () => {
         const res = await request({
-            uri: '/courses',
+            path: '/courses',
             method: 'GET'
         });
 
@@ -27,7 +27,7 @@ describe('API requests', () => {
         mock.mockAll({ core: { netError: true } });
 
         const res = await request({
-            uri: '/courses',
+            path: '/courses',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -42,7 +42,7 @@ describe('API requests', () => {
         mock.mockAll({ core: { badResponse: true } });
 
         const res = await request({
-            uri: '/courses',
+            path: '/courses',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -57,7 +57,7 @@ describe('API requests', () => {
         mock.mockAll({ core: { unauthorized: true } });
 
         const res = await request({
-            uri: '/courses',
+            path: '/courses',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -72,7 +72,7 @@ describe('API requests', () => {
         mock.mockAll({ mainPermissions: { netError: true } });
 
         const res = await request({
-            uri: '/courses',
+            path: '/courses',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -87,7 +87,7 @@ describe('API requests', () => {
         mock.mockAll({ mainPermissions: { badResponse: true } });
 
         const res = await request({
-            uri: '/courses',
+            path: '/courses',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -102,7 +102,7 @@ describe('API requests', () => {
         mock.mockAll({ mainPermissions: { unauthorized: true } });
 
         const res = await request({
-            uri: '/courses',
+            path: '/courses',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -115,7 +115,7 @@ describe('API requests', () => {
 
     test('should fail if body is not JSON', async () => {
         const res = await request({
-            uri: '/courses',
+            path: '/courses',
             method: 'POST',
             headers: {
                 'X-Auth-Token': 'blablabla',
@@ -130,7 +130,7 @@ describe('API requests', () => {
 
     test('should fail on accessing non-existant endpoint', async () => {
         const res = await request({
-            uri: '/nonexistant',
+            path: '/nonexistant',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/knowledge/test/api/chapter-creating.test.js
+++ b/knowledge/test/api/chapter-creating.test.js
@@ -28,7 +28,7 @@ describe('Chapter creating', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters',
+            path: '/courses/' + course.id + '/chapters',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateChapter()
@@ -42,7 +42,7 @@ describe('Chapter creating', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters',
+            path: '/courses/' + course.id + '/chapters',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateChapter({ name: 'test' })
@@ -67,7 +67,7 @@ describe('Chapter creating', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters',
+            path: '/courses/' + course.id + '/chapters',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateChapter({ name: null })

--- a/knowledge/test/api/chapter-deleting.test.js
+++ b/knowledge/test/api/chapter-deleting.test.js
@@ -29,7 +29,7 @@ describe('Chapter deleting', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id,
+            path: '/courses/' + course.id + '/chapters/' + chapter.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -43,7 +43,7 @@ describe('Chapter deleting', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id,
+            path: '/courses/' + course.id + '/chapters/' + chapter.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -62,7 +62,7 @@ describe('Chapter deleting', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/1337',
+            path: '/courses/' + course.id + '/chapters/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/knowledge/test/api/chapter-details.test.js
+++ b/knowledge/test/api/chapter-details.test.js
@@ -28,7 +28,7 @@ describe('Chapter details', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id,
+            path: '/courses/' + course.id + '/chapters/' + chapter.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -42,7 +42,7 @@ describe('Chapter details', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id,
+            path: '/courses/' + course.id + '/chapters/' + chapter.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -59,7 +59,7 @@ describe('Chapter details', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/1337',
+            path: '/courses/' + course.id + '/chapters/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -74,7 +74,7 @@ describe('Chapter details', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/nan',
+            path: '/courses/' + course.id + '/chapters/nan',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/knowledge/test/api/chapter-editing.test.js
+++ b/knowledge/test/api/chapter-editing.test.js
@@ -29,7 +29,7 @@ describe('Chapter editing', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id,
+            path: '/courses/' + course.id + '/chapters/' + chapter.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: 'test' }
@@ -44,7 +44,7 @@ describe('Chapter editing', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id,
+            path: '/courses/' + course.id + '/chapters/' + chapter.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: 'test' }
@@ -68,7 +68,7 @@ describe('Chapter editing', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id,
+            path: '/courses/' + course.id + '/chapters/' + chapter.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: null }
@@ -84,7 +84,7 @@ describe('Chapter editing', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/1337',
+            path: '/courses/' + course.id + '/chapters/1337',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: 'test' }

--- a/knowledge/test/api/chapter-listing.test.js
+++ b/knowledge/test/api/chapter-listing.test.js
@@ -27,7 +27,7 @@ describe('Chapter listing', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters',
+            path: '/courses/' + course.id + '/chapters',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -41,7 +41,7 @@ describe('Chapter listing', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters',
+            path: '/courses/' + course.id + '/chapters',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -63,7 +63,7 @@ describe('Chapter listing', () => {
         await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters?limit=1&offset=1', // second one should be returned
+            path: '/courses/' + course.id + '/chapters?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -87,7 +87,7 @@ describe('Chapter listing', () => {
         const secondChapter = await generator.createChapter({ name: 'bbb', course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters?sort=name&direction=desc', // second one should be returned
+            path: '/courses/' + course.id + '/chapters?sort=name&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/knowledge/test/api/course-creating.test.js
+++ b/knowledge/test/api/course-creating.test.js
@@ -25,7 +25,7 @@ describe('Course creating', () => {
     test('should fail if no permission', async () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
         const res = await request({
-            uri: '/courses',
+            path: '/courses',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateCourse()
@@ -41,7 +41,7 @@ describe('Course creating', () => {
         });
 
         const res = await request({
-            uri: '/courses',
+            path: '/courses',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: course
@@ -62,7 +62,7 @@ describe('Course creating', () => {
 
     test('should fail if name is not set', async () => {
         const res = await request({
-            uri: '/courses',
+            path: '/courses',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateCourse({ name: null })

--- a/knowledge/test/api/course-deleting.test.js
+++ b/knowledge/test/api/course-deleting.test.js
@@ -28,7 +28,7 @@ describe('Course deleting', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses/' + course.id,
+            path: '/courses/' + course.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -41,7 +41,7 @@ describe('Course deleting', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses/' + course.id,
+            path: '/courses/' + course.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -58,7 +58,7 @@ describe('Course deleting', () => {
 
     test('should fail if course is not found', async () => {
         const res = await request({
-            uri: '/courses/1337',
+            path: '/courses/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/knowledge/test/api/course-details.test.js
+++ b/knowledge/test/api/course-details.test.js
@@ -27,7 +27,7 @@ describe('Course details', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses/' + course.id,
+            path: '/courses/' + course.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -40,7 +40,7 @@ describe('Course details', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses/' + course.id,
+            path: '/courses/' + course.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -55,7 +55,7 @@ describe('Course details', () => {
 
     test('should fail if course is not found', async () => {
         const res = await request({
-            uri: '/courses/1337',
+            path: '/courses/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -68,7 +68,7 @@ describe('Course details', () => {
 
     test('should fail if course id is not a number', async () => {
         const res = await request({
-            uri: '/courses/nan',
+            path: '/courses/nan',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/knowledge/test/api/course-editing.test.js
+++ b/knowledge/test/api/course-editing.test.js
@@ -28,7 +28,7 @@ describe('Course editing', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses/' + course.id,
+            path: '/courses/' + course.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: 'test' }
@@ -42,7 +42,7 @@ describe('Course editing', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses/' + course.id,
+            path: '/courses/' + course.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: 'test' }
@@ -65,7 +65,7 @@ describe('Course editing', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses/' + course.id,
+            path: '/courses/' + course.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: null }
@@ -79,7 +79,7 @@ describe('Course editing', () => {
 
     test('should fail if course is not found', async () => {
         const res = await request({
-            uri: '/courses/1337',
+            path: '/courses/1337',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: 'test' }

--- a/knowledge/test/api/course-listing.test.js
+++ b/knowledge/test/api/course-listing.test.js
@@ -24,7 +24,7 @@ describe('Course listing', () => {
     test('should fail if no permission', async () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
         const res = await request({
-            uri: '/courses',
+            path: '/courses',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -37,7 +37,7 @@ describe('Course listing', () => {
         const course = await generator.createCourse();
 
         const res = await request({
-            uri: '/courses',
+            path: '/courses',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -57,7 +57,7 @@ describe('Course listing', () => {
         await generator.createCourse();
 
         const res = await request({
-            uri: '/courses?limit=1&offset=1', // second one should be returned
+            path: '/courses?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -79,7 +79,7 @@ describe('Course listing', () => {
         const secondCourse = await generator.createCourse({ name: 'bbb' });
 
         const res = await request({
-            uri: '/courses?sort=name&direction=desc', // second one should be returned
+            path: '/courses?sort=name&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/knowledge/test/api/metrics.test.js
+++ b/knowledge/test/api/metrics.test.js
@@ -20,9 +20,9 @@ describe('Metrics requests', () => {
         await generator.createCourse();
 
         const res = await request({
-            uri: '/metrics',
+            path: '/metrics',
             method: 'GET',
-            json: false
+            responseType: 'text'
         });
 
         expect(res.statusCode).toEqual(200);
@@ -30,9 +30,9 @@ describe('Metrics requests', () => {
 
     test('should return data correctly on /metrics/requests', async () => {
         const res = await request({
-            uri: '/metrics/requests',
+            path: '/metrics/requests',
             method: 'GET',
-            json: false
+            responseType: 'text'
         });
 
         expect(res.statusCode).toEqual(200);

--- a/knowledge/test/api/page-creating.test.js
+++ b/knowledge/test/api/page-creating.test.js
@@ -29,7 +29,7 @@ describe('Page creating', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages',
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generatePage()
@@ -44,7 +44,7 @@ describe('Page creating', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages',
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generatePage({ name: 'test' })
@@ -70,7 +70,7 @@ describe('Page creating', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages',
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generatePage({ name: null })

--- a/knowledge/test/api/page-deleting.test.js
+++ b/knowledge/test/api/page-deleting.test.js
@@ -30,7 +30,7 @@ describe('Page deleting', () => {
         const page = await generator.createPage({ chapter_id: chapter.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/' + page.id,
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/' + page.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -45,7 +45,7 @@ describe('Page deleting', () => {
         const page = await generator.createPage({ chapter_id: chapter.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/' + page.id,
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/' + page.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -65,7 +65,7 @@ describe('Page deleting', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/1337',
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/knowledge/test/api/page-details.test.js
+++ b/knowledge/test/api/page-details.test.js
@@ -29,7 +29,7 @@ describe('Page details', () => {
         const page = await generator.createPage({ chapter_id: chapter.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/' + page.id,
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/' + page.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -44,7 +44,7 @@ describe('Page details', () => {
         const page = await generator.createPage({ chapter_id: chapter.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/' + page.id,
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/' + page.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -62,7 +62,7 @@ describe('Page details', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/1337',
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -78,7 +78,7 @@ describe('Page details', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/nan',
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/nan',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/knowledge/test/api/page-editing.test.js
+++ b/knowledge/test/api/page-editing.test.js
@@ -30,7 +30,7 @@ describe('Page editing', () => {
         const page = await generator.createPage({ chapter_id: chapter.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/' + page.id,
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/' + page.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: 'test' }
@@ -46,7 +46,7 @@ describe('Page editing', () => {
         const page = await generator.createPage({ chapter_id: chapter.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/' + page.id,
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/' + page.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: 'test' }
@@ -71,7 +71,7 @@ describe('Page editing', () => {
         const page = await generator.createPage({ chapter_id: chapter.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/' + page.id,
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/' + page.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: null }
@@ -88,7 +88,7 @@ describe('Page editing', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/1337',
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages/1337',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { name: 'test' }

--- a/knowledge/test/api/page-listing.test.js
+++ b/knowledge/test/api/page-listing.test.js
@@ -28,7 +28,7 @@ describe('Page listing', () => {
         const chapter = await generator.createChapter({ course_id: course.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages',
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -43,7 +43,7 @@ describe('Page listing', () => {
         const page = await generator.createPage({ chapter_id: chapter.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages',
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -66,7 +66,7 @@ describe('Page listing', () => {
         await generator.createPage({ chapter_id: chapter.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages?limit=1&offset=1', // second one should be returned
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages?limit=1&offset=1', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -91,7 +91,7 @@ describe('Page listing', () => {
         const secondPage = await generator.createPage({ name: 'bbb', chapter_id: chapter.id });
 
         const res = await request({
-            uri: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages?sort=name&direction=desc', // second one should be returned
+            path: '/courses/' + course.id + '/chapters/' + chapter.id + '/pages?sort=name&direction=desc', // second one should be returned
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/knowledge/test/scripts/helpers.js
+++ b/knowledge/test/scripts/helpers.js
@@ -22,24 +22,20 @@ const appendQuery = (url, query) => {
 };
 
 const request = async (options) => {
-    const parseJson = options.json !== false;
+    const responseType = options.responseType || 'json';
     const headers = { ...(options.headers || {}) };
     const fetchOptions = { method: options.method || 'GET', headers };
 
     if (options.body !== undefined) {
-        if (parseJson) {
-            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
-            fetchOptions.body = JSON.stringify(options.body);
-        } else {
-            fetchOptions.body = options.body;
-        }
+        headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+        fetchOptions.body = JSON.stringify(options.body);
     }
 
-    const response = await fetch(appendQuery(new URL(options.uri, baseUrl + '/').toString(), options.qs), fetchOptions);
+    const response = await fetch(appendQuery(new URL(options.path, baseUrl + '/').toString(), options.query), fetchOptions);
     const text = await response.text();
     let body = text;
 
-    if (parseJson && text) {
+    if (responseType === 'json' && text) {
         try {
             body = JSON.parse(text);
         } catch (err) { // eslint-disable-line no-unused-vars

--- a/knowledge/test/scripts/helpers.js
+++ b/knowledge/test/scripts/helpers.js
@@ -1,13 +1,58 @@
-const requestPromise = require('request-promise-native');
-
 const config = require('../../config');
 
-const request = requestPromise.defaults({
-    json: true,
-    resolveWithFullResponse: true,
-    simple: false,
-    baseUrl: 'http://localhost:' + config.port,
-    qsStringifyOptions: { arrayFormat: 'brackets' }
-});
+const baseUrl = 'http://localhost:' + config.port;
+
+const appendQuery = (url, query) => {
+    if (!query) return url;
+
+    const requestUrl = new URL(url);
+    for (const [key, value] of Object.entries(query)) {
+        if (Array.isArray(value)) {
+            value.forEach((item) => requestUrl.searchParams.append(key, item));
+        } else if (typeof value === 'object' && value !== null) {
+            for (const [nestedKey, nestedValue] of Object.entries(value)) {
+                requestUrl.searchParams.append(`${key}[${nestedKey}]`, nestedValue);
+            }
+        } else {
+            requestUrl.searchParams.append(key, value);
+        }
+    }
+
+    return requestUrl.toString();
+};
+
+const request = async (options) => {
+    const parseJson = options.json !== false;
+    const headers = { ...(options.headers || {}) };
+    const fetchOptions = { method: options.method || 'GET', headers };
+
+    if (options.body !== undefined) {
+        if (parseJson) {
+            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+            fetchOptions.body = JSON.stringify(options.body);
+        } else {
+            fetchOptions.body = options.body;
+        }
+    }
+
+    const response = await fetch(appendQuery(new URL(options.uri, baseUrl + '/').toString(), options.qs), fetchOptions);
+    const text = await response.text();
+    let body = text;
+
+    if (parseJson && text) {
+        try {
+            body = JSON.parse(text);
+        } catch (err) { // eslint-disable-line no-unused-vars
+            body = text;
+        }
+    }
+
+    return {
+        statusCode: response.status,
+        statusMessage: response.statusText,
+        headers: Object.fromEntries(response.headers.entries()),
+        body
+    };
+};
 
 exports.request = request;

--- a/network/lib/core.js
+++ b/network/lib/core.js
@@ -11,8 +11,6 @@ module.exports.getMyProfile = async (req) => {
             'X-Auth-Token': req.headers['x-auth-token'],
             'X-Service': 'network'
         },
-        simple: false,
-        json: true,
     });
 
     return myProfileBody;
@@ -27,8 +25,6 @@ module.exports.getMyPermissions = async (req) => {
             'X-Auth-Token': req.headers['x-auth-token'],
             'X-Service': 'network'
         },
-        simple: false,
-        json: true,
     });
 
     return permissionsBody;
@@ -43,9 +39,7 @@ const makeRequest = (options) => {
             'X-Auth-Token': options.token,
             'X-Service': 'network'
         },
-        simple: false,
-        json: true,
-        resolveWithFullResponse: options.resolveWithFullResponse || false
+        fullResponse: options.fullResponse || false
     };
 
     if (options.body) {

--- a/network/lib/core.js
+++ b/network/lib/core.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const { request } = require('./http');
 
 const config = require('../config');
 

--- a/network/lib/http.js
+++ b/network/lib/http.js
@@ -1,9 +1,5 @@
-const parseBody = async (response, parseJson) => {
+const parseBody = async (response) => {
     const text = await response.text();
-
-    if (!parseJson) {
-        return text;
-    }
 
     if (!text) {
         return null;
@@ -17,7 +13,6 @@ const parseBody = async (response, parseJson) => {
 };
 
 module.exports.request = async (options) => {
-    const parseJson = options.json !== false;
     const headers = { ...(options.headers || {}) };
     const fetchOptions = {
         method: options.method || 'GET',
@@ -26,13 +21,13 @@ module.exports.request = async (options) => {
 
     if (options.body !== undefined) {
         headers['Content-Type'] = headers['Content-Type'] || 'application/json';
-        fetchOptions.body = parseJson ? JSON.stringify(options.body) : options.body;
+        fetchOptions.body = JSON.stringify(options.body);
     }
 
     const response = await fetch(options.url, fetchOptions);
-    const body = await parseBody(response, parseJson);
+    const body = await parseBody(response);
 
-    if (options.resolveWithFullResponse) {
+    if (options.fullResponse) {
         return {
             statusCode: response.status,
             statusMessage: response.statusText,

--- a/network/lib/http.js
+++ b/network/lib/http.js
@@ -1,0 +1,45 @@
+const parseBody = async (response, parseJson) => {
+    const text = await response.text();
+
+    if (!parseJson) {
+        return text;
+    }
+
+    if (!text) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch (err) { // eslint-disable-line no-unused-vars
+        return text;
+    }
+};
+
+module.exports.request = async (options) => {
+    const parseJson = options.json !== false;
+    const headers = { ...(options.headers || {}) };
+    const fetchOptions = {
+        method: options.method || 'GET',
+        headers
+    };
+
+    if (options.body !== undefined) {
+        headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+        fetchOptions.body = parseJson ? JSON.stringify(options.body) : options.body;
+    }
+
+    const response = await fetch(options.url, fetchOptions);
+    const body = await parseBody(response, parseJson);
+
+    if (options.resolveWithFullResponse) {
+        return {
+            statusCode: response.status,
+            statusMessage: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body
+        };
+    }
+
+    return body;
+};

--- a/network/lib/mailer.js
+++ b/network/lib/mailer.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const { request } = require('./http');
 
 const config = require('../config');
 

--- a/network/lib/mailer.js
+++ b/network/lib/mailer.js
@@ -6,8 +6,6 @@ module.exports.sendMail = async (options) => {
     const mailerBody = await request({
         url: config.mailer.url + ':' + config.mailer.port + '/',
         method: 'POST',
-        simple: false,
-        json: true,
         body: {
             from: options.from,
             to: options.to,

--- a/network/lib/middlewares.js
+++ b/network/lib/middlewares.js
@@ -28,13 +28,11 @@ exports.authenticateUser = async (req, res, next) => {
             'X-Requested-With': 'XMLHttpRequest',
             'X-Auth-Token': req.headers['x-auth-token'],
         },
-        simple: false,
-        json: true,
         body: {
             action: 'manage_network',
             object: 'boards'
         },
-        resolveWithFullResponse: true
+        fullResponse: true
     });
 
     req.manageRequest = manageRequest;

--- a/network/lib/middlewares.js
+++ b/network/lib/middlewares.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const { request } = require('./http');
 
 const core = require('./core');
 const errors = require('./errors');

--- a/network/package-lock.json
+++ b/network/package-lock.json
@@ -22,8 +22,6 @@
         "on-finished": "^2.4.1",
         "pg": "^8.20.0",
         "prom-client": "^15.1.3",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "sequelize": "^6.37.8",
         "sequelize-cli": "^6.6.3"
       },
@@ -1997,6 +1995,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2224,24 +2223,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2251,12 +2232,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2282,21 +2257,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "license": "MIT"
     },
     "node_modules/babel-jest": {
       "version": "30.3.0",
@@ -2433,15 +2393,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "node_modules/bintrees": {
       "version": "1.0.2",
@@ -2665,12 +2616,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2909,18 +2854,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -2998,12 +2931,6 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "license": "MIT"
-    },
     "node_modules/cron": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/cron/-/cron-3.5.0.tgz",
@@ -3026,18 +2953,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/data-view-buffer": {
@@ -3179,15 +3094,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3270,16 +3176,6 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/editorconfig": {
       "version": "1.0.7",
@@ -4153,31 +4049,18 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -4361,29 +4244,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/forwarded": {
@@ -4601,15 +4461,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -4725,29 +4576,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -4866,21 +4694,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/human-signals": {
@@ -5427,12 +5240,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -5497,12 +5304,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6274,12 +6075,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6307,16 +6102,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -6330,6 +6120,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -6355,21 +6146,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/keyv": {
@@ -7180,15 +6956,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -7542,12 +7309,6 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT"
-    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
@@ -7864,18 +7625,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -7890,6 +7639,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8021,90 +7771,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "license": "ISC",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "license": "ISC",
-      "dependencies": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
-      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-directory": {
@@ -8957,31 +8623,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stack-generator": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
@@ -9027,15 +8668,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -9400,19 +9032,6 @@
       "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==",
       "license": "MIT"
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -9456,24 +9075,6 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -9753,6 +9354,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -9808,20 +9410,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/walker": {

--- a/network/package.json
+++ b/network/package.json
@@ -66,8 +66,6 @@
     "on-finished": "^2.4.1",
     "pg": "^8.20.0",
     "prom-client": "^15.1.3",
-    "request": "^2.88.2",
-    "request-promise-native": "^1.0.9",
     "sequelize": "^6.37.8",
     "sequelize-cli": "^6.6.3"
   }

--- a/network/test/api/antenna-criteria.test.js
+++ b/network/test/api/antenna-criteria.test.js
@@ -25,7 +25,7 @@ describe('Antenna Criteria', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/antennaCriteria/1',
+            path: '/antennaCriteria/1',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -39,7 +39,7 @@ describe('Antenna Criteria', () => {
         await generator.createAntennaCriterion({ agora_id: 1 });
 
         const res = await request({
-            uri: '/antennaCriteria/1',
+            path: '/antennaCriteria/1',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -56,7 +56,7 @@ describe('Antenna Criteria', () => {
         await generator.createAntennaCriterion({ agora_id: 2 });
 
         const res = await request({
-            uri: '/antennaCriteria/1',
+            path: '/antennaCriteria/1',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -73,7 +73,7 @@ describe('Antenna Criteria', () => {
         const criterion = generator.generateAntennaCriterion();
 
         const res = await request({
-            uri: '/antennaCriteria',
+            path: '/antennaCriteria',
             method: 'PUT',
             body: criterion,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -89,7 +89,7 @@ describe('Antenna Criteria', () => {
     //     const criterion = generator.generateAntennaCriterion({ antenna_criterion: 'fulfilment report' });
 
     //     const res = await request({
-    //         uri: '/antennaCriteria',
+    //         path: '/antennaCriteria',
     //         method: 'PUT',
     //         body: criterion,
     //         headers: { 'X-Auth-Token': 'blablabla' }
@@ -105,7 +105,7 @@ describe('Antenna Criteria', () => {
     //     const criterion = generator.generateAntennaCriterion({ antenna_criterion: 'communication' });
 
     //     const res = await request({
-    //         uri: '/antennaCriteria',
+    //         path: '/antennaCriteria',
     //         method: 'PUT',
     //         body: criterion,
     //         headers: { 'X-Auth-Token': 'blablabla' }
@@ -119,7 +119,7 @@ describe('Antenna Criteria', () => {
         const criterion = generator.generateAntennaCriterion({ agora_id: null });
 
         const res = await request({
-            uri: '/antennaCriteria',
+            path: '/antennaCriteria',
             method: 'PUT',
             body: criterion,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -136,7 +136,7 @@ describe('Antenna Criteria', () => {
         const criterion = generator.generateAntennaCriterion({ body_id: null });
 
         const res = await request({
-            uri: '/antennaCriteria',
+            path: '/antennaCriteria',
             method: 'PUT',
             body: criterion,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -153,7 +153,7 @@ describe('Antenna Criteria', () => {
         const criterion = generator.generateAntennaCriterion({ antenna_criterion: null });
 
         const res = await request({
-            uri: '/antennaCriteria',
+            path: '/antennaCriteria',
             method: 'PUT',
             body: criterion,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -168,7 +168,7 @@ describe('Antenna Criteria', () => {
         const criterion = generator.generateAntennaCriterion({ antenna_criterion: 'blabla' });
 
         const res = await request({
-            uri: '/antennaCriteria',
+            path: '/antennaCriteria',
             method: 'PUT',
             body: criterion,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -183,7 +183,7 @@ describe('Antenna Criteria', () => {
         const criterion = generator.generateAntennaCriterion({ value: 'blabla' });
 
         const res = await request({
-            uri: '/antennaCriteria',
+            path: '/antennaCriteria',
             method: 'PUT',
             body: criterion,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -200,7 +200,7 @@ describe('Antenna Criteria', () => {
         const criterion = generator.generateAntennaCriterion();
 
         const res = await request({
-            uri: '/antennaCriteria',
+            path: '/antennaCriteria',
             method: 'PUT',
             body: criterion,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -220,7 +220,7 @@ describe('Antenna Criteria', () => {
         const criterion = generator.generateAntennaCriterion({ agora_id: 1, body_id: 2, antenna_criterion: 'communication', value: 'true', comment: 'They are responding!' });
 
         const res = await request({
-            uri: '/antennaCriteria',
+            path: '/antennaCriteria',
             method: 'PUT',
             body: criterion,
             headers: { 'X-Auth-Token': 'blablabla' }

--- a/network/test/api/api-requests.test.js
+++ b/network/test/api/api-requests.test.js
@@ -15,7 +15,7 @@ describe('API requests', () => {
 
     test('should fail if X-Auth-Token is not specified', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET'
         });
 
@@ -27,7 +27,7 @@ describe('API requests', () => {
         mock.mockAll({ core: { netError: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -42,7 +42,7 @@ describe('API requests', () => {
         mock.mockAll({ core: { badResponse: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -57,7 +57,7 @@ describe('API requests', () => {
         mock.mockAll({ core: { unauthorized: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -72,7 +72,7 @@ describe('API requests', () => {
         mock.mockAll({ mainPermissions: { netError: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -87,7 +87,7 @@ describe('API requests', () => {
         mock.mockAll({ mainPermissions: { badResponse: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -102,7 +102,7 @@ describe('API requests', () => {
         mock.mockAll({ mainPermissions: { unauthorized: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -115,7 +115,7 @@ describe('API requests', () => {
 
     test('should fail if body is not JSON', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: {
                 'X-Auth-Token': 'blablabla',
@@ -130,7 +130,7 @@ describe('API requests', () => {
 
     test('should fail on accessing non-existant endpoint', async () => {
         const res = await request({
-            uri: '/nonexistant',
+            path: '/nonexistant',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 

--- a/network/test/api/board-creation.test.js
+++ b/network/test/api/board-creation.test.js
@@ -31,7 +31,7 @@ describe('Board creation', () => {
         const board = generator.generateBoard();
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/boards',
+            path: '/bodies/' + body.id + '/boards',
             method: 'POST',
             body: board,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -45,7 +45,7 @@ describe('Board creation', () => {
         const board = generator.generateBoard({ elected_date: null });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/boards',
+            path: '/bodies/' + body.id + '/boards',
             method: 'POST',
             body: board,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -62,7 +62,7 @@ describe('Board creation', () => {
         const board = generator.generateBoard({ elected_date: faker.date.future() });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/boards',
+            path: '/bodies/' + body.id + '/boards',
             method: 'POST',
             body: board,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -79,7 +79,7 @@ describe('Board creation', () => {
         const board = generator.generateBoard({ start_date: null });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/boards',
+            path: '/bodies/' + body.id + '/boards',
             method: 'POST',
             body: board,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -96,7 +96,7 @@ describe('Board creation', () => {
         const board = generator.generateBoard({ end_date: faker.date.past() });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/boards',
+            path: '/bodies/' + body.id + '/boards',
             method: 'POST',
             body: board,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -113,7 +113,7 @@ describe('Board creation', () => {
         const board = generator.generateBoard({ image_id: 'NaN' });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/boards',
+            path: '/bodies/' + body.id + '/boards',
             method: 'POST',
             body: board,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -131,7 +131,7 @@ describe('Board creation', () => {
         const board = generator.generateBoard({ president: user.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/boards',
+            path: '/bodies/' + body.id + '/boards',
             method: 'POST',
             body: board,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -147,7 +147,7 @@ describe('Board creation', () => {
         const board = generator.generateBoard({ president: user.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/boards',
+            path: '/bodies/' + body.id + '/boards',
             method: 'POST',
             body: board,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -163,7 +163,7 @@ describe('Board creation', () => {
         const board = generator.generateBoard({ president: user.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/boards',
+            path: '/bodies/' + body.id + '/boards',
             method: 'POST',
             body: board,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -179,7 +179,7 @@ describe('Board creation', () => {
         const board = generator.generateBoard({ body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/boards',
+            path: '/bodies/' + body.id + '/boards',
             method: 'POST',
             body: board,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -195,7 +195,7 @@ describe('Board creation', () => {
         const board = generator.generateBoard({ body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/boards',
+            path: '/bodies/' + body.id + '/boards',
             method: 'POST',
             body: board,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -211,7 +211,7 @@ describe('Board creation', () => {
         const board = generator.generateBoard({ body_id: body.id });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/boards',
+            path: '/bodies/' + body.id + '/boards',
             method: 'POST',
             body: board,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -226,7 +226,7 @@ describe('Board creation', () => {
         const board = generator.generateBoard({});
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/boards',
+            path: '/bodies/' + body.id + '/boards',
             method: 'POST',
             body: board,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -248,7 +248,7 @@ describe('Board creation', () => {
         const board = generator.generateBoard({ other_members: [{ function: 'Test', user_id: user.id }] });
 
         const res = await request({
-            uri: '/bodies/' + body.id + '/boards',
+            path: '/bodies/' + body.id + '/boards',
             method: 'POST',
             body: board,
             headers: { 'X-Auth-Token': 'blablabla' }

--- a/network/test/api/board-deleting.test.js
+++ b/network/test/api/board-deleting.test.js
@@ -28,7 +28,7 @@ describe('Board deleting', () => {
         const board = await generator.createBoard();
 
         const res = await request({
-            uri: '/bodies/' + board.body_id + '/boards/' + board.id,
+            path: '/bodies/' + board.body_id + '/boards/' + board.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -41,7 +41,7 @@ describe('Board deleting', () => {
         const board = await generator.createBoard({});
 
         const res = await request({
-            uri: '/bodies/' + board.body_id + '/boards/' + board.id,
+            path: '/bodies/' + board.body_id + '/boards/' + board.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -58,7 +58,7 @@ describe('Board deleting', () => {
 
     test('should fail if board is not found', async () => {
         const res = await request({
-            uri: '/bodies/1/boards/1337',
+            path: '/bodies/1/boards/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/network/test/api/board-details.test.js
+++ b/network/test/api/board-details.test.js
@@ -27,7 +27,7 @@ describe('Board details', () => {
         const board = await generator.createBoard();
 
         const res = await request({
-            uri: '/bodies/' + board.body_id + '/boards/' + board.id,
+            path: '/bodies/' + board.body_id + '/boards/' + board.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -40,7 +40,7 @@ describe('Board details', () => {
         const board = await generator.createBoard();
 
         const res = await request({
-            uri: '/bodies/' + board.body_id + '/boards/' + board.id,
+            path: '/bodies/' + board.body_id + '/boards/' + board.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -54,7 +54,7 @@ describe('Board details', () => {
 
     test('should fail if board is not found', async () => {
         const res = await request({
-            uri: '/bodies/1/boards/1337',
+            path: '/bodies/1/boards/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -67,7 +67,7 @@ describe('Board details', () => {
 
     test('should fail if board id is not a number', async () => {
         const res = await request({
-            uri: '/bodies/1/boards/NaN',
+            path: '/bodies/1/boards/NaN',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/network/test/api/board-editing.test.js
+++ b/network/test/api/board-editing.test.js
@@ -27,7 +27,7 @@ describe('Board editing', () => {
         const board = await generator.createBoard();
 
         const res = await request({
-            uri: '/bodies/' + board.body_id + '/boards/' + board.id,
+            path: '/bodies/' + board.body_id + '/boards/' + board.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: board
@@ -41,7 +41,7 @@ describe('Board editing', () => {
         const board = await generator.createBoard({ message: 'some text' });
 
         await request({
-            uri: '/bodies/' + board.body_id + '/boards/' + board.id,
+            path: '/bodies/' + board.body_id + '/boards/' + board.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -50,7 +50,7 @@ describe('Board editing', () => {
         });
 
         const res = await request({
-            uri: '/bodies/' + board.body_id + '/boards/' + board.id,
+            path: '/bodies/' + board.body_id + '/boards/' + board.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/network/test/api/board-listing.test.js
+++ b/network/test/api/board-listing.test.js
@@ -28,7 +28,7 @@ describe('Board listing', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/boards',
+            path: '/boards',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -41,7 +41,7 @@ describe('Board listing', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/bodies/1/boards/current',
+            path: '/bodies/1/boards/current',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -54,7 +54,7 @@ describe('Board listing', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/boards/recents',
+            path: '/boards/recents',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -67,7 +67,7 @@ describe('Board listing', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/bodies/1/boards',
+            path: '/bodies/1/boards',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -80,7 +80,7 @@ describe('Board listing', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/bodies/1/boards/current',
+            path: '/bodies/1/boards/current',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -94,7 +94,7 @@ describe('Board listing', () => {
         await generator.createBoard();
 
         const res = await request({
-            uri: '/boards',
+            path: '/boards',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -111,7 +111,7 @@ describe('Board listing', () => {
         await generator.createBoard({ body_id: 2 });
 
         const res = await request({
-            uri: '/bodies/1/boards',
+            path: '/bodies/1/boards',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -124,7 +124,7 @@ describe('Board listing', () => {
 
     test('should fail if body_id is not a number', async () => {
         const res = await request({
-            uri: 'bodies/NaN/boards',
+            path: 'bodies/NaN/boards',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -139,7 +139,7 @@ describe('Board listing', () => {
         await generator.createBoard({ body_id: 2 });
 
         const res = await request({
-            uri: 'bodies/1',
+            path: 'bodies/1',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -154,7 +154,7 @@ describe('Board listing', () => {
         await generator.createBoard({ body_id: 1, start_date: faker.date.past(), end_date: faker.date.future() });
 
         const res = await request({
-            uri: '/bodies/1/boards/current',
+            path: '/bodies/1/boards/current',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -169,7 +169,7 @@ describe('Board listing', () => {
         await generator.createBoard({ body_id: 1, start_date: faker.date.past() });
 
         const res = await request({
-            uri: 'bodies/1/boards/current',
+            path: 'bodies/1/boards/current',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -182,7 +182,7 @@ describe('Board listing', () => {
 
     test('should fail if body_id current board is not a number', async () => {
         const res = await request({
-            uri: 'bodies/NaN/boards/current',
+            path: 'bodies/NaN/boards/current',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -197,7 +197,7 @@ describe('Board listing', () => {
         await generator.createBoard({ body_id: 1, start_date: faker.date.future() });
 
         const res = await request({
-            uri: 'bodies/1/boards/current',
+            path: 'bodies/1/boards/current',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -220,7 +220,7 @@ describe('Board listing', () => {
         });
 
         const res = await request({
-            uri: '/boards?sort=start_date&direction=desc',
+            path: '/boards?sort=start_date&direction=desc',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -251,7 +251,7 @@ describe('Board listing', () => {
         await generator.createBoard({ body_id: 2 });
 
         const res = await request({
-            uri: '/bodies/1/boards?sort=start_date&direction=desc',
+            path: '/bodies/1/boards?sort=start_date&direction=desc',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -277,7 +277,7 @@ describe('Board listing', () => {
         });
 
         const res = await request({
-            uri: '/boards/recents',
+            path: '/boards/recents',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -302,7 +302,7 @@ describe('Board listing', () => {
         const ends = moment().subtract(1, 'weeks').toISOString();
 
         const res = await request({
-            uri: '/boards/recents?ends=' + ends,
+            path: '/boards/recents?ends=' + ends,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/network/test/api/mail-component.test.js
+++ b/network/test/api/mail-component.test.js
@@ -25,7 +25,7 @@ describe('MailComponent', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/mailComponent/1',
+            path: '/mailComponent/1',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -39,7 +39,7 @@ describe('MailComponent', () => {
         await generator.createMailComponent({ agora_id: 1, mail_component: 'communication' });
 
         const res = await request({
-            uri: '/mailComponent/1',
+            path: '/mailComponent/1',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -56,7 +56,7 @@ describe('MailComponent', () => {
         await generator.createMailComponent({ agora_id: 2, mail_component: 'board election' });
 
         const res = await request({
-            uri: '/mailComponent/1',
+            path: '/mailComponent/1',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -73,7 +73,7 @@ describe('MailComponent', () => {
         const component = generator.generateMailComponent();
 
         const res = await request({
-            uri: '/mailComponent',
+            path: '/mailComponent',
             method: 'PUT',
             body: component,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -87,7 +87,7 @@ describe('MailComponent', () => {
         const component = generator.generateMailComponent({ agora_id: null });
 
         const res = await request({
-            uri: '/mailComponent',
+            path: '/mailComponent',
             method: 'PUT',
             body: component,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -104,7 +104,7 @@ describe('MailComponent', () => {
         const component = generator.generateMailComponent({ mail_component: null });
 
         const res = await request({
-            uri: '/mailComponent',
+            path: '/mailComponent',
             method: 'PUT',
             body: component,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -121,7 +121,7 @@ describe('MailComponent', () => {
         const component = generator.generateMailComponent({ mail_component: 'blabla' });
 
         const res = await request({
-            uri: '/mailComponent',
+            path: '/mailComponent',
             method: 'PUT',
             body: component,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -136,7 +136,7 @@ describe('MailComponent', () => {
         const component = generator.generateMailComponent({ text: null });
 
         const res = await request({
-            uri: '/mailComponent',
+            path: '/mailComponent',
             method: 'PUT',
             body: component,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -153,7 +153,7 @@ describe('MailComponent', () => {
         const component = generator.generateMailComponent();
 
         const res = await request({
-            uri: '/mailComponent',
+            path: '/mailComponent',
             method: 'PUT',
             body: component,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -173,7 +173,7 @@ describe('MailComponent', () => {
         const component = generator.generateMailComponent({ agora_id: 1, mail_component: 'introduction', text: 'Goodbye!' });
 
         const res = await request({
-            uri: '/mailComponent',
+            path: '/mailComponent',
             method: 'PUT',
             body: component,
             headers: { 'X-Auth-Token': 'blablabla' }

--- a/network/test/api/metrics.test.js
+++ b/network/test/api/metrics.test.js
@@ -20,9 +20,9 @@ describe('Metrics requests', () => {
         await generator.createBoard();
 
         const res = await request({
-            uri: '/metrics',
+            path: '/metrics',
             method: 'GET',
-            json: false
+            responseType: 'text'
         });
 
         expect(res.statusCode).toEqual(200);
@@ -30,9 +30,9 @@ describe('Metrics requests', () => {
 
     test('should return data correctly on /metrics/requests', async () => {
         const res = await request({
-            uri: '/metrics/requests',
+            path: '/metrics/requests',
             method: 'GET',
-            json: false
+            responseType: 'text'
         });
 
         expect(res.statusCode).toEqual(200);

--- a/network/test/api/netcom.test.js
+++ b/network/test/api/netcom.test.js
@@ -26,7 +26,7 @@ describe('Netcom', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/netcom',
+            path: '/netcom',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -39,7 +39,7 @@ describe('Netcom', () => {
         await generator.createNetcom();
 
         const res = await request({
-            uri: '/netcom',
+            path: '/netcom',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -56,7 +56,7 @@ describe('Netcom', () => {
         const netcom = generator.generateNetcom();
 
         const res = await request({
-            uri: '/netcom',
+            path: '/netcom',
             method: 'PUT',
             body: netcom,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -70,7 +70,7 @@ describe('Netcom', () => {
         const netcom = generator.generateNetcom({ body_id: null });
 
         const res = await request({
-            uri: '/netcom',
+            path: '/netcom',
             method: 'PUT',
             body: netcom,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -87,7 +87,7 @@ describe('Netcom', () => {
         const netcom = generator.generateNetcom({ netcom_id: null });
 
         const res = await request({
-            uri: '/netcom',
+            path: '/netcom',
             method: 'PUT',
             body: netcom,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -104,7 +104,7 @@ describe('Netcom', () => {
         const netcom = generator.generateNetcom();
 
         const res = await request({
-            uri: '/netcom',
+            path: '/netcom',
             method: 'PUT',
             body: netcom,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -123,7 +123,7 @@ describe('Netcom', () => {
         const netcom = generator.generateNetcom({ body_id: 1, netcom_id: 3 });
 
         const res = await request({
-            uri: '/netcom',
+            path: '/netcom',
             method: 'PUT',
             body: netcom,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -145,7 +145,7 @@ describe('Netcom', () => {
         const netcom = await generator.createNetcom();
 
         const res = await request({
-            uri: '/netcom/' + netcom.body_id,
+            path: '/netcom/' + netcom.body_id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -158,7 +158,7 @@ describe('Netcom', () => {
         const netcom = await generator.createNetcom();
 
         const res = await request({
-            uri: '/netcom/' + netcom.body_id,
+            path: '/netcom/' + netcom.body_id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/network/test/scripts/helpers.js
+++ b/network/test/scripts/helpers.js
@@ -22,24 +22,20 @@ const appendQuery = (url, query) => {
 };
 
 const request = async (options) => {
-    const parseJson = options.json !== false;
+    const responseType = options.responseType || 'json';
     const headers = { ...(options.headers || {}) };
     const fetchOptions = { method: options.method || 'GET', headers };
 
     if (options.body !== undefined) {
-        if (parseJson) {
-            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
-            fetchOptions.body = JSON.stringify(options.body);
-        } else {
-            fetchOptions.body = options.body;
-        }
+        headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+        fetchOptions.body = JSON.stringify(options.body);
     }
 
-    const response = await fetch(appendQuery(new URL(options.uri, baseUrl + '/').toString(), options.qs), fetchOptions);
+    const response = await fetch(appendQuery(new URL(options.path, baseUrl + '/').toString(), options.query), fetchOptions);
     const text = await response.text();
     let body = text;
 
-    if (parseJson && text) {
+    if (responseType === 'json' && text) {
         try {
             body = JSON.parse(text);
         } catch (err) { // eslint-disable-line no-unused-vars

--- a/network/test/scripts/helpers.js
+++ b/network/test/scripts/helpers.js
@@ -1,13 +1,58 @@
-const requestPromise = require('request-promise-native');
-
 const config = require('../../config');
 
-const request = requestPromise.defaults({
-    json: true,
-    resolveWithFullResponse: true,
-    simple: false,
-    baseUrl: 'http://localhost:' + config.port,
-    qsStringifyOptions: { arrayFormat: 'brackets' }
-});
+const baseUrl = 'http://localhost:' + config.port;
+
+const appendQuery = (url, query) => {
+    if (!query) return url;
+
+    const requestUrl = new URL(url);
+    for (const [key, value] of Object.entries(query)) {
+        if (Array.isArray(value)) {
+            value.forEach((item) => requestUrl.searchParams.append(key, item));
+        } else if (typeof value === 'object' && value !== null) {
+            for (const [nestedKey, nestedValue] of Object.entries(value)) {
+                requestUrl.searchParams.append(`${key}[${nestedKey}]`, nestedValue);
+            }
+        } else {
+            requestUrl.searchParams.append(key, value);
+        }
+    }
+
+    return requestUrl.toString();
+};
+
+const request = async (options) => {
+    const parseJson = options.json !== false;
+    const headers = { ...(options.headers || {}) };
+    const fetchOptions = { method: options.method || 'GET', headers };
+
+    if (options.body !== undefined) {
+        if (parseJson) {
+            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+            fetchOptions.body = JSON.stringify(options.body);
+        } else {
+            fetchOptions.body = options.body;
+        }
+    }
+
+    const response = await fetch(appendQuery(new URL(options.uri, baseUrl + '/').toString(), options.qs), fetchOptions);
+    const text = await response.text();
+    let body = text;
+
+    if (parseJson && text) {
+        try {
+            body = JSON.parse(text);
+        } catch (err) { // eslint-disable-line no-unused-vars
+            body = text;
+        }
+    }
+
+    return {
+        statusCode: response.status,
+        statusMessage: response.statusText,
+        headers: Object.fromEntries(response.headers.entries()),
+        body
+    };
+};
 
 exports.request = request;

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,8 +61,6 @@
         "pg": "^8.20.0",
         "prom-client": "^15.1.3",
         "read-chunk": "^3.2.0",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "sequelize": "^6.37.8",
         "sequelize-cli": "^6.6.3"
       },
@@ -142,8 +140,6 @@
         "on-finished": "^2.4.1",
         "pg": "^8.20.0",
         "prom-client": "^15.1.3",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "sequelize": "^6.37.8",
         "sequelize-cli": "^6.6.3"
       },
@@ -230,8 +226,6 @@
         "pg": "^8.20.0",
         "prom-client": "^15.1.3",
         "read-chunk": "^3.2.0",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "sequelize": "^6.37.8",
         "sequelize-cli": "^6.6.3"
       },
@@ -316,7 +310,7 @@
         "@vue/cli-service": "^4.5.15",
         "@vue/eslint-config-airbnb": "^7.0.0",
         "animate.css": "^4.1.1",
-        "axios": "^1.13.3",
+        "axios": "^1.16.0",
         "buefy": "^0.9.29",
         "chart.js": "^2.9.4",
         "compression-webpack-plugin": "^6.1.1",
@@ -355,6 +349,1745 @@
         "conventional-changelog": "^5.1.0"
       }
     },
+    "frontend/node_modules/@achrinza/node-ipc": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@achrinza/node-ipc/-/node-ipc-9.2.2.tgz",
+      "integrity": "sha512-b90U39dx0cU6emsOvy5hxU4ApNXnE3+Tuo8XQZfiKTGelDwpMwBVgBP7QX6dGTcJgu/miyJuNJ/2naFBliNWEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@node-ipc/js-queue": "2.0.3",
+        "event-pubsub": "4.3.0",
+        "js-message": "1.0.7"
+      },
+      "engines": {
+        "node": "8 || 10 || 12 || 14 || 16 || 17"
+      }
+    },
+    "frontend/node_modules/@nodelib/fs.stat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "frontend/node_modules/@vue/babel-preset-app": {
+      "version": "4.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-4.5.19.tgz",
+      "integrity": "sha512-VCNRiAt2P/bLo09rYt3DLe6xXUMlhJwrvU18Ddd/lYJgC7s8+wvhgYs+MTx4OiAXdu58drGwSBO9SPx7C6J82Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.0",
+        "@babel/helper-compilation-targets": "^7.9.6",
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/plugin-proposal-class-properties": "^7.8.3",
+        "@babel/plugin-proposal-decorators": "^7.8.3",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-jsx": "^7.8.3",
+        "@babel/plugin-transform-runtime": "^7.11.0",
+        "@babel/preset-env": "^7.11.0",
+        "@babel/runtime": "^7.11.0",
+        "@vue/babel-plugin-jsx": "^1.0.3",
+        "@vue/babel-preset-jsx": "^1.2.4",
+        "babel-plugin-dynamic-import-node": "^2.3.3",
+        "core-js": "^3.6.5",
+        "core-js-compat": "^3.6.5",
+        "semver": "^6.1.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*",
+        "core-js": "^3",
+        "vue": "^2 || ^3.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "core-js": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/@vue/cli-overlay": {
+      "version": "4.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/cli-overlay/-/cli-overlay-4.5.19.tgz",
+      "integrity": "sha512-GdxvNSmOw7NHIazCO8gTK+xZbaOmScTtxj6eHVeMbYpDYVPJ+th3VMLWNpw/b6uOjwzzcyKlA5dRQ1DAb+gF/g==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/@vue/cli-plugin-babel": {
+      "version": "4.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-babel/-/cli-plugin-babel-4.5.19.tgz",
+      "integrity": "sha512-8ebXzaMW9KNTMAN6+DzkhFsjty1ieqT7hIW5Lbk4v30Qhfjkms7lBWyXPGkoq+wAikXFa1Gnam2xmWOBqDDvWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.0",
+        "@vue/babel-preset-app": "^4.5.19",
+        "@vue/cli-shared-utils": "^4.5.19",
+        "babel-loader": "^8.1.0",
+        "cache-loader": "^4.1.0",
+        "thread-loader": "^2.1.3",
+        "webpack": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@vue/cli-service": "^3.0.0 || ^4.0.0-0"
+      }
+    },
+    "frontend/node_modules/@vue/cli-plugin-router": {
+      "version": "4.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-router/-/cli-plugin-router-4.5.19.tgz",
+      "integrity": "sha512-3icGzH1IbVYmMMsOwYa0lal/gtvZLebFXdE5hcQJo2mnTwngXGMTyYAzL56EgHBPjbMmRpyj6Iw9k4aVInVX6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/cli-shared-utils": "^4.5.19"
+      },
+      "peerDependencies": {
+        "@vue/cli-service": "^3.0.0 || ^4.0.0-0"
+      }
+    },
+    "frontend/node_modules/@vue/cli-plugin-vuex": {
+      "version": "4.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-vuex/-/cli-plugin-vuex-4.5.19.tgz",
+      "integrity": "sha512-DUmfdkG3pCdkP7Iznd87RfE9Qm42mgp2hcrNcYQYSru1W1gX2dG/JcW8bxmeGSa06lsxi9LEIc/QD1yPajSCZw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@vue/cli-service": "^3.0.0 || ^4.0.0-0"
+      }
+    },
+    "frontend/node_modules/@vue/cli-service": {
+      "version": "4.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/cli-service/-/cli-service-4.5.19.tgz",
+      "integrity": "sha512-+Wpvj8fMTCt9ZPOLu5YaLkFCQmB4MrZ26aRmhhKiCQ/4PMoL6mLezfqdt6c+m2htM+1WV5RunRo+0WHl2DfwZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@intervolga/optimize-cssnano-plugin": "^1.0.5",
+        "@soda/friendly-errors-webpack-plugin": "^1.7.1",
+        "@soda/get-current-script": "^1.0.0",
+        "@types/minimist": "^1.2.0",
+        "@types/webpack": "^4.0.0",
+        "@types/webpack-dev-server": "^3.11.0",
+        "@vue/cli-overlay": "^4.5.19",
+        "@vue/cli-plugin-router": "^4.5.19",
+        "@vue/cli-plugin-vuex": "^4.5.19",
+        "@vue/cli-shared-utils": "^4.5.19",
+        "@vue/component-compiler-utils": "^3.1.2",
+        "@vue/preload-webpack-plugin": "^1.1.0",
+        "@vue/web-component-wrapper": "^1.2.0",
+        "acorn": "^7.4.0",
+        "acorn-walk": "^7.1.1",
+        "address": "^1.1.2",
+        "autoprefixer": "^9.8.6",
+        "browserslist": "^4.12.0",
+        "cache-loader": "^4.1.0",
+        "case-sensitive-paths-webpack-plugin": "^2.3.0",
+        "cli-highlight": "^2.1.4",
+        "clipboardy": "^2.3.0",
+        "cliui": "^6.0.0",
+        "copy-webpack-plugin": "^5.1.1",
+        "css-loader": "^3.5.3",
+        "cssnano": "^4.1.10",
+        "debug": "^4.1.1",
+        "default-gateway": "^5.0.5",
+        "dotenv": "^8.2.0",
+        "dotenv-expand": "^5.1.0",
+        "file-loader": "^4.2.0",
+        "fs-extra": "^7.0.1",
+        "globby": "^9.2.0",
+        "hash-sum": "^2.0.0",
+        "html-webpack-plugin": "^3.2.0",
+        "launch-editor-middleware": "^2.2.1",
+        "lodash.defaultsdeep": "^4.6.1",
+        "lodash.mapvalues": "^4.6.0",
+        "lodash.transform": "^4.6.0",
+        "mini-css-extract-plugin": "^0.9.0",
+        "minimist": "^1.2.5",
+        "pnp-webpack-plugin": "^1.6.4",
+        "portfinder": "^1.0.26",
+        "postcss-loader": "^3.0.0",
+        "ssri": "^8.0.1",
+        "terser-webpack-plugin": "^1.4.4",
+        "thread-loader": "^2.1.3",
+        "url-loader": "^2.2.0",
+        "vue-loader": "^15.9.2",
+        "vue-style-loader": "^4.1.2",
+        "webpack": "^4.0.0",
+        "webpack-bundle-analyzer": "^3.8.0",
+        "webpack-chain": "^6.4.0",
+        "webpack-dev-server": "^3.11.0",
+        "webpack-merge": "^4.2.2"
+      },
+      "bin": {
+        "vue-cli-service": "bin/vue-cli-service.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "optionalDependencies": {
+        "vue-loader-v16": "npm:vue-loader@^16.1.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "^3.0.0-beta.14",
+        "vue-template-compiler": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "less-loader": {
+          "optional": true
+        },
+        "pug-plain-loader": {
+          "optional": true
+        },
+        "raw-loader": {
+          "optional": true
+        },
+        "sass-loader": {
+          "optional": true
+        },
+        "stylus-loader": {
+          "optional": true
+        },
+        "vue-template-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/@vue/cli-service/node_modules/css-loader": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
+      "integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "cssesc": "^3.0.0",
+        "icss-utils": "^4.1.1",
+        "loader-utils": "^1.2.3",
+        "normalize-path": "^3.0.0",
+        "postcss": "^7.0.32",
+        "postcss-modules-extract-imports": "^2.0.0",
+        "postcss-modules-local-by-default": "^3.0.2",
+        "postcss-modules-scope": "^2.2.0",
+        "postcss-modules-values": "^3.0.0",
+        "postcss-value-parser": "^4.1.0",
+        "schema-utils": "^2.7.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "frontend/node_modules/@vue/cli-service/node_modules/vue-loader": {
+      "version": "15.11.1",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.11.1.tgz",
+      "integrity": "sha512-0iw4VchYLePqJfJu9s62ACWUXeSqM30SQqlIftbYWM3C+jpPcEHKSPUZBLjSF9au4HTHQ/naF6OGnO3Q/qGR3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/component-compiler-utils": "^3.1.0",
+        "hash-sum": "^1.0.2",
+        "loader-utils": "^1.1.0",
+        "vue-hot-reload-api": "^2.3.0",
+        "vue-style-loader": "^4.1.0"
+      },
+      "peerDependencies": {
+        "css-loader": "*",
+        "webpack": "^3.0.0 || ^4.1.0 || ^5.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "cache-loader": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "vue-template-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/@vue/cli-service/node_modules/vue-loader/node_modules/hash-sum": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
+      "integrity": "sha512-fUs4B4L+mlt8/XAtSOGMUO1TXmAelItBPtJG7CyHJfYTdDjwisntGO2JQz7oUsatOY9o68+57eziUVNw/mRHmA==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/@vue/cli-shared-utils": {
+      "version": "4.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-4.5.19.tgz",
+      "integrity": "sha512-JYpdsrC/d9elerKxbEUtmSSU6QRM60rirVubOewECHkBHj+tLNznWq/EhCjswywtePyLaMUK25eTqnTSZlEE+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@achrinza/node-ipc": "9.2.2",
+        "@hapi/joi": "^15.0.1",
+        "chalk": "^2.4.2",
+        "execa": "^1.0.0",
+        "launch-editor": "^2.2.1",
+        "lru-cache": "^5.1.1",
+        "open": "^6.3.0",
+        "ora": "^3.4.0",
+        "read-pkg": "^5.1.1",
+        "request": "^2.88.2",
+        "semver": "^6.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "frontend/node_modules/@webassemblyjs/ast": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+      "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0"
+      }
+    },
+    "frontend/node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
+      "integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
+      "integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+      "integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
+      "integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0"
+      }
+    },
+    "frontend/node_modules/@webassemblyjs/ieee754": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
+      "integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "frontend/node_modules/@webassemblyjs/leb128": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
+      "integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "frontend/node_modules/@webassemblyjs/utf8": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
+      "integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
+      "integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/helper-wasm-section": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-opt": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "@webassemblyjs/wast-printer": "1.9.0"
+      }
+    },
+    "frontend/node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
+      "integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
+      }
+    },
+    "frontend/node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
+      "integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0"
+      }
+    },
+    "frontend/node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
+      "integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-api-error": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
+      }
+    },
+    "frontend/node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
+      "integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "frontend/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "frontend/node_modules/acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "frontend/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "frontend/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "frontend/node_modules/array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+      "license": "MIT",
+      "dependencies": {
+        "array-uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/autoprefixer": {
+      "version": "9.8.8",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
+      "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.12.0",
+        "caniuse-lite": "^1.0.30001109",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "picocolors": "^0.2.1",
+        "postcss": "^7.0.32",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+      }
+    },
+    "frontend/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "frontend/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "license": "MIT",
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/cacache": {
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+      "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      }
+    },
+    "frontend/node_modules/cacache/node_modules/ssri": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
+      "license": "ISC",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1"
+      }
+    },
+    "frontend/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "frontend/node_modules/chokidar/node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "frontend/node_modules/chokidar/node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "frontend/node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "frontend/node_modules/chokidar/node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "frontend/node_modules/chokidar/node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "frontend/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "frontend/node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "frontend/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "frontend/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "frontend/node_modules/copy-webpack-plugin": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz",
+      "integrity": "sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cacache": "^12.0.3",
+        "find-cache-dir": "^2.1.0",
+        "glob-parent": "^3.1.0",
+        "globby": "^7.1.1",
+        "is-glob": "^4.0.1",
+        "loader-utils": "^1.2.3",
+        "minimatch": "^3.0.4",
+        "normalize-path": "^3.0.0",
+        "p-limit": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^4.0.0",
+        "webpack-log": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "frontend/node_modules/copy-webpack-plugin/node_modules/globby": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+      "integrity": "sha512-yANWAN2DUcBtuus5Cpd+SKROzXHs2iVXFZt/Ykrfz6SAXqacLX25NZpltE+39ceMexYF4TtEadjuSTw8+3wX4g==",
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^1.0.1",
+        "dir-glob": "^2.0.0",
+        "glob": "^7.1.2",
+        "ignore": "^3.3.5",
+        "pify": "^3.0.0",
+        "slash": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/copy-webpack-plugin/node_modules/ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/copy-webpack-plugin/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/copy-webpack-plugin/node_modules/schema-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.1.0",
+        "ajv-errors": "^1.0.0",
+        "ajv-keywords": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "frontend/node_modules/copy-webpack-plugin/node_modules/slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha512-3TYDR7xWt4dIqV2JauJr+EJeW356RXijHeUlO+8djJ+uBXPn8/2dpzBc8yQhh583sVvc9CvFAeQVgijsH+PNNg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "license": "MIT",
+      "dependencies": {
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/css-declaration-sorter": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
+      "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.1",
+        "timsort": "^0.3.0"
+      },
+      "engines": {
+        "node": ">4"
+      }
+    },
+    "frontend/node_modules/css-tree": {
+      "version": "1.0.0-alpha.37",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+      "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.4",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "frontend/node_modules/css-what": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
+      "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "frontend/node_modules/cssnano": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.11.tgz",
+      "integrity": "sha512-6gZm2htn7xIPJOHY824ERgj8cNPgPxyCSnkXc4v7YvNW+TdVfzgngHcEhy/8D11kUWRUMbke+tC+AUcUsnMz2g==",
+      "license": "MIT",
+      "dependencies": {
+        "cosmiconfig": "^5.0.0",
+        "cssnano-preset-default": "^4.0.8",
+        "is-resolvable": "^1.0.0",
+        "postcss": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/cssnano-preset-default": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.8.tgz",
+      "integrity": "sha512-LdAyHuq+VRyeVREFmuxUZR1TXjQm8QQU/ktoo/x7bz+SdOge1YKc5eMN6pRW7YWBmyq59CqYba1dJ5cUukEjLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-declaration-sorter": "^4.0.1",
+        "cssnano-util-raw-cache": "^4.0.1",
+        "postcss": "^7.0.0",
+        "postcss-calc": "^7.0.1",
+        "postcss-colormin": "^4.0.3",
+        "postcss-convert-values": "^4.0.1",
+        "postcss-discard-comments": "^4.0.2",
+        "postcss-discard-duplicates": "^4.0.2",
+        "postcss-discard-empty": "^4.0.1",
+        "postcss-discard-overridden": "^4.0.1",
+        "postcss-merge-longhand": "^4.0.11",
+        "postcss-merge-rules": "^4.0.3",
+        "postcss-minify-font-values": "^4.0.2",
+        "postcss-minify-gradients": "^4.0.2",
+        "postcss-minify-params": "^4.0.2",
+        "postcss-minify-selectors": "^4.0.2",
+        "postcss-normalize-charset": "^4.0.1",
+        "postcss-normalize-display-values": "^4.0.2",
+        "postcss-normalize-positions": "^4.0.2",
+        "postcss-normalize-repeat-style": "^4.0.2",
+        "postcss-normalize-string": "^4.0.2",
+        "postcss-normalize-timing-functions": "^4.0.2",
+        "postcss-normalize-unicode": "^4.0.1",
+        "postcss-normalize-url": "^4.0.1",
+        "postcss-normalize-whitespace": "^4.0.2",
+        "postcss-ordered-values": "^4.1.2",
+        "postcss-reduce-initial": "^4.0.3",
+        "postcss-reduce-transforms": "^4.0.2",
+        "postcss-svgo": "^4.0.3",
+        "postcss-unique-selectors": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/default-gateway": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.5.tgz",
+      "integrity": "sha512-z2RnruVmj8hVMmAnEJMTIJNijhKCDiGjbLP+BHJFOT7ld3Bo5qcIBpVYDniqhbMIIf+jZDlkP2MkPXiQy/DBLA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "execa": "^3.3.0"
+      },
+      "engines": {
+        "node": "^8.12.0 || >=9.7.0"
+      }
+    },
+    "frontend/node_modules/default-gateway/node_modules/execa": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+      "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "p-finally": "^2.0.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": "^8.12.0 || >=9.7.0"
+      }
+    },
+    "frontend/node_modules/default-gateway/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "frontend/node_modules/default-gateway/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "frontend/node_modules/default-gateway/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/default-gateway/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "frontend/node_modules/default-gateway/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "frontend/node_modules/default-gateway/node_modules/p-finally": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "frontend/node_modules/default-gateway/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "frontend/node_modules/dir-glob": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      }
+    },
+    "frontend/node_modules/domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "frontend/node_modules/domutils/node_modules/domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "license": "BSD-2-Clause"
+    },
+    "frontend/node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "frontend/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/enhanced-resolve": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+      "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.5.0",
+        "tapable": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/enhanced-resolve/node_modules/memory-fs": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+      "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+      "license": "MIT",
+      "dependencies": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.3.0 <5.0.0 || >=5.10"
+      }
+    },
+    "frontend/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "frontend/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "frontend/node_modules/eslint-scope": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "frontend/node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "frontend/node_modules/execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/execa/node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "frontend/node_modules/execa/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "frontend/node_modules/fast-glob": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+      "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.1.2",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.3",
+        "micromatch": "^3.1.10"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "frontend/node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "frontend/node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      }
+    },
+    "frontend/node_modules/glob-parent/node_modules/is-glob": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/globby": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+      "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^1.0.2",
+        "dir-glob": "^2.2.2",
+        "fast-glob": "^2.2.6",
+        "glob": "^7.1.3",
+        "ignore": "^4.0.3",
+        "pify": "^4.0.1",
+        "slash": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/gzip-size": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
+      "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "pify": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "license": "ISC"
+    },
+    "frontend/node_modules/html-entities": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
+      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/html-webpack-plugin": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "integrity": "sha512-Br4ifmjQojUP4EmHnRBoUIYcZ9J7M4bTMcm7u6xoIAIuq2Nte4TzXX0533owvkQKQD1WeMTTTyD4Ni4QKxS0Bg==",
+      "deprecated": "3.x is no longer supported",
+      "license": "MIT",
+      "dependencies": {
+        "html-minifier": "^3.2.3",
+        "loader-utils": "^0.2.16",
+        "lodash": "^4.17.3",
+        "pretty-error": "^2.0.2",
+        "tapable": "^1.0.0",
+        "toposort": "^1.0.0",
+        "util.promisify": "1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9"
+      },
+      "peerDependencies": {
+        "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "frontend/node_modules/html-webpack-plugin/node_modules/big.js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "frontend/node_modules/html-webpack-plugin/node_modules/emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "frontend/node_modules/html-webpack-plugin/node_modules/json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "frontend/node_modules/html-webpack-plugin/node_modules/loader-utils": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+      "integrity": "sha512-tiv66G0SmiOx+pLWMtGEkfSEejxvb6N6uRrQjfWJIT79W9GMpgKeCAmm9aVBKtd4WEgntciI8CsGqjpDoCWJug==",
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "frontend/node_modules/http-proxy-middleware": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+      "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.11",
+        "micromatch": "^3.1.10"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "frontend/node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "frontend/node_modules/icss-utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
+      "license": "ISC",
+      "dependencies": {
+        "postcss": "^7.0.14"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "frontend/node_modules/ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "frontend/node_modules/import-fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
+      "license": "MIT",
+      "dependencies": {
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/import-local": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+      "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^3.0.0",
+        "resolve-cwd": "^2.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "frontend/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "frontend/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "frontend/node_modules/loader-runner": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
+      "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.3.0 <5.0.0 || >=5.10"
+      }
+    },
+    "frontend/node_modules/loader-utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "frontend/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "frontend/node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/make-dir/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "frontend/node_modules/marked": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
@@ -365,6 +2098,1845 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "frontend/node_modules/mdn-data": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+      "license": "CC0-1.0"
+    },
+    "frontend/node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "license": "MIT",
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "frontend/node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/mini-css-extract-plugin": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
+      "integrity": "sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==",
+      "license": "MIT",
+      "dependencies": {
+        "loader-utils": "^1.1.0",
+        "normalize-url": "1.9.1",
+        "schema-utils": "^1.0.0",
+        "webpack-sources": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.4.0"
+      }
+    },
+    "frontend/node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.1.0",
+        "ajv-errors": "^1.0.0",
+        "ajv-keywords": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "frontend/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "frontend/node_modules/node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "frontend/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "frontend/node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "frontend/node_modules/normalize-url": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+      "integrity": "sha512-A48My/mtCklowHBlI8Fq2jFWK4tX4lJ5E6ytFsSOq1fzpvT0SQSgKhSg7lN5c2uYFOrUAOQp6zhhJnpp1eMloQ==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.0.1",
+        "prepend-http": "^1.0.0",
+        "query-string": "^4.1.0",
+        "sort-keys": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "~1.0.0"
+      }
+    },
+    "frontend/node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/open": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "frontend/node_modules/ora": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
+      "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-spinners": "^2.0.0",
+        "log-symbols": "^2.2.0",
+        "strip-ansi": "^5.2.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/ora/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/p-retry": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
+      "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/path-type/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "license": "ISC"
+    },
+    "frontend/node_modules/pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "frontend/node_modules/postcss-calc": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.5.tgz",
+      "integrity": "sha512-1tKHutbGtLtEZF6PT4JSihCHfIVldU72mZ8SdZHIYriIZ9fh9k9aWSppaT8rHsyI3dX+KSR+W+Ix9BMY3AODrg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.27",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "frontend/node_modules/postcss-colormin": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
+      "integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.0.0",
+        "color": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-colormin/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-convert-values": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
+      "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-convert-values/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-discard-comments": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
+      "integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-discard-duplicates": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+      "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-discard-empty": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
+      "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-discard-overridden": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
+      "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-loader": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
+      "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
+      "license": "MIT",
+      "dependencies": {
+        "loader-utils": "^1.1.0",
+        "postcss": "^7.0.0",
+        "postcss-load-config": "^2.0.0",
+        "schema-utils": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "frontend/node_modules/postcss-loader/node_modules/schema-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.1.0",
+        "ajv-errors": "^1.0.0",
+        "ajv-keywords": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "frontend/node_modules/postcss-merge-longhand": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
+      "integrity": "sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-color-names": "0.0.4",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "stylehacks": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-merge-longhand/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-merge-rules": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
+      "integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "cssnano-util-same-parent": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0",
+        "vendors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-merge-rules/node_modules/postcss-selector-parser": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+      "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
+      "license": "MIT",
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "frontend/node_modules/postcss-minify-font-values": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
+      "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-minify-font-values/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-minify-gradients": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
+      "integrity": "sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "is-color-stop": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-minify-gradients/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-minify-params": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
+      "integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
+      "license": "MIT",
+      "dependencies": {
+        "alphanum-sort": "^1.0.0",
+        "browserslist": "^4.0.0",
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "uniqs": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-minify-params/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-minify-selectors": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
+      "integrity": "sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==",
+      "license": "MIT",
+      "dependencies": {
+        "alphanum-sort": "^1.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-minify-selectors/node_modules/postcss-selector-parser": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+      "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
+      "license": "MIT",
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "frontend/node_modules/postcss-modules-extract-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+      "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
+      "license": "ISC",
+      "dependencies": {
+        "postcss": "^7.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "frontend/node_modules/postcss-modules-local-by-default": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
+      "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^4.1.1",
+        "postcss": "^7.0.32",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "frontend/node_modules/postcss-modules-scope": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
+      "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
+      "license": "ISC",
+      "dependencies": {
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "frontend/node_modules/postcss-modules-values": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+      "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
+      "license": "ISC",
+      "dependencies": {
+        "icss-utils": "^4.0.0",
+        "postcss": "^7.0.6"
+      }
+    },
+    "frontend/node_modules/postcss-normalize-charset": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
+      "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-normalize-display-values": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
+      "integrity": "sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-normalize-display-values/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-normalize-positions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
+      "integrity": "sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-normalize-positions/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-normalize-repeat-style": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
+      "integrity": "sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-normalize-repeat-style/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-normalize-string": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
+      "integrity": "sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==",
+      "license": "MIT",
+      "dependencies": {
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-normalize-string/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-normalize-timing-functions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
+      "integrity": "sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-normalize-timing-functions/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-normalize-unicode": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
+      "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-normalize-unicode/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-normalize-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
+      "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^3.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-normalize-url/node_modules/normalize-url": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/postcss-normalize-url/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-normalize-whitespace": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
+      "integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-normalize-whitespace/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-ordered-values": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
+      "integrity": "sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-ordered-values/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-reduce-initial": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
+      "integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-reduce-transforms": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
+      "integrity": "sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-util-get-match": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-reduce-transforms/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-svgo": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.3.tgz",
+      "integrity": "sha512-NoRbrcMWTtUghzuKSoIm6XV+sJdvZ7GZSc3wdBN0W19FTtp2ko8NqLsgoh/m9CzNhU3KLPvQmjIwtaNFkaFTvw==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "svgo": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/postcss-svgo/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/postcss-unique-selectors": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
+      "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
+      "license": "MIT",
+      "dependencies": {
+        "alphanum-sort": "^1.0.0",
+        "postcss": "^7.0.0",
+        "uniqs": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/pretty-error": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.2.tgz",
+      "integrity": "sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.20",
+        "renderkid": "^2.0.4"
+      }
+    },
+    "frontend/node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "frontend/node_modules/read-pkg/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "frontend/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "frontend/node_modules/renderkid": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
+      "integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^4.1.3",
+        "dom-converter": "^0.2.0",
+        "htmlparser2": "^6.1.0",
+        "lodash": "^4.17.21",
+        "strip-ansi": "^3.0.1"
+      }
+    },
+    "frontend/node_modules/renderkid/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/renderkid/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha512-ccu8zQTrzVr954472aUVPLEcB3YpKSYR3cg/3lo1okzobPBM+1INXBbBZlDbnI/hbEocnf8j0QVo43hQKrbchg==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "frontend/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "frontend/node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "license": "ISC"
+    },
+    "frontend/node_modules/selfsigned": {
+      "version": "1.10.14",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.14.tgz",
+      "integrity": "sha512-lkjaiAye+wBZDCBsu5BGi0XiLRxeUlsGod5ZP924CRSEoGuZAw/f7y9RKu28rwTfiHVhdavhB0qH0INV6P1lEA==",
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "^0.10.0"
+      }
+    },
+    "frontend/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "frontend/node_modules/serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "frontend/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "frontend/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/stylehacks": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
+      "integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "frontend/node_modules/stylehacks/node_modules/postcss-selector-parser": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+      "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
+      "license": "MIT",
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "frontend/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "frontend/node_modules/svgo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
+      "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
+      "deprecated": "This SVGO version is no longer supported. Upgrade to v2.x.x.",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "coa": "^2.0.2",
+        "css-select": "^2.0.0",
+        "css-select-base-adapter": "^0.1.1",
+        "css-tree": "1.0.0-alpha.37",
+        "csso": "^4.0.2",
+        "js-yaml": "^3.13.1",
+        "mkdirp": "~0.5.1",
+        "object.values": "^1.1.0",
+        "sax": "~1.2.4",
+        "stable": "^0.1.8",
+        "unquote": "~1.1.1",
+        "util.promisify": "~1.0.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "frontend/node_modules/svgo/node_modules/css-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
+      "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^3.2.1",
+        "domutils": "^1.7.0",
+        "nth-check": "^1.0.2"
+      }
+    },
+    "frontend/node_modules/tapable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/terser": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "frontend/node_modules/terser-webpack-plugin": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.6.tgz",
+      "integrity": "sha512-2lBVf/VMVIddjSn3GqbT90GvIJ/eYXJkt8cTzU7NbjKqK8fwv18Ftr4PlbF46b/e88743iZFL5Dtr/rC4hjIeA==",
+      "license": "MIT",
+      "dependencies": {
+        "cacache": "^12.0.2",
+        "find-cache-dir": "^2.1.0",
+        "is-wsl": "^1.1.0",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^4.0.0",
+        "source-map": "^0.6.1",
+        "terser": "^4.1.2",
+        "webpack-sources": "^1.4.0",
+        "worker-farm": "^1.7.0"
+      },
+      "engines": {
+        "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      }
+    },
+    "frontend/node_modules/terser-webpack-plugin/node_modules/schema-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.1.0",
+        "ajv-errors": "^1.0.0",
+        "ajv-keywords": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "frontend/node_modules/thread-loader": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.3.tgz",
+      "integrity": "sha512-wNrVKH2Lcf8ZrWxDF/khdlLlsTMczdcwPA9VEK4c2exlEPynYWxi9op3nPTo5lAnDIkE0rQEB3VBP+4Zncc9Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "loader-runner": "^2.3.1",
+        "loader-utils": "^1.1.0",
+        "neo-async": "^2.6.0"
+      },
+      "engines": {
+        "node": ">= 6.9.0 <7.0.0 || >= 8.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "frontend/node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "frontend/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "frontend/node_modules/watchpack": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
+      "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0"
+      },
+      "optionalDependencies": {
+        "chokidar": "^3.4.1",
+        "watchpack-chokidar2": "^2.0.1"
+      }
+    },
+    "frontend/node_modules/webpack": {
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.47.0.tgz",
+      "integrity": "sha512-td7fYwgLSrky3fI1EuU5cneU4+pbH6GgOfuKNS1tNPcfdGinGELAqsb/BP4nnvZyKSG2i/xFGU7+n2PvZA8HJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/wasm-edit": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "acorn": "^6.4.1",
+        "ajv": "^6.10.2",
+        "ajv-keywords": "^3.4.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^4.5.0",
+        "eslint-scope": "^4.0.3",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^2.4.0",
+        "loader-utils": "^1.2.3",
+        "memory-fs": "^0.4.1",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.3",
+        "neo-async": "^2.6.1",
+        "node-libs-browser": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "tapable": "^1.1.3",
+        "terser-webpack-plugin": "^1.4.3",
+        "watchpack": "^1.7.4",
+        "webpack-sources": "^1.4.1"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        },
+        "webpack-command": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/webpack-bundle-analyzer": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.9.0.tgz",
+      "integrity": "sha512-Ob8amZfCm3rMB1ScjQVlbYYUEJyEjdEtQ92jqiFUYt5VkEeO2v5UMbv49P/gnmCZm3A6yaFQzCBvpZqN4MUsdA==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1",
+        "bfj": "^6.1.1",
+        "chalk": "^2.4.1",
+        "commander": "^2.18.0",
+        "ejs": "^2.6.1",
+        "express": "^4.16.3",
+        "filesize": "^3.6.1",
+        "gzip-size": "^5.0.0",
+        "lodash": "^4.17.19",
+        "mkdirp": "^0.5.1",
+        "opener": "^1.5.1",
+        "ws": "^6.0.0"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 6.14.4"
+      }
+    },
+    "frontend/node_modules/webpack-dev-middleware": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.3.tgz",
+      "integrity": "sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.4",
+        "mkdirp": "^0.5.1",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "frontend/node_modules/webpack-dev-server": {
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz",
+      "integrity": "sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-html-community": "0.0.8",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.3.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.8",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.26",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.8",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "^0.3.21",
+        "sockjs-client": "^1.5.0",
+        "spdy": "^4.0.2",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "^13.3.2"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/webpack-dev-server/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/webpack-dev-server/node_modules/anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "license": "ISC",
+      "dependencies": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      }
+    },
+    "frontend/node_modules/webpack-dev-server/node_modules/anymatch/node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/webpack-dev-server/node_modules/chokidar": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      },
+      "optionalDependencies": {
+        "fsevents": "^1.2.7"
+      }
+    },
+    "frontend/node_modules/webpack-dev-server/node_modules/fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
+    "frontend/node_modules/webpack-dev-server/node_modules/is-absolute-url": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "frontend/node_modules/webpack-dev-server/node_modules/is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/webpack-dev-server/node_modules/readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "frontend/node_modules/webpack-dev-server/node_modules/schema-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.1.0",
+        "ajv-errors": "^1.0.0",
+        "ajv-keywords": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "frontend/node_modules/webpack-dev-server/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "frontend/node_modules/webpack-dev-server/node_modules/supports-color": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/webpack-merge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
+    "frontend/node_modules/webpack/node_modules/acorn": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "frontend/node_modules/webpack/node_modules/schema-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.1.0",
+        "ajv-errors": "^1.0.0",
+        "ajv-keywords": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "frontend/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "frontend/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "frontend/node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "frontend/node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "frontend/node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "frontend/node_modules/ws": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "frontend/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "frontend/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
+    },
+    "frontend/node_modules/yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      }
+    },
+    "frontend/node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "frontend/node_modules/yargs/node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "frontend/node_modules/yargs/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/yargs/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "frontend/node_modules/yargs/node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "knowledge": {
@@ -383,8 +3955,6 @@
         "on-finished": "^2.4.1",
         "pg": "^8.20.0",
         "prom-client": "^15.1.3",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "sequelize": "^6.37.8",
         "sequelize-cli": "^6.6.3"
       },
@@ -472,8 +4042,6 @@
         "on-finished": "^2.4.1",
         "pg": "^8.20.0",
         "prom-client": "^15.1.3",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "sequelize": "^6.37.8",
         "sequelize-cli": "^6.6.3"
       },
@@ -535,20 +4103,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@achrinza/node-ipc": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/@achrinza/node-ipc/-/node-ipc-9.2.2.tgz",
-      "integrity": "sha512-b90U39dx0cU6emsOvy5hxU4ApNXnE3+Tuo8XQZfiKTGelDwpMwBVgBP7QX6dGTcJgu/miyJuNJ/2naFBliNWEw==",
-      "license": "MIT",
-      "dependencies": {
-        "@node-ipc/js-queue": "2.0.3",
-        "event-pubsub": "4.3.0",
-        "js-message": "1.0.7"
-      },
-      "engines": {
-        "node": "8 || 10 || 12 || 14 || 16 || 17"
       }
     },
     "node_modules/@actions/core": {
@@ -1851,9 +5405,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.28.6",
@@ -2289,9 +5843,9 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.3.tgz",
-      "integrity": "sha512-ySZypNLAIH1ClygLDQzVMoGQRViATnkHkYYV6TcNDz+8+jwZCdsguGvsb3EY5d9wyWyhmF1iSuFM0Yh5XPnqSA==",
+      "version": "7.29.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.5.tgz",
+      "integrity": "sha512-/69t2aEzGKHD76DyLbHysF/QH2LJOB8iFnYO37unDTKBTubzcMRv0f3H5EiN1Q6ajOd/eB7dAInF0qdFVS06kA==",
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.29.3",
@@ -2333,7 +5887,7 @@
         "@babel/plugin-transform-member-expression-literals": "^7.27.1",
         "@babel/plugin-transform-modules-amd": "^7.27.1",
         "@babel/plugin-transform-modules-commonjs": "^7.28.6",
-        "@babel/plugin-transform-modules-systemjs": "^7.29.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.29.4",
         "@babel/plugin-transform-modules-umd": "^7.27.1",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
         "@babel/plugin-transform-new-target": "^7.27.1",
@@ -3255,6 +6809,920 @@
         "webpack": "^4.0.0"
       }
     },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "license": "MIT",
+      "dependencies": {
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/css-declaration-sorter": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
+      "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.1",
+        "timsort": "^0.3.0"
+      },
+      "engines": {
+        "node": ">4"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/css-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
+      "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^3.2.1",
+        "domutils": "^1.7.0",
+        "nth-check": "^1.0.2"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/css-tree": {
+      "version": "1.0.0-alpha.37",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+      "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.4",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/css-what": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
+      "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/cssnano": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.11.tgz",
+      "integrity": "sha512-6gZm2htn7xIPJOHY824ERgj8cNPgPxyCSnkXc4v7YvNW+TdVfzgngHcEhy/8D11kUWRUMbke+tC+AUcUsnMz2g==",
+      "license": "MIT",
+      "dependencies": {
+        "cosmiconfig": "^5.0.0",
+        "cssnano-preset-default": "^4.0.8",
+        "is-resolvable": "^1.0.0",
+        "postcss": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/cssnano-preset-default": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.8.tgz",
+      "integrity": "sha512-LdAyHuq+VRyeVREFmuxUZR1TXjQm8QQU/ktoo/x7bz+SdOge1YKc5eMN6pRW7YWBmyq59CqYba1dJ5cUukEjLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-declaration-sorter": "^4.0.1",
+        "cssnano-util-raw-cache": "^4.0.1",
+        "postcss": "^7.0.0",
+        "postcss-calc": "^7.0.1",
+        "postcss-colormin": "^4.0.3",
+        "postcss-convert-values": "^4.0.1",
+        "postcss-discard-comments": "^4.0.2",
+        "postcss-discard-duplicates": "^4.0.2",
+        "postcss-discard-empty": "^4.0.1",
+        "postcss-discard-overridden": "^4.0.1",
+        "postcss-merge-longhand": "^4.0.11",
+        "postcss-merge-rules": "^4.0.3",
+        "postcss-minify-font-values": "^4.0.2",
+        "postcss-minify-gradients": "^4.0.2",
+        "postcss-minify-params": "^4.0.2",
+        "postcss-minify-selectors": "^4.0.2",
+        "postcss-normalize-charset": "^4.0.1",
+        "postcss-normalize-display-values": "^4.0.2",
+        "postcss-normalize-positions": "^4.0.2",
+        "postcss-normalize-repeat-style": "^4.0.2",
+        "postcss-normalize-string": "^4.0.2",
+        "postcss-normalize-timing-functions": "^4.0.2",
+        "postcss-normalize-unicode": "^4.0.1",
+        "postcss-normalize-url": "^4.0.1",
+        "postcss-normalize-whitespace": "^4.0.2",
+        "postcss-ordered-values": "^4.1.2",
+        "postcss-reduce-initial": "^4.0.3",
+        "postcss-reduce-transforms": "^4.0.2",
+        "postcss-svgo": "^4.0.3",
+        "postcss-unique-selectors": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/domutils/node_modules/domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/import-fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
+      "license": "MIT",
+      "dependencies": {
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/mdn-data": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/normalize-url": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "~1.0.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "license": "ISC"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-calc": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.5.tgz",
+      "integrity": "sha512-1tKHutbGtLtEZF6PT4JSihCHfIVldU72mZ8SdZHIYriIZ9fh9k9aWSppaT8rHsyI3dX+KSR+W+Ix9BMY3AODrg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.27",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-colormin": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
+      "integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.0.0",
+        "color": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-colormin/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-convert-values": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
+      "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-convert-values/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-discard-comments": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
+      "integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-discard-duplicates": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+      "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-discard-empty": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
+      "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-discard-overridden": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
+      "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-merge-longhand": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
+      "integrity": "sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-color-names": "0.0.4",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "stylehacks": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-merge-longhand/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-merge-rules": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
+      "integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "cssnano-util-same-parent": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0",
+        "vendors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-merge-rules/node_modules/postcss-selector-parser": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+      "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
+      "license": "MIT",
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-minify-font-values": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
+      "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-minify-font-values/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-minify-gradients": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
+      "integrity": "sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "is-color-stop": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-minify-gradients/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-minify-params": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
+      "integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
+      "license": "MIT",
+      "dependencies": {
+        "alphanum-sort": "^1.0.0",
+        "browserslist": "^4.0.0",
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "uniqs": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-minify-params/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-minify-selectors": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
+      "integrity": "sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==",
+      "license": "MIT",
+      "dependencies": {
+        "alphanum-sort": "^1.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-minify-selectors/node_modules/postcss-selector-parser": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+      "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
+      "license": "MIT",
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-charset": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
+      "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-display-values": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
+      "integrity": "sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-display-values/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-positions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
+      "integrity": "sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-positions/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-repeat-style": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
+      "integrity": "sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-repeat-style/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-string": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
+      "integrity": "sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==",
+      "license": "MIT",
+      "dependencies": {
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-string/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-timing-functions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
+      "integrity": "sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-timing-functions/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-unicode": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
+      "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-unicode/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
+      "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^3.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-url/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-whitespace": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
+      "integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-normalize-whitespace/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-ordered-values": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
+      "integrity": "sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-ordered-values/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-reduce-initial": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
+      "integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-reduce-transforms": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
+      "integrity": "sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-util-get-match": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-reduce-transforms/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-svgo": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.3.tgz",
+      "integrity": "sha512-NoRbrcMWTtUghzuKSoIm6XV+sJdvZ7GZSc3wdBN0W19FTtp2ko8NqLsgoh/m9CzNhU3KLPvQmjIwtaNFkaFTvw==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "svgo": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-svgo/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/postcss-unique-selectors": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
+      "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
+      "license": "MIT",
+      "dependencies": {
+        "alphanum-sort": "^1.0.0",
+        "postcss": "^7.0.0",
+        "uniqs": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "license": "ISC"
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/stylehacks": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
+      "integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/stylehacks/node_modules/postcss-selector-parser": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+      "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
+      "license": "MIT",
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@intervolga/optimize-cssnano-plugin/node_modules/svgo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
+      "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
+      "deprecated": "This SVGO version is no longer supported. Upgrade to v2.x.x.",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "coa": "^2.0.2",
+        "css-select": "^2.0.0",
+        "css-select-base-adapter": "^0.1.1",
+        "css-tree": "1.0.0-alpha.37",
+        "csso": "^4.0.2",
+        "js-yaml": "^3.13.1",
+        "mkdirp": "~0.5.1",
+        "object.values": "^1.1.0",
+        "sax": "~1.2.4",
+        "stable": "^0.1.8",
+        "unquote": "~1.1.1",
+        "util.promisify": "~1.0.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -3473,16 +7941,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@jest/console/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/core": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
@@ -3545,16 +8003,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@jest/core/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@jest/diff-sequences": {
@@ -3817,16 +8265,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@jest/reporters/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/schemas": {
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
@@ -3920,16 +8358,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/test-sequencer/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/transform": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
@@ -3971,16 +8399,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@jest/types": {
@@ -4210,6 +8628,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/@mrmlnc/readdir-enhanced/node_modules/glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig==",
+      "license": "BSD"
     },
     "node_modules/@mswjs/interceptors": {
       "version": "0.41.8",
@@ -5632,20 +10056,33 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
-      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^5.0.0",
-        "@types/serve-static": "^2"
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
       }
     },
     "node_modules/@types/express-serve-static-core": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
       "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/express/node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -5724,6 +10161,12 @@
       "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
       "license": "MIT"
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "license": "MIT"
+    },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
@@ -5785,12 +10228,23 @@
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
@@ -5860,6 +10314,34 @@
         "@types/serve-static": "*",
         "@types/webpack": "^4",
         "http-proxy-middleware": "^1.0.0"
+      }
+    },
+    "node_modules/@types/webpack-dev-server/node_modules/http-proxy-middleware": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.3.1.tgz",
+      "integrity": "sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.5",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@types/webpack-dev-server/node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@types/webpack-sources": {
@@ -6271,52 +10753,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@vue/babel-preset-app": {
-      "version": "4.5.19",
-      "resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-4.5.19.tgz",
-      "integrity": "sha512-VCNRiAt2P/bLo09rYt3DLe6xXUMlhJwrvU18Ddd/lYJgC7s8+wvhgYs+MTx4OiAXdu58drGwSBO9SPx7C6J82Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.0",
-        "@babel/helper-compilation-targets": "^7.9.6",
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/plugin-proposal-class-properties": "^7.8.3",
-        "@babel/plugin-proposal-decorators": "^7.8.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-syntax-jsx": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.11.0",
-        "@babel/preset-env": "^7.11.0",
-        "@babel/runtime": "^7.11.0",
-        "@vue/babel-plugin-jsx": "^1.0.3",
-        "@vue/babel-preset-jsx": "^1.2.4",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "core-js": "^3.6.5",
-        "core-js-compat": "^3.6.5",
-        "semver": "^6.1.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "*",
-        "core-js": "^3",
-        "vue": "^2 || ^3.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "core-js": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vue/babel-preset-app/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@vue/babel-preset-jsx": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@vue/babel-preset-jsx/-/babel-preset-jsx-1.4.0.tgz",
@@ -6421,652 +10857,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@vue/cli-overlay": {
-      "version": "4.5.19",
-      "resolved": "https://registry.npmjs.org/@vue/cli-overlay/-/cli-overlay-4.5.19.tgz",
-      "integrity": "sha512-GdxvNSmOw7NHIazCO8gTK+xZbaOmScTtxj6eHVeMbYpDYVPJ+th3VMLWNpw/b6uOjwzzcyKlA5dRQ1DAb+gF/g==",
-      "license": "MIT"
-    },
-    "node_modules/@vue/cli-plugin-babel": {
-      "version": "4.5.19",
-      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-babel/-/cli-plugin-babel-4.5.19.tgz",
-      "integrity": "sha512-8ebXzaMW9KNTMAN6+DzkhFsjty1ieqT7hIW5Lbk4v30Qhfjkms7lBWyXPGkoq+wAikXFa1Gnam2xmWOBqDDvWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.0",
-        "@vue/babel-preset-app": "^4.5.19",
-        "@vue/cli-shared-utils": "^4.5.19",
-        "babel-loader": "^8.1.0",
-        "cache-loader": "^4.1.0",
-        "thread-loader": "^2.1.3",
-        "webpack": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@vue/cli-service": "^3.0.0 || ^4.0.0-0"
-      }
-    },
-    "node_modules/@vue/cli-plugin-router": {
-      "version": "4.5.19",
-      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-router/-/cli-plugin-router-4.5.19.tgz",
-      "integrity": "sha512-3icGzH1IbVYmMMsOwYa0lal/gtvZLebFXdE5hcQJo2mnTwngXGMTyYAzL56EgHBPjbMmRpyj6Iw9k4aVInVX6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/cli-shared-utils": "^4.5.19"
-      },
-      "peerDependencies": {
-        "@vue/cli-service": "^3.0.0 || ^4.0.0-0"
-      }
-    },
-    "node_modules/@vue/cli-plugin-vuex": {
-      "version": "4.5.19",
-      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-vuex/-/cli-plugin-vuex-4.5.19.tgz",
-      "integrity": "sha512-DUmfdkG3pCdkP7Iznd87RfE9Qm42mgp2hcrNcYQYSru1W1gX2dG/JcW8bxmeGSa06lsxi9LEIc/QD1yPajSCZw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@vue/cli-service": "^3.0.0 || ^4.0.0-0"
-      }
-    },
-    "node_modules/@vue/cli-service": {
-      "version": "4.5.19",
-      "resolved": "https://registry.npmjs.org/@vue/cli-service/-/cli-service-4.5.19.tgz",
-      "integrity": "sha512-+Wpvj8fMTCt9ZPOLu5YaLkFCQmB4MrZ26aRmhhKiCQ/4PMoL6mLezfqdt6c+m2htM+1WV5RunRo+0WHl2DfwZA==",
-      "license": "MIT",
-      "dependencies": {
-        "@intervolga/optimize-cssnano-plugin": "^1.0.5",
-        "@soda/friendly-errors-webpack-plugin": "^1.7.1",
-        "@soda/get-current-script": "^1.0.0",
-        "@types/minimist": "^1.2.0",
-        "@types/webpack": "^4.0.0",
-        "@types/webpack-dev-server": "^3.11.0",
-        "@vue/cli-overlay": "^4.5.19",
-        "@vue/cli-plugin-router": "^4.5.19",
-        "@vue/cli-plugin-vuex": "^4.5.19",
-        "@vue/cli-shared-utils": "^4.5.19",
-        "@vue/component-compiler-utils": "^3.1.2",
-        "@vue/preload-webpack-plugin": "^1.1.0",
-        "@vue/web-component-wrapper": "^1.2.0",
-        "acorn": "^7.4.0",
-        "acorn-walk": "^7.1.1",
-        "address": "^1.1.2",
-        "autoprefixer": "^9.8.6",
-        "browserslist": "^4.12.0",
-        "cache-loader": "^4.1.0",
-        "case-sensitive-paths-webpack-plugin": "^2.3.0",
-        "cli-highlight": "^2.1.4",
-        "clipboardy": "^2.3.0",
-        "cliui": "^6.0.0",
-        "copy-webpack-plugin": "^5.1.1",
-        "css-loader": "^3.5.3",
-        "cssnano": "^4.1.10",
-        "debug": "^4.1.1",
-        "default-gateway": "^5.0.5",
-        "dotenv": "^8.2.0",
-        "dotenv-expand": "^5.1.0",
-        "file-loader": "^4.2.0",
-        "fs-extra": "^7.0.1",
-        "globby": "^9.2.0",
-        "hash-sum": "^2.0.0",
-        "html-webpack-plugin": "^3.2.0",
-        "launch-editor-middleware": "^2.2.1",
-        "lodash.defaultsdeep": "^4.6.1",
-        "lodash.mapvalues": "^4.6.0",
-        "lodash.transform": "^4.6.0",
-        "mini-css-extract-plugin": "^0.9.0",
-        "minimist": "^1.2.5",
-        "pnp-webpack-plugin": "^1.6.4",
-        "portfinder": "^1.0.26",
-        "postcss-loader": "^3.0.0",
-        "ssri": "^8.0.1",
-        "terser-webpack-plugin": "^1.4.4",
-        "thread-loader": "^2.1.3",
-        "url-loader": "^2.2.0",
-        "vue-loader": "^15.9.2",
-        "vue-style-loader": "^4.1.2",
-        "webpack": "^4.0.0",
-        "webpack-bundle-analyzer": "^3.8.0",
-        "webpack-chain": "^6.4.0",
-        "webpack-dev-server": "^3.11.0",
-        "webpack-merge": "^4.2.2"
-      },
-      "bin": {
-        "vue-cli-service": "bin/vue-cli-service.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "optionalDependencies": {
-        "vue-loader-v16": "npm:vue-loader@^16.1.0"
-      },
-      "peerDependencies": {
-        "@vue/compiler-sfc": "^3.0.0-beta.14",
-        "vue-template-compiler": "^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/compiler-sfc": {
-          "optional": true
-        },
-        "less-loader": {
-          "optional": true
-        },
-        "pug-plain-loader": {
-          "optional": true
-        },
-        "raw-loader": {
-          "optional": true
-        },
-        "sass-loader": {
-          "optional": true
-        },
-        "stylus-loader": {
-          "optional": true
-        },
-        "vue-template-compiler": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vue/cli-service/node_modules/css-loader": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
-      "integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^5.3.1",
-        "cssesc": "^3.0.0",
-        "icss-utils": "^4.1.1",
-        "loader-utils": "^1.2.3",
-        "normalize-path": "^3.0.0",
-        "postcss": "^7.0.32",
-        "postcss-modules-extract-imports": "^2.0.0",
-        "postcss-modules-local-by-default": "^3.0.2",
-        "postcss-modules-scope": "^2.2.0",
-        "postcss-modules-values": "^3.0.0",
-        "postcss-value-parser": "^4.1.0",
-        "schema-utils": "^2.7.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">= 8.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/@vue/cli-service/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@vue/cli-service/node_modules/icss-utils": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
-      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
-      "license": "ISC",
-      "dependencies": {
-        "postcss": "^7.0.14"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@vue/cli-service/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/@vue/cli-service/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@vue/cli-service/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/@vue/cli-service/node_modules/postcss-modules-extract-imports": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
-      "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
-      "license": "ISC",
-      "dependencies": {
-        "postcss": "^7.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@vue/cli-service/node_modules/postcss-modules-local-by-default": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
-      "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
-      "license": "MIT",
-      "dependencies": {
-        "icss-utils": "^4.1.1",
-        "postcss": "^7.0.32",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@vue/cli-service/node_modules/postcss-modules-scope": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
-      "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
-      "license": "ISC",
-      "dependencies": {
-        "postcss": "^7.0.6",
-        "postcss-selector-parser": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@vue/cli-service/node_modules/postcss-modules-values": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
-      "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
-      "license": "ISC",
-      "dependencies": {
-        "icss-utils": "^4.0.0",
-        "postcss": "^7.0.6"
-      }
-    },
-    "node_modules/@vue/cli-service/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@vue/cli-service/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/@vue/cli-service/node_modules/vue-loader": {
-      "version": "15.11.1",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.11.1.tgz",
-      "integrity": "sha512-0iw4VchYLePqJfJu9s62ACWUXeSqM30SQqlIftbYWM3C+jpPcEHKSPUZBLjSF9au4HTHQ/naF6OGnO3Q/qGR3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/component-compiler-utils": "^3.1.0",
-        "hash-sum": "^1.0.2",
-        "loader-utils": "^1.1.0",
-        "vue-hot-reload-api": "^2.3.0",
-        "vue-style-loader": "^4.1.0"
-      },
-      "peerDependencies": {
-        "css-loader": "*",
-        "webpack": "^3.0.0 || ^4.1.0 || ^5.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "cache-loader": {
-          "optional": true
-        },
-        "prettier": {
-          "optional": true
-        },
-        "vue-template-compiler": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vue/cli-service/node_modules/vue-loader/node_modules/hash-sum": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
-      "integrity": "sha512-fUs4B4L+mlt8/XAtSOGMUO1TXmAelItBPtJG7CyHJfYTdDjwisntGO2JQz7oUsatOY9o68+57eziUVNw/mRHmA==",
-      "license": "MIT"
-    },
-    "node_modules/@vue/cli-shared-utils": {
-      "version": "4.5.19",
-      "resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-4.5.19.tgz",
-      "integrity": "sha512-JYpdsrC/d9elerKxbEUtmSSU6QRM60rirVubOewECHkBHj+tLNznWq/EhCjswywtePyLaMUK25eTqnTSZlEE+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@achrinza/node-ipc": "9.2.2",
-        "@hapi/joi": "^15.0.1",
-        "chalk": "^2.4.2",
-        "execa": "^1.0.0",
-        "launch-editor": "^2.2.1",
-        "lru-cache": "^5.1.1",
-        "open": "^6.3.0",
-        "ora": "^3.4.0",
-        "read-pkg": "^5.1.1",
-        "request": "^2.88.2",
-        "semver": "^6.1.0",
-        "strip-ansi": "^6.0.0"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/cross-spawn": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
-      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
-      "license": "MIT",
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/cross-spawn/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/execa": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/get-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "license": "ISC"
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/@vue/cli-shared-utils/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "license": "ISC"
-    },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.33",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
@@ -7105,34 +10895,6 @@
         "magic-string": "^0.30.21",
         "postcss": "^8.5.10",
         "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/@vue/compiler-ssr": {
@@ -7178,6 +10940,29 @@
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/@vue/component-compiler-utils/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "license": "ISC"
+    },
+    "node_modules/@vue/component-compiler-utils/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/@vue/component-compiler-utils/node_modules/yallist": {
@@ -7251,7 +11036,16 @@
       "integrity": "sha512-Iu8Tbg3f+emIIMmI2ycSI8QcEuAUgPTgHwesDU1eKMLE4YC/c/sFbGc70QgMq31ijRftV0R7vCm9co6rldCeOA==",
       "license": "MIT"
     },
-    "node_modules/@webassemblyjs/ast": {
+    "node_modules/@webassemblyjs/helper-code-frame": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
+      "integrity": "sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/wast-printer": "1.9.0"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-code-frame/node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
       "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
@@ -7262,31 +11056,21 @@
         "@webassemblyjs/wast-parser": "1.9.0"
       }
     },
-    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+    "node_modules/@webassemblyjs/helper-code-frame/node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
-      "integrity": "sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+      "integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
       "license": "MIT"
     },
-    "node_modules/@webassemblyjs/helper-api-error": {
+    "node_modules/@webassemblyjs/helper-code-frame/node_modules/@webassemblyjs/wast-printer": {
       "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
-      "integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
-      "integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==",
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/helper-code-frame": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
-      "integrity": "sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
+      "integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
       "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/wast-printer": "1.9.0"
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0",
+        "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/helper-fsm": {
@@ -7304,102 +11088,22 @@
         "@webassemblyjs/ast": "1.9.0"
       }
     },
-    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+    "node_modules/@webassemblyjs/helper-module-context/node_modules/@webassemblyjs/ast": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+      "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-module-context/node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
       "integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
       "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
-      "integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0"
-      }
-    },
-    "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
-      "integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
-      "license": "MIT",
-      "dependencies": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "node_modules/@webassemblyjs/leb128": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
-      "integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/utf8": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
-      "integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==",
-      "license": "MIT"
-    },
-    "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
-      "integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/helper-wasm-section": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0",
-        "@webassemblyjs/wasm-opt": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0",
-        "@webassemblyjs/wast-printer": "1.9.0"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
-      "integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/ieee754": "1.9.0",
-        "@webassemblyjs/leb128": "1.9.0",
-        "@webassemblyjs/utf8": "1.9.0"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
-      "integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
-      "integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-api-error": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/ieee754": "1.9.0",
-        "@webassemblyjs/leb128": "1.9.0",
-        "@webassemblyjs/utf8": "1.9.0"
-      }
     },
     "node_modules/@webassemblyjs/wast-parser": {
       "version": "1.9.0",
@@ -7415,16 +11119,34 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@webassemblyjs/wast-printer": {
+    "node_modules/@webassemblyjs/wast-parser/node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
-      "integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+      "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
       "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/wast-parser": "1.9.0",
-        "@xtuc/long": "4.2.2"
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0"
       }
+    },
+    "node_modules/@webassemblyjs/wast-parser/node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
+      "integrity": "sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/wast-parser/node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
+      "integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/wast-parser/node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+      "integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
+      "license": "MIT"
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -7470,9 +11192,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -7488,15 +11210,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/add-stream": {
@@ -7854,15 +11567,13 @@
       }
     },
     "node_modules/array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "array-uniq": "^1.0.1"
-      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/array-uniq": {
@@ -8154,34 +11865,6 @@
         "node": ">= 4.5.0"
       }
     },
-    "node_modules/autoprefixer": {
-      "version": "9.8.8",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
-      "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.12.0",
-        "caniuse-lite": "^1.0.30001109",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "picocolors": "^0.2.1",
-        "postcss": "^7.0.32",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-      }
-    },
-    "node_modules/autoprefixer/node_modules/picocolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-      "license": "ISC"
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -8278,16 +11961,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/babel-jest/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/babel-loader": {
@@ -8588,12 +12261,16 @@
       }
     },
     "node_modules/binary-extensions": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "license": "MIT",
+      "optional": true,
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bindings": {
@@ -8889,17 +12566,6 @@
       },
       "peerDependencies": {
         "vue": "^2.6.11"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
       }
     },
     "node_modules/buffer-from": {
@@ -9214,16 +12880,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camel-case": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-      "integrity": "sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
-      }
-    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -9496,18 +13152,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/clean-css": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
-      "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -9568,34 +13212,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/cli-highlight/node_modules/yargs": {
@@ -9842,14 +13458,14 @@
       }
     },
     "node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
+        "wrap-ansi": "^7.0.0"
       }
     },
     "node_modules/clone": {
@@ -10058,12 +13674,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-      "license": "MIT"
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -10269,15 +13879,6 @@
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "license": "MIT"
-    },
-    "node_modules/connect-history-api-fallback": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
-      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/console-browserify": {
       "version": "1.2.0",
@@ -10853,375 +14454,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/copy-webpack-plugin": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz",
-      "integrity": "sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "cacache": "^12.0.3",
-        "find-cache-dir": "^2.1.0",
-        "glob-parent": "^3.1.0",
-        "globby": "^7.1.1",
-        "is-glob": "^4.0.1",
-        "loader-utils": "^1.2.3",
-        "minimatch": "^3.0.4",
-        "normalize-path": "^3.0.0",
-        "p-limit": "^2.2.1",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^4.0.0",
-        "webpack-log": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/copy-webpack-plugin/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/cacache": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
-      "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
-      "license": "ISC",
-      "dependencies": {
-        "bluebird": "^3.5.5",
-        "chownr": "^1.1.1",
-        "figgy-pudding": "^3.5.1",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.1.15",
-        "infer-owner": "^1.0.3",
-        "lru-cache": "^5.1.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.3",
-        "ssri": "^6.0.1",
-        "unique-filename": "^1.1.1",
-        "y18n": "^4.0.0"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
-    },
-    "node_modules/copy-webpack-plugin/node_modules/dir-glob": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/find-cache-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/globby": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-      "integrity": "sha512-yANWAN2DUcBtuus5Cpd+SKROzXHs2iVXFZt/Ykrfz6SAXqacLX25NZpltE+39ceMexYF4TtEadjuSTw8+3wX4g==",
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/globby/node_modules/pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/ignore": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-      "license": "MIT"
-    },
-    "node_modules/copy-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
-    },
-    "node_modules/copy-webpack-plugin/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/path-type/node_modules/pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/pkg-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/schema-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha512-3TYDR7xWt4dIqV2JauJr+EJeW356RXijHeUlO+8djJ+uBXPn8/2dpzBc8yQhh583sVvc9CvFAeQVgijsH+PNNg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/ssri": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
-      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
-      "license": "ISC",
-      "dependencies": {
-        "figgy-pudding": "^3.5.1"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "license": "ISC"
-    },
-    "node_modules/copy-webpack-plugin/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "license": "ISC"
-    },
     "node_modules/core": {
       "resolved": "core",
       "link": true
@@ -11480,19 +14712,6 @@
         "node": "*"
       }
     },
-    "node_modules/css-declaration-sorter": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
-      "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.1",
-        "timsort": "^0.3.0"
-      },
-      "engines": {
-        "node": ">4"
-      }
-    },
     "node_modules/css-loader": {
       "version": "5.2.7",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
@@ -11543,34 +14762,6 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
     },
-    "node_modules/css-loader/node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/css-loader/node_modules/schema-utils": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -11612,12 +14803,12 @@
       "license": "MIT"
     },
     "node_modules/css-tree": {
-      "version": "1.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
-      "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.0.4",
+        "mdn-data": "2.0.14",
         "source-map": "^0.6.1"
       },
       "engines": {
@@ -11654,62 +14845,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssnano": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.11.tgz",
-      "integrity": "sha512-6gZm2htn7xIPJOHY824ERgj8cNPgPxyCSnkXc4v7YvNW+TdVfzgngHcEhy/8D11kUWRUMbke+tC+AUcUsnMz2g==",
-      "license": "MIT",
-      "dependencies": {
-        "cosmiconfig": "^5.0.0",
-        "cssnano-preset-default": "^4.0.8",
-        "is-resolvable": "^1.0.0",
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/cssnano-preset-default": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.8.tgz",
-      "integrity": "sha512-LdAyHuq+VRyeVREFmuxUZR1TXjQm8QQU/ktoo/x7bz+SdOge1YKc5eMN6pRW7YWBmyq59CqYba1dJ5cUukEjLQ==",
-      "license": "MIT",
-      "dependencies": {
-        "css-declaration-sorter": "^4.0.1",
-        "cssnano-util-raw-cache": "^4.0.1",
-        "postcss": "^7.0.0",
-        "postcss-calc": "^7.0.1",
-        "postcss-colormin": "^4.0.3",
-        "postcss-convert-values": "^4.0.1",
-        "postcss-discard-comments": "^4.0.2",
-        "postcss-discard-duplicates": "^4.0.2",
-        "postcss-discard-empty": "^4.0.1",
-        "postcss-discard-overridden": "^4.0.1",
-        "postcss-merge-longhand": "^4.0.11",
-        "postcss-merge-rules": "^4.0.3",
-        "postcss-minify-font-values": "^4.0.2",
-        "postcss-minify-gradients": "^4.0.2",
-        "postcss-minify-params": "^4.0.2",
-        "postcss-minify-selectors": "^4.0.2",
-        "postcss-normalize-charset": "^4.0.1",
-        "postcss-normalize-display-values": "^4.0.2",
-        "postcss-normalize-positions": "^4.0.2",
-        "postcss-normalize-repeat-style": "^4.0.2",
-        "postcss-normalize-string": "^4.0.2",
-        "postcss-normalize-timing-functions": "^4.0.2",
-        "postcss-normalize-unicode": "^4.0.1",
-        "postcss-normalize-url": "^4.0.1",
-        "postcss-normalize-whitespace": "^4.0.2",
-        "postcss-ordered-values": "^4.1.2",
-        "postcss-reduce-initial": "^4.0.3",
-        "postcss-reduce-transforms": "^4.0.2",
-        "postcss-svgo": "^4.0.3",
-        "postcss-unique-selectors": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/cssnano-util-get-arguments": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
@@ -11740,6 +14875,29 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/cssnano-util-raw-cache/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "license": "ISC"
+    },
+    "node_modules/cssnano-util-raw-cache/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
     "node_modules/cssnano-util-same-parent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
@@ -11747,91 +14905,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/cssnano/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/cssnano/node_modules/cosmiconfig": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-      "license": "MIT",
-      "dependencies": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cssnano/node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cssnano/node_modules/import-fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-      "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
-      "license": "MIT",
-      "dependencies": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cssnano/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/cssnano/node_modules/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cssnano/node_modules/resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/csso": {
@@ -11845,25 +14918,6 @@
       "engines": {
         "node": ">=8.0.0"
       }
-    },
-    "node_modules/csso/node_modules/css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "license": "CC0-1.0"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -12074,126 +15128,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/default-gateway": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.5.tgz",
-      "integrity": "sha512-z2RnruVmj8hVMmAnEJMTIJNijhKCDiGjbLP+BHJFOT7ld3Bo5qcIBpVYDniqhbMIIf+jZDlkP2MkPXiQy/DBLA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "execa": "^3.3.0"
-      },
-      "engines": {
-        "node": "^8.12.0 || >=9.7.0"
-      }
-    },
-    "node_modules/default-gateway/node_modules/execa": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-      "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": "^8.12.0 || >=9.7.0"
-      }
-    },
-    "node_modules/default-gateway/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-gateway/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/default-gateway/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-gateway/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/default-gateway/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-gateway/node_modules/p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/default-gateway/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
-    "node_modules/default-gateway/node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -12269,6 +15203,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/del/node_modules/array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+      "license": "MIT",
+      "dependencies": {
+        "array-uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/del/node_modules/globby": {
@@ -12564,15 +15510,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/dotenv-expand": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
@@ -12824,32 +15761,6 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/enhanced-resolve": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
-      "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.5.0",
-        "tapable": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/enhanced-resolve/node_modules/memory-fs": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-      "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-      "license": "MIT",
-      "dependencies": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4.3.0 <5.0.0 || >=5.10"
       }
     },
     "node_modules/entities": {
@@ -13418,18 +16329,6 @@
         "eslint-plugin-import": ">=2.2.0"
       }
     },
-    "node_modules/eslint-import-resolver-custom-alias/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.10",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
@@ -13897,18 +16796,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -13966,18 +16853,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/espree/node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
@@ -14594,159 +17469,33 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
-      "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.3",
-        "micromatch": "^3.1.10"
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=8.6.0"
       }
     },
-    "node_modules/fast-glob/node_modules/@nodelib/fs.stat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
-      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
-      "license": "MIT",
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/fast-glob/node_modules/braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-      "license": "MIT",
-      "dependencies": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/braces/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/fill-range/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/is-number": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/is-number/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-      "license": "MIT",
-      "dependencies": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -15590,32 +18339,16 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "license": "ISC",
       "dependencies": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      }
-    },
-    "node_modules/glob-parent/node_modules/is-glob": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-      "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.0"
+        "is-glob": "^4.0.3"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10.13.0"
       }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-      "integrity": "sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig==",
-      "license": "BSD"
     },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "1.0.2",
@@ -15705,64 +18438,24 @@
       }
     },
     "node_modules/globby": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
-      "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/glob": "^7.1.1",
-        "array-union": "^1.0.2",
-        "dir-glob": "^2.2.2",
-        "fast-glob": "^2.2.6",
-        "glob": "^7.1.3",
-        "ignore": "^4.0.3",
-        "pify": "^4.0.1",
-        "slash": "^2.0.0"
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/globby/node_modules/dir-glob": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^3.0.0"
+        "node": ">=10"
       },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/globby/node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/globby/node_modules/path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/globby/node_modules/path-type/node_modules/pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -15794,19 +18487,6 @@
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
       "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
       "license": "ISC"
-    },
-    "node_modules/gzip-size": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
-      "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "^0.1.1",
-        "pify": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -16189,12 +18869,6 @@
       "integrity": "sha512-7Wn5GMLuHBjZCb2bTmnDOycho0p/7UVaAeqXZGbHrBCl6Yd/xDhQJAXe6Ga9AXJH2I5zY1dEdYw2u1UptnSBJA==",
       "license": "MIT"
     },
-    "node_modules/html-entities": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
-      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
-      "license": "MIT"
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -16221,6 +18895,58 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/html-minifier/node_modules/camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==",
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
+    "node_modules/html-minifier/node_modules/clean-css": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
+      "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
+    "node_modules/html-minifier/node_modules/commander": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+      "license": "MIT"
+    },
+    "node_modules/html-minifier/node_modules/lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==",
+      "license": "MIT"
+    },
+    "node_modules/html-minifier/node_modules/no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^1.1.1"
+      }
+    },
+    "node_modules/html-minifier/node_modules/param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==",
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^2.2.0"
       }
     },
     "node_modules/html-minifier/node_modules/uglify-js": {
@@ -16252,67 +18978,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/html-webpack-plugin": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
-      "integrity": "sha512-Br4ifmjQojUP4EmHnRBoUIYcZ9J7M4bTMcm7u6xoIAIuq2Nte4TzXX0533owvkQKQD1WeMTTTyD4Ni4QKxS0Bg==",
-      "deprecated": "3.x is no longer supported",
-      "license": "MIT",
-      "dependencies": {
-        "html-minifier": "^3.2.3",
-        "loader-utils": "^0.2.16",
-        "lodash": "^4.17.3",
-        "pretty-error": "^2.0.2",
-        "tapable": "^1.0.0",
-        "toposort": "^1.0.0",
-        "util.promisify": "1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9"
-      },
-      "peerDependencies": {
-        "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
-      }
-    },
-    "node_modules/html-webpack-plugin/node_modules/big.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/html-webpack-plugin/node_modules/emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/html-webpack-plugin/node_modules/json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/html-webpack-plugin/node_modules/loader-utils": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-      "integrity": "sha512-tiv66G0SmiOx+pLWMtGEkfSEejxvb6N6uRrQjfWJIT79W9GMpgKeCAmm9aVBKtd4WEgntciI8CsGqjpDoCWJug==",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0",
-        "object-assign": "^4.0.1"
       }
     },
     "node_modules/htmlparser2": {
@@ -16401,34 +19066,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/http-proxy-middleware": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.3.1.tgz",
-      "integrity": "sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-proxy": "^1.17.5",
-        "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.1",
-        "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/http-proxy-middleware/node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/http-signature": {
@@ -17052,15 +19689,16 @@
       }
     },
     "node_modules/is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "^2.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -18061,16 +20699,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/jest-circus/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-cli": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
@@ -18295,16 +20923,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-config/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-config/node_modules/strip-json-comments": {
@@ -18584,16 +21202,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/jest-message-util/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-mock": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
@@ -18686,16 +21294,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-runner": {
@@ -18903,16 +21501,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-snapshot": {
@@ -19784,15 +22372,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/loader-runner": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
-      "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.3.0 <5.0.0 || >=5.10"
-      }
-    },
     "node_modules/loader-utils": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
@@ -19923,89 +22502,6 @@
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/log-symbols/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/log-symbols/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/log-symbols/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/log-symbols/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/log-symbols/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/log-symbols/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -20162,12 +22658,6 @@
       "bin": {
         "loose-envify": "cli.js"
       }
-    },
-    "node_modules/lower-case": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==",
-      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "11.3.5",
@@ -20406,9 +22896,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
-      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
@@ -20558,6 +23048,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -20574,101 +23065,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mini-css-extract-plugin": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
-      "integrity": "sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==",
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^1.1.0",
-        "normalize-url": "1.9.1",
-        "schema-utils": "^1.0.0",
-        "webpack-sources": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.4.0"
-      }
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/normalize-url": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-      "integrity": "sha512-A48My/mtCklowHBlI8Fq2jFWK4tX4lJ5E6ytFsSOq1fzpvT0SQSgKhSg7lN5c2uYFOrUAOQp6zhhJnpp1eMloQ==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.0.1",
-        "prepend-http": "^1.0.0",
-        "query-string": "^4.1.0",
-        "sort-keys": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -21235,15 +23631,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "license": "MIT"
     },
-    "node_modules/no-case": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lower-case": "^1.1.1"
-      }
-    },
     "node_modules/nock": {
       "version": "14.0.14",
       "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.14.tgz",
@@ -21340,15 +23727,6 @@
         }
       }
     },
-    "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -21385,6 +23763,17 @@
         "url": "^0.11.0",
         "util": "^0.11.0",
         "vm-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/node-libs-browser/node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "node_modules/node-libs-browser/node_modules/events": {
@@ -23760,27 +26149,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/open": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
-      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/open/node_modules/is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/opener": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -23826,167 +26194,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/ora": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
-      "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-spinners": "^2.0.0",
-        "log-symbols": "^2.2.0",
-        "strip-ansi": "^5.2.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ora/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ora/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ora/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ora/node_modules/cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ora/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/ora/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/ora/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/ora/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ora/node_modules/mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ora/node_modules/onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ora/node_modules/restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ora/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
-    "node_modules/ora/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ora/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/os-browserify": {
@@ -24151,18 +26358,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/p-retry": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
-      "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
-      "license": "MIT",
-      "dependencies": {
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/p-timeout": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
@@ -24206,15 +26401,6 @@
         "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
-      }
-    },
-    "node_modules/param-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-      "integrity": "sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^2.2.0"
       }
     },
     "node_modules/parent-module": {
@@ -24908,120 +27094,31 @@
       }
     },
     "node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/postcss-calc": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.5.tgz",
-      "integrity": "sha512-1tKHutbGtLtEZF6PT4JSihCHfIVldU72mZ8SdZHIYriIZ9fh9k9aWSppaT8rHsyI3dX+KSR+W+Ix9BMY3AODrg==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.27",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.0.2"
-      }
-    },
-    "node_modules/postcss-colormin": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
-      "integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "color": "^3.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-colormin/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-convert-values": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
-      "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-convert-values/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-discard-comments": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
-      "integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-discard-duplicates": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
-      "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-discard-empty": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
-      "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-discard-overridden": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
-      "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postcss-load-config": {
@@ -25126,227 +27223,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/postcss-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
-      "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^1.1.0",
-        "postcss": "^7.0.0",
-        "postcss-load-config": "^2.0.0",
-        "schema-utils": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/postcss-loader/node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/postcss-loader/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-loader/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/postcss-loader/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/postcss-loader/node_modules/schema-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/postcss-merge-longhand": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
-      "integrity": "sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==",
-      "license": "MIT",
-      "dependencies": {
-        "css-color-names": "0.0.4",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "stylehacks": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-merge-longhand/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-merge-rules": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
-      "integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "caniuse-api": "^3.0.0",
-        "cssnano-util-same-parent": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0",
-        "vendors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-merge-rules/node_modules/postcss-selector-parser": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
-      "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
-      "license": "MIT",
-      "dependencies": {
-        "dot-prop": "^5.2.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/postcss-minify-font-values": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
-      "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-minify-font-values/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-minify-gradients": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
-      "integrity": "sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "is-color-stop": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-minify-gradients/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-minify-params": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
-      "integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
-      "license": "MIT",
-      "dependencies": {
-        "alphanum-sort": "^1.0.0",
-        "browserslist": "^4.0.0",
-        "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "uniqs": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-minify-params/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-minify-selectors": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
-      "integrity": "sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==",
-      "license": "MIT",
-      "dependencies": {
-        "alphanum-sort": "^1.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-minify-selectors/node_modules/postcss-selector-parser": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
-      "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
-      "license": "MIT",
-      "dependencies": {
-        "dot-prop": "^5.2.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/postcss-modules-extract-imports": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
@@ -25432,245 +27308,6 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/postcss-normalize-charset": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
-      "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-display-values": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
-      "integrity": "sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-display-values/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-normalize-positions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
-      "integrity": "sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-positions/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-normalize-repeat-style": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
-      "integrity": "sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-repeat-style/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-normalize-string": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
-      "integrity": "sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==",
-      "license": "MIT",
-      "dependencies": {
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-string/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-normalize-timing-functions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
-      "integrity": "sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-timing-functions/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-normalize-unicode": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
-      "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-unicode/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-normalize-url": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
-      "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-absolute-url": "^2.0.0",
-        "normalize-url": "^3.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-url/node_modules/normalize-url": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/postcss-normalize-url/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-normalize-whitespace": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
-      "integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-normalize-whitespace/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-ordered-values": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
-      "integrity": "sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-ordered-values/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-reduce-initial": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
-      "integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "caniuse-api": "^3.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-reduce-transforms": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
-      "integrity": "sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-util-get-match": "^4.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-reduce-transforms/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
@@ -25684,51 +27321,11 @@
         "node": ">=4"
       }
     },
-    "node_modules/postcss-svgo": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.3.tgz",
-      "integrity": "sha512-NoRbrcMWTtUghzuKSoIm6XV+sJdvZ7GZSc3wdBN0W19FTtp2ko8NqLsgoh/m9CzNhU3KLPvQmjIwtaNFkaFTvw==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "svgo": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/postcss-svgo/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
-    },
-    "node_modules/postcss-unique-selectors": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
-      "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
-      "license": "MIT",
-      "dependencies": {
-        "alphanum-sort": "^1.0.0",
-        "postcss": "^7.0.0",
-        "uniqs": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
-    },
-    "node_modules/postcss/node_modules/picocolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-      "license": "ISC"
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
@@ -25817,16 +27414,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/pretty-error": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.2.tgz",
-      "integrity": "sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.20",
-        "renderkid": "^2.0.4"
       }
     },
     "node_modules/pretty-format": {
@@ -26856,40 +28443,6 @@
       "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
       "license": "ISC"
     },
-    "node_modules/renderkid": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
-      "integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "css-select": "^4.1.3",
-        "dom-converter": "^0.2.0",
-        "htmlparser2": "^6.1.0",
-        "lodash": "^4.17.21",
-        "strip-ansi": "^3.0.1"
-      }
-    },
-    "node_modules/renderkid/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/renderkid/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/repeat-element": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
@@ -26938,39 +28491,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "license": "ISC",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "license": "ISC",
-      "dependencies": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
       }
     },
     "node_modules/request/node_modules/form-data": {
@@ -27121,15 +28641,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/retry-as-promised": {
@@ -27483,12 +28994,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "license": "ISC"
-    },
     "node_modules/schema-utils": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
@@ -27534,15 +29039,6 @@
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
       "license": "MIT"
-    },
-    "node_modules/selfsigned": {
-      "version": "1.10.14",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.14.tgz",
-      "integrity": "sha512-lkjaiAye+wBZDCBsu5BGi0XiLRxeUlsGod5ZP924CRSEoGuZAw/f7y9RKu28rwTfiHVhdavhB0qH0INV6P1lEA==",
-      "license": "MIT",
-      "dependencies": {
-        "node-forge": "^0.10.0"
-      }
     },
     "node_modules/semantic-release": {
       "version": "25.0.3",
@@ -27612,16 +29108,6 @@
         "semantic-release": ">=22.0.7"
       }
     },
-    "node_modules/semantic-release-monorepo/node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/semantic-release-monorepo/node_modules/crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -27679,23 +29165,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/semantic-release-monorepo/node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
     "node_modules/semantic-release-monorepo/node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -27717,40 +29186,6 @@
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release-monorepo/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/semantic-release-monorepo/node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
       "engines": {
         "node": ">=10"
       },
@@ -27926,16 +29361,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/semantic-release-monorepo/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/semantic-release-monorepo/node_modules/strip-final-newline": {
       "version": "2.0.0",
@@ -28427,17 +29852,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/sequelize-cli/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
     "node_modules/sequelize-cli/node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -28451,23 +29865,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/sequelize-cli/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/sequelize-cli/node_modules/yargs": {
@@ -29019,12 +30416,13 @@
       }
     },
     "node_modules/slash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/slice-ansi": {
@@ -29572,15 +30970,6 @@
       "resolved": "statutory",
       "link": true
     },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -29969,34 +31358,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/stylehacks": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
-      "integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/stylehacks/node_modules/postcss-selector-parser": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
-      "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
-      "license": "MIT",
-      "dependencies": {
-        "dot-prop": "^5.2.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/summeruniversity": {
       "resolved": "summeruniversity",
       "link": true
@@ -30074,208 +31435,6 @@
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA=="
     },
-    "node_modules/svgo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
-      "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
-      "deprecated": "This SVGO version is no longer supported. Upgrade to v2.x.x.",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "coa": "^2.0.2",
-        "css-select": "^2.0.0",
-        "css-select-base-adapter": "^0.1.1",
-        "css-tree": "1.0.0-alpha.37",
-        "csso": "^4.0.2",
-        "js-yaml": "^3.13.1",
-        "mkdirp": "~0.5.1",
-        "object.values": "^1.1.0",
-        "sax": "~1.2.4",
-        "stable": "^0.1.8",
-        "unquote": "~1.1.1",
-        "util.promisify": "~1.0.0"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/svgo/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/svgo/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/svgo/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/svgo/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/svgo/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/svgo/node_modules/css-select": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
-      "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^3.2.1",
-        "domutils": "^1.7.0",
-        "nth-check": "^1.0.2"
-      }
-    },
-    "node_modules/svgo/node_modules/css-what": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
-      "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/svgo/node_modules/dom-serializer": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/svgo/node_modules/domutils": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/svgo/node_modules/domutils/node_modules/domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/svgo/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/svgo/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/svgo/node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/svgo/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/svgo/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/svgo/node_modules/nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "~1.0.0"
-      }
-    },
-    "node_modules/svgo/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/synckit": {
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -30303,15 +31462,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/tapable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tar": {
@@ -30417,272 +31567,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/terser": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
-      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/terser-webpack-plugin": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.6.tgz",
-      "integrity": "sha512-2lBVf/VMVIddjSn3GqbT90GvIJ/eYXJkt8cTzU7NbjKqK8fwv18Ftr4PlbF46b/e88743iZFL5Dtr/rC4hjIeA==",
-      "license": "MIT",
-      "dependencies": {
-        "cacache": "^12.0.2",
-        "find-cache-dir": "^2.1.0",
-        "is-wsl": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^4.0.0",
-        "source-map": "^0.6.1",
-        "terser": "^4.1.2",
-        "webpack-sources": "^1.4.0",
-        "worker-farm": "^1.7.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/cacache": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
-      "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
-      "license": "ISC",
-      "dependencies": {
-        "bluebird": "^3.5.5",
-        "chownr": "^1.1.1",
-        "figgy-pudding": "^3.5.1",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.1.15",
-        "infer-owner": "^1.0.3",
-        "lru-cache": "^5.1.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.3",
-        "ssri": "^6.0.1",
-        "unique-filename": "^1.1.1",
-        "y18n": "^4.0.0"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
-    },
-    "node_modules/terser-webpack-plugin/node_modules/find-cache-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
-    },
-    "node_modules/terser-webpack-plugin/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/pkg-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/ssri": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
-      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
-      "license": "ISC",
-      "dependencies": {
-        "figgy-pudding": "^3.5.1"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "license": "ISC"
-    },
-    "node_modules/terser-webpack-plugin/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "license": "ISC"
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -30767,49 +31651,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/thread-loader": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.3.tgz",
-      "integrity": "sha512-wNrVKH2Lcf8ZrWxDF/khdlLlsTMczdcwPA9VEK4c2exlEPynYWxi9op3nPTo5lAnDIkE0rQEB3VBP+4Zncc9Hg==",
-      "license": "MIT",
-      "dependencies": {
-        "loader-runner": "^2.3.1",
-        "loader-utils": "^1.1.0",
-        "neo-async": "^2.6.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0 <7.0.0 || >= 8.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
-      }
-    },
-    "node_modules/thread-loader/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/thread-loader/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/through": {
@@ -32305,34 +33146,6 @@
         "prettier": "^1.18.2 || ^2.0.0"
       }
     },
-    "node_modules/vue/node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/vue2-touch-events": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/vue2-touch-events/-/vue2-touch-events-3.2.3.tgz",
@@ -32368,20 +33181,6 @@
         "makeerror": "1.0.12"
       }
     },
-    "node_modules/watchpack": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
-      "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
-      },
-      "optionalDependencies": {
-        "chokidar": "^3.4.1",
-        "watchpack-chokidar2": "^2.0.1"
-      }
-    },
     "node_modules/watchpack-chokidar2": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
@@ -32412,6 +33211,16 @@
       "dependencies": {
         "remove-trailing-separator": "^1.0.1"
       },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/watchpack-chokidar2/node_modules/binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -32522,6 +33331,43 @@
         "node": ">= 4.0"
       }
     },
+    "node_modules/watchpack-chokidar2/node_modules/glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      }
+    },
+    "node_modules/watchpack-chokidar2/node_modules/glob-parent/node_modules/is-glob": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-extglob": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/watchpack-chokidar2/node_modules/is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "binary-extensions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/watchpack-chokidar2/node_modules/is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -32612,83 +33458,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/watchpack/node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/watchpack/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/watchpack/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/watchpack/node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/watchpack/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
     "node_modules/wbuf": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
@@ -32720,159 +33489,6 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
-    "node_modules/webpack": {
-      "version": "4.47.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.47.0.tgz",
-      "integrity": "sha512-td7fYwgLSrky3fI1EuU5cneU4+pbH6GgOfuKNS1tNPcfdGinGELAqsb/BP4nnvZyKSG2i/xFGU7+n2PvZA8HJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-module-context": "1.9.0",
-        "@webassemblyjs/wasm-edit": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0",
-        "acorn": "^6.4.1",
-        "ajv": "^6.10.2",
-        "ajv-keywords": "^3.4.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.5.0",
-        "eslint-scope": "^4.0.3",
-        "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.4.0",
-        "loader-utils": "^1.2.3",
-        "memory-fs": "^0.4.1",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.3",
-        "neo-async": "^2.6.1",
-        "node-libs-browser": "^2.2.1",
-        "schema-utils": "^1.0.0",
-        "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.3",
-        "watchpack": "^1.7.4",
-        "webpack-sources": "^1.4.1"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        },
-        "webpack-command": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-bundle-analyzer": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.9.0.tgz",
-      "integrity": "sha512-Ob8amZfCm3rMB1ScjQVlbYYUEJyEjdEtQ92jqiFUYt5VkEeO2v5UMbv49P/gnmCZm3A6yaFQzCBvpZqN4MUsdA==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^7.1.1",
-        "acorn-walk": "^7.1.1",
-        "bfj": "^6.1.1",
-        "chalk": "^2.4.1",
-        "commander": "^2.18.0",
-        "ejs": "^2.6.1",
-        "express": "^4.16.3",
-        "filesize": "^3.6.1",
-        "gzip-size": "^5.0.0",
-        "lodash": "^4.17.19",
-        "mkdirp": "^0.5.1",
-        "opener": "^1.5.1",
-        "ws": "^6.0.0"
-      },
-      "bin": {
-        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
-      },
-      "engines": {
-        "node": ">= 6.14.4"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/webpack-bundle-analyzer/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/webpack-chain": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/webpack-chain/-/webpack-chain-6.5.1.tgz",
@@ -32894,683 +33510,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack-dev-middleware": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.3.tgz",
-      "integrity": "sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "memory-fs": "^0.4.1",
-        "mime": "^2.4.4",
-        "mkdirp": "^0.5.1",
-        "range-parser": "^1.2.1",
-        "webpack-log": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/webpack-dev-middleware/node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/webpack-dev-server": {
-      "version": "3.11.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz",
-      "integrity": "sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-html-community": "0.0.8",
-        "bonjour": "^3.5.0",
-        "chokidar": "^2.1.8",
-        "compression": "^1.7.4",
-        "connect-history-api-fallback": "^1.6.0",
-        "debug": "^4.1.1",
-        "del": "^4.1.1",
-        "express": "^4.17.1",
-        "html-entities": "^1.3.1",
-        "http-proxy-middleware": "0.19.1",
-        "import-local": "^2.0.0",
-        "internal-ip": "^4.3.0",
-        "ip": "^1.1.5",
-        "is-absolute-url": "^3.0.3",
-        "killable": "^1.0.1",
-        "loglevel": "^1.6.8",
-        "opn": "^5.5.0",
-        "p-retry": "^3.0.1",
-        "portfinder": "^1.0.26",
-        "schema-utils": "^1.0.0",
-        "selfsigned": "^1.10.8",
-        "semver": "^6.3.0",
-        "serve-index": "^1.9.1",
-        "sockjs": "^0.3.21",
-        "sockjs-client": "^1.5.0",
-        "spdy": "^4.0.2",
-        "strip-ansi": "^3.0.1",
-        "supports-color": "^6.1.0",
-        "url": "^0.11.0",
-        "webpack-dev-middleware": "^3.7.2",
-        "webpack-log": "^2.0.0",
-        "ws": "^6.2.1",
-        "yargs": "^13.3.2"
-      },
-      "bin": {
-        "webpack-dev-server": "bin/webpack-dev-server.js"
-      },
-      "engines": {
-        "node": ">= 6.11.5"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/anymatch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-      "license": "ISC",
-      "dependencies": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/anymatch/node_modules/normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "remove-trailing-separator": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-      "license": "MIT",
-      "dependencies": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/braces/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/chokidar": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
-      },
-      "optionalDependencies": {
-        "fsevents": "^1.2.7"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/cliui/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/cliui/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/webpack-dev-server/node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "license": "MIT"
-    },
-    "node_modules/webpack-dev-server/node_modules/fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/fill-range/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/fsevents": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-      "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
-      "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "http-proxy": "^1.17.0",
-        "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
-        "micromatch": "^3.1.10"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/import-local": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-      "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "pkg-dir": "^3.0.0",
-        "resolve-cwd": "^2.0.0"
-      },
-      "bin": {
-        "import-local-fixture": "fixtures/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/is-absolute-url": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
-      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/is-number": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/is-number/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
-    },
-    "node_modules/webpack-dev-server/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-      "license": "MIT",
-      "dependencies": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/pkg-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/readdirp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/resolve-cwd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-      "integrity": "sha512-ccu8zQTrzVr954472aUVPLEcB3YpKSYR3cg/3lo1okzobPBM+1INXBbBZlDbnI/hbEocnf8j0QVo43hQKrbchg==",
-      "license": "MIT",
-      "dependencies": {
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/schema-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/string-width/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/string-width/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/supports-color": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "license": "ISC"
-    },
-    "node_modules/webpack-dev-server/node_modules/yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
       }
     },
     "node_modules/webpack-log": {
@@ -33596,15 +33535,6 @@
         "uuid": "bin/uuid"
       }
     },
-    "node_modules/webpack-merge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
-      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.15"
-      }
-    },
     "node_modules/webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
@@ -33613,232 +33543,6 @@
       "dependencies": {
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/webpack/node_modules/acorn": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack/node_modules/braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-      "license": "MIT",
-      "dependencies": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/braces/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/eslint-scope": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/webpack/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/webpack/node_modules/fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/fill-range/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/is-number": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/is-number/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
-    },
-    "node_modules/webpack/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/webpack/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/webpack/node_modules/micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-      "license": "MIT",
-      "dependencies": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack/node_modules/schema-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/webpack/node_modules/to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/websocket-driver": {
@@ -34050,9 +33754,9 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -34060,7 +33764,10 @@
         "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrap-ansi-cjs": {
@@ -34099,15 +33806,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
-      "license": "MIT",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
       }
     },
     "node_modules/xlsx": {
@@ -34222,24 +33920,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/yargs/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -34291,8 +33971,6 @@
         "prom-client": "^15.1.3",
         "qs": "^6.15.1",
         "read-chunk": "^3.2.0",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "sequelize": "^6.37.8",
         "sequelize-cli": "^6.6.3"
       },
@@ -34426,8 +34104,6 @@
         "pg": "^8.20.0",
         "prom-client": "^15.1.3",
         "read-chunk": "^3.2.0",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "sequelize": "^6.37.8",
         "sequelize-cli": "^6.6.3"
       },

--- a/statutory/lib/core.js
+++ b/statutory/lib/core.js
@@ -11,9 +11,7 @@ const makeRequest = (options) => {
             'X-Auth-Token': options.token,
             'X-Service': 'statutory'
         },
-        simple: false,
-        json: true,
-        resolveWithFullResponse: options.resolveWithFullResponse || false
+        fullResponse: options.fullResponse || false
     };
 
     if (options.body) {
@@ -69,7 +67,7 @@ const getApprovePermissions = async (req, event) => {
         url: config.core.url + ':' + config.core.port + '/my_permissions',
         method: 'POST',
         token: req.headers['x-auth-token'],
-        resolveWithFullResponse: true,
+        fullResponse: true,
         body: {
             action: 'approve_members',
             object: event.type
@@ -86,7 +84,7 @@ const getMemberslistPermissions = async (req, event) => {
         url: config.core.url + ':' + config.core.port + '/my_permissions',
         method: 'POST',
         token: req.headers['x-auth-token'],
-        resolveWithFullResponse: true,
+        fullResponse: true,
         body: {
             action: 'manage_memberslist',
             object: event.type
@@ -110,7 +108,7 @@ const getMyProfile = async (req) => {
         url: config.core.url + ':' + config.core.port + '/members/me',
         method: 'GET',
         token: req.headers['x-auth-token'],
-        resolveWithFullResponse: true
+        fullResponse: true
     });
 
     return myProfileBody;
@@ -121,7 +119,7 @@ const getMyPermissions = async (req) => {
         url: config.core.url + ':' + config.core.port + '/my_permissions',
         method: 'GET',
         token: req.headers['x-auth-token'],
-        resolveWithFullResponse: true
+        fullResponse: true
     });
 
     return permissionsBody;

--- a/statutory/lib/core.js
+++ b/statutory/lib/core.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const { request } = require('./http');
 
 const config = require('../config');
 

--- a/statutory/lib/http.js
+++ b/statutory/lib/http.js
@@ -1,9 +1,5 @@
-const parseBody = async (response, parseJson) => {
+const parseBody = async (response) => {
     const text = await response.text();
-
-    if (!parseJson) {
-        return text;
-    }
 
     if (!text) {
         return null;
@@ -38,7 +34,6 @@ const appendQuery = (url, query) => {
 };
 
 module.exports.request = async (options) => {
-    const parseJson = options.json !== false;
     const headers = { ...(options.headers || {}) };
     const fetchOptions = {
         method: options.method || 'GET',
@@ -47,13 +42,13 @@ module.exports.request = async (options) => {
 
     if (options.body !== undefined) {
         headers['Content-Type'] = headers['Content-Type'] || 'application/json';
-        fetchOptions.body = parseJson ? JSON.stringify(options.body) : options.body;
+        fetchOptions.body = JSON.stringify(options.body);
     }
 
     const response = await fetch(appendQuery(options.url, options.qs), fetchOptions);
-    const body = await parseBody(response, parseJson);
+    const body = await parseBody(response);
 
-    if (options.resolveWithFullResponse) {
+    if (options.fullResponse) {
         return {
             statusCode: response.status,
             statusMessage: response.statusText,

--- a/statutory/lib/http.js
+++ b/statutory/lib/http.js
@@ -1,0 +1,66 @@
+const parseBody = async (response, parseJson) => {
+    const text = await response.text();
+
+    if (!parseJson) {
+        return text;
+    }
+
+    if (!text) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch (err) { // eslint-disable-line no-unused-vars
+        return text;
+    }
+};
+
+const appendQuery = (url, query) => {
+    if (!query) {
+        return url;
+    }
+
+    const requestUrl = new URL(url);
+    for (const [key, value] of Object.entries(query)) {
+        if (Array.isArray(value)) {
+            value.forEach((item) => requestUrl.searchParams.append(key, item));
+        } else if (typeof value === 'object' && value !== null) {
+            for (const [nestedKey, nestedValue] of Object.entries(value)) {
+                requestUrl.searchParams.append(`${key}[${nestedKey}]`, nestedValue);
+            }
+        } else {
+            requestUrl.searchParams.append(key, value);
+        }
+    }
+
+    return requestUrl.toString();
+};
+
+module.exports.request = async (options) => {
+    const parseJson = options.json !== false;
+    const headers = { ...(options.headers || {}) };
+    const fetchOptions = {
+        method: options.method || 'GET',
+        headers
+    };
+
+    if (options.body !== undefined) {
+        headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+        fetchOptions.body = parseJson ? JSON.stringify(options.body) : options.body;
+    }
+
+    const response = await fetch(appendQuery(options.url, options.qs), fetchOptions);
+    const body = await parseBody(response, parseJson);
+
+    if (options.resolveWithFullResponse) {
+        return {
+            statusCode: response.status,
+            statusMessage: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body
+        };
+    }
+
+    return body;
+};

--- a/statutory/lib/mailer.js
+++ b/statutory/lib/mailer.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const { request } = require('./http');
 
 const config = require('../config');
 

--- a/statutory/lib/mailer.js
+++ b/statutory/lib/mailer.js
@@ -6,8 +6,6 @@ module.exports.sendMail = async (options) => {
     const mailerBody = await request({
         url: config.mailer.url + ':' + config.mailer.port + '/',
         method: 'POST',
-        simple: false,
-        json: true,
         body: {
             from: options.from,
             to: options.to,

--- a/statutory/models/MembersList.js
+++ b/statutory/models/MembersList.js
@@ -1,7 +1,7 @@
-const request = require('request-promise-native');
 const Joi = require('joi');
 
 const { Sequelize, sequelize } = require('../lib/sequelize');
+const { request } = require('../lib/http');
 const helpers = require('../lib/helpers');
 const constants = require('../lib/constants');
 

--- a/statutory/models/MembersList.js
+++ b/statutory/models/MembersList.js
@@ -114,9 +114,7 @@ MembersList.beforeSave(async (memberslist, options) => {
 
     const conversion = await request({
         url: constants.CONVERSION_RATE_API.host + constants.CONVERSION_RATE_API.path,
-        method: 'GET',
-        simple: false,
-        json: true
+        method: 'GET'
     });
 
     if (typeof conversion !== 'object') {

--- a/statutory/package-lock.json
+++ b/statutory/package-lock.json
@@ -31,8 +31,6 @@
         "prom-client": "^15.1.3",
         "qs": "^6.15.1",
         "read-chunk": "^3.2.0",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "sequelize": "^6.37.8",
         "sequelize-cli": "^6.6.3"
       },
@@ -2037,6 +2035,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2270,24 +2269,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2297,12 +2278,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2328,21 +2303,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "license": "MIT"
     },
     "node_modules/babel-jest": {
       "version": "30.3.0",
@@ -2499,15 +2459,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "node_modules/bintrees": {
       "version": "1.0.2",
@@ -2766,12 +2717,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3009,18 +2954,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -3113,12 +3046,6 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "license": "MIT"
-    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -3173,18 +3100,6 @@
       },
       "engines": {
         "node": ">=0.12"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/data-view-buffer": {
@@ -3326,15 +3241,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3417,16 +3323,6 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/editorconfig": {
       "version": "1.0.7",
@@ -4398,31 +4294,18 @@
         "type": "^2.7.2"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -4623,29 +4506,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/forwarded": {
@@ -4863,15 +4723,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -4987,29 +4838,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -5128,21 +4956,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/human-signals": {
@@ -5709,12 +5522,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -5779,12 +5586,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6561,12 +6362,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6594,16 +6389,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -6617,6 +6407,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -6642,21 +6433,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/keyv": {
@@ -7564,15 +7340,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7956,12 +7723,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT"
-    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
@@ -8296,18 +8057,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -8322,6 +8071,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8512,90 +8262,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "license": "ISC",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "license": "ISC",
-      "dependencies": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
-      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-directory": {
@@ -9466,31 +9132,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stack-generator": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
@@ -9536,15 +9177,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -9967,19 +9599,6 @@
       "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==",
       "license": "MIT"
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -10023,24 +9642,6 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense"
     },
     "node_modules/type": {
       "version": "2.7.3",
@@ -10332,6 +9933,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -10393,20 +9995,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/walker": {

--- a/statutory/package.json
+++ b/statutory/package.json
@@ -61,8 +61,6 @@
     "prom-client": "^15.1.3",
     "qs": "^6.15.1",
     "read-chunk": "^3.2.0",
-    "request": "^2.88.2",
-    "request-promise-native": "^1.0.9",
     "sequelize": "^6.37.8",
     "sequelize-cli": "^6.6.3"
   },

--- a/statutory/test/api/api-requests.test.js
+++ b/statutory/test/api/api-requests.test.js
@@ -18,7 +18,7 @@ describe('API requests', () => {
         mock.mockAll({ core: { netError: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -33,7 +33,7 @@ describe('API requests', () => {
         mock.mockAll({ core: { badResponse: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -48,7 +48,7 @@ describe('API requests', () => {
         mock.mockAll({ mainPermissions: { netError: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -63,7 +63,7 @@ describe('API requests', () => {
         mock.mockAll({ mainPermissions: { badResponse: true } });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -80,7 +80,7 @@ describe('API requests', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications',
+            path: '/events/' + event.id + '/applications',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -97,7 +97,7 @@ describe('API requests', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications',
+            path: '/events/' + event.id + '/applications',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -114,7 +114,7 @@ describe('API requests', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications',
+            path: '/events/' + event.id + '/applications',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -131,7 +131,7 @@ describe('API requests', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications',
+            path: '/events/' + event.id + '/applications',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -148,7 +148,7 @@ describe('API requests', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications',
+            path: '/events/' + event.id + '/applications',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -165,7 +165,7 @@ describe('API requests', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications',
+            path: '/events/' + event.id + '/applications',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -181,7 +181,7 @@ describe('API requests', () => {
         const event = await generator.createEvent({});
 
         const res = await request({
-            uri: '/events/' + event.id,
+            path: '/events/' + event.id,
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -198,7 +198,7 @@ describe('API requests', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications',
+            path: '/events/' + event.id + '/applications',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -215,7 +215,7 @@ describe('API requests', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications',
+            path: '/events/' + event.id + '/applications',
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -231,7 +231,7 @@ describe('API requests', () => {
         const event = await generator.createEvent({});
 
         const res = await request({
-            uri: '/events/' + event.id,
+            path: '/events/' + event.id,
             method: 'GET',
             headers: {
                 'X-Auth-Token': 'blablabla'
@@ -244,7 +244,7 @@ describe('API requests', () => {
 
     test('should fail if body is not JSON', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: {
                 'X-Auth-Token': 'blablabla',
@@ -259,7 +259,7 @@ describe('API requests', () => {
 
     test('should fail on accessing non-existant endpoint', async () => {
         const res = await request({
-            uri: '/nonexistant',
+            path: '/nonexistant',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 

--- a/statutory/test/api/applications-attendance.test.js
+++ b/statutory/test/api/applications-attendance.test.js
@@ -29,7 +29,7 @@ describe('Applications attendance', () => {
         await generator.createApplication({ user_id: regularUser.id }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/me/attended',
+            path: '/events/' + event.id + '/applications/me/attended',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { attended: true }
@@ -46,7 +46,7 @@ describe('Applications attendance', () => {
         const application = await generator.createApplication({ confirmed: true }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/attended',
+            path: '/events/' + event.id + '/applications/' + application.id + '/attended',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { attended: true }
@@ -65,7 +65,7 @@ describe('Applications attendance', () => {
         const application = await generator.createApplication({ confirmed: false }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/attended',
+            path: '/events/' + event.id + '/applications/' + application.id + '/attended',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { attended: true }
@@ -85,7 +85,7 @@ describe('Applications attendance', () => {
         const application = await generator.createApplication({ confirmed: true }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/attended',
+            path: '/events/' + event.id + '/applications/' + application.id + '/attended',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { attended: true }
@@ -101,7 +101,7 @@ describe('Applications attendance', () => {
         const event = await generator.createEvent({ applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/333/attended',
+            path: '/events/' + event.id + '/applications/333/attended',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { attended: true }
@@ -118,7 +118,7 @@ describe('Applications attendance', () => {
         const application = await generator.createApplication({ confirmed: true }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/attended',
+            path: '/events/' + event.id + '/applications/' + application.id + '/attended',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { attended: 'lalala' }

--- a/statutory/test/api/applications-board-multiple.test.js
+++ b/statutory/test/api/applications-board-multiple.test.js
@@ -50,7 +50,7 @@ describe('Applications pax type/board comment for a body', () => {
         ];
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body
@@ -89,7 +89,7 @@ describe('Applications pax type/board comment for a body', () => {
         ];
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body
@@ -118,7 +118,7 @@ describe('Applications pax type/board comment for a body', () => {
         ];
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body
@@ -140,7 +140,7 @@ describe('Applications pax type/board comment for a body', () => {
         ];
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body
@@ -160,7 +160,7 @@ describe('Applications pax type/board comment for a body', () => {
         ];
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/lalala',
+            path: '/events/' + event.id + '/applications/boardview/lalala',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body
@@ -174,7 +174,7 @@ describe('Applications pax type/board comment for a body', () => {
 
     test('should return 400 if body is not an array', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {}
@@ -188,7 +188,7 @@ describe('Applications pax type/board comment for a body', () => {
 
     test('should return 400 if any of the entries is not an array', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: [false]
@@ -202,7 +202,7 @@ describe('Applications pax type/board comment for a body', () => {
 
     test('should return 400 if any of the entries does not have participant orger', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: [{ participant_type: 'delegate', user_id: 1, board_comment: 'test' }]
@@ -216,7 +216,7 @@ describe('Applications pax type/board comment for a body', () => {
 
     test('should return 400 if any of the entries does not have participant type', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: [{ participant_order: 1, user_id: 1, board_comment: 'test' }]
@@ -230,7 +230,7 @@ describe('Applications pax type/board comment for a body', () => {
 
     test('should return 400 if any of the entries does not have user ID', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: [{ participant_type: 'delegate', participant_order: 1, board_comment: 'test' }]
@@ -244,7 +244,7 @@ describe('Applications pax type/board comment for a body', () => {
 
     test('should return 400 if any of the entries has user ID as not string', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: [{ participant_type: 'delegate', participant_order: 1, board_comment: 'test', user_id: false }]
@@ -260,7 +260,7 @@ describe('Applications pax type/board comment for a body', () => {
         await generator.createApplication({ user_id: 10, body_id: regularUser.bodies[0].id, participant_type: null, participant_order: null }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: [{ participant_type: 'invalid', participant_order: 1, user_id: 10 }]
@@ -286,7 +286,7 @@ describe('Applications pax type/board comment for a body', () => {
         ];
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body
@@ -312,7 +312,7 @@ describe('Applications pax type/board comment for a body', () => {
         ];
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body
@@ -338,7 +338,7 @@ describe('Applications pax type/board comment for a body', () => {
         ];
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body

--- a/statutory/test/api/applications-board.test.js
+++ b/statutory/test/api/applications-board.test.js
@@ -46,7 +46,7 @@ describe('Applications pax type/board comment', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/me/board',
+            path: '/events/' + event.id + '/applications/me/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'delegate' }
@@ -62,7 +62,7 @@ describe('Applications pax type/board comment', () => {
         application = await application.update({ user_id: 1337 }, { returning: ['*'] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'delegate', board_comment: 'test', participant_order: 1 }
@@ -82,7 +82,7 @@ describe('Applications pax type/board comment', () => {
         application = await application.update({ user_id: 1337 }, { returning: ['*'] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.statutory_id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.statutory_id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'delegate', board_comment: 'test', participant_order: 1 }
@@ -104,7 +104,7 @@ describe('Applications pax type/board comment', () => {
         application = await application.update({ user_id: 1337 }, { returning: ['*'] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'delegate', participant_order: 1 }
@@ -122,7 +122,7 @@ describe('Applications pax type/board comment', () => {
         application = await application.update({ user_id: 1337 }, { returning: ['*'] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'delegate', board_comment: 'test', participant_order: 1 }
@@ -140,7 +140,7 @@ describe('Applications pax type/board comment', () => {
         application = await application.update({ user_id: 1337 }, { returning: ['*'] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'delegate', participant_order: 1 }
@@ -153,7 +153,7 @@ describe('Applications pax type/board comment', () => {
 
     test('should return 404 if the application is not found', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/1337/board',
+            path: '/events/' + event.id + '/applications/1337/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'delegate', participant_order: 1 }
@@ -167,7 +167,7 @@ describe('Applications pax type/board comment', () => {
 
     test('should return 422 if info is invalid', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'invalid', participant_order: 1 }
@@ -181,7 +181,7 @@ describe('Applications pax type/board comment', () => {
 
     test('should return 422 if participant type is set, but participant order is not', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_order: 1 }
@@ -195,7 +195,7 @@ describe('Applications pax type/board comment', () => {
 
     test('should return 422 if participant order is not a number', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'delegate', participant_order: 'invalid' }
@@ -209,7 +209,7 @@ describe('Applications pax type/board comment', () => {
 
     test('should return 422 if participant order is negative', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'delegate', participant_order: -1 }
@@ -223,7 +223,7 @@ describe('Applications pax type/board comment', () => {
 
     test('should return 422 if participant order is set, but participant type is not', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'delegate' }
@@ -250,7 +250,7 @@ describe('Applications pax type/board comment', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + otherApplication.id + '/board',
+            path: '/events/' + event.id + '/applications/' + otherApplication.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'delegate', participant_order: 1 }
@@ -269,7 +269,7 @@ describe('Applications pax type/board comment', () => {
         }, { returning: ['*'] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {}
@@ -297,7 +297,7 @@ describe('Applications pax type/board comment', () => {
         }, { returning: ['*'] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'delegate', participant_order: 1 }
@@ -318,7 +318,7 @@ describe('Applications pax type/board comment', () => {
         }, { returning: ['*'] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: null, participant_order: null }
@@ -340,7 +340,7 @@ describe('Applications pax type/board comment', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'delegate', participant_order: 1 }
@@ -355,7 +355,7 @@ describe('Applications pax type/board comment', () => {
     test('should return 403 when using default limits and too much applications', async () => {
         // The body type is antenna, it cannot send observers.
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'observer', participant_order: 1 }
@@ -376,7 +376,7 @@ describe('Applications pax type/board comment', () => {
 
         // The body type is antenna, it cannot send observers.
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'delegate', participant_order: 1 }
@@ -390,7 +390,7 @@ describe('Applications pax type/board comment', () => {
 
     test('should return 403 when the pax order is too big', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: 'delegate', participant_order: 1337 }
@@ -411,7 +411,7 @@ describe('Applications pax type/board comment', () => {
         }, { returning: ['*'] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: null, participant_order: null }
@@ -432,7 +432,7 @@ describe('Applications pax type/board comment', () => {
         }, { returning: ['*'] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: null, participant_order: null }
@@ -453,7 +453,7 @@ describe('Applications pax type/board comment', () => {
         }, { returning: ['*'] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/board',
+            path: '/events/' + event.id + '/applications/' + application.id + '/board',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { participant_type: null, participant_order: null }

--- a/statutory/test/api/applications-boardview.test.js
+++ b/statutory/test/api/applications-boardview.test.js
@@ -29,7 +29,7 @@ describe('Applications boardview list', () => {
         const application = await generator.createApplication({ body_id: regularUser.bodies[0].id }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -48,7 +48,7 @@ describe('Applications boardview list', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -66,7 +66,7 @@ describe('Applications boardview list', () => {
         const application = await generator.createApplication({ body_id: regularUser.bodies[0].id }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -85,7 +85,7 @@ describe('Applications boardview list', () => {
         const application = await generator.createApplication({ body_id: 1337 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/1337',
+            path: '/events/' + event.id + '/applications/boardview/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -102,7 +102,7 @@ describe('Applications boardview list', () => {
     test('should result in an error if :id is malformed', async () => {
         const event = await generator.createEvent();
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/invalid',
+            path: '/events/' + event.id + '/applications/boardview/invalid',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -163,7 +163,7 @@ describe('Applications boardview list', () => {
         ];
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/applications/boardview/' + regularUser.bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/applications-cancellation.test.js
+++ b/statutory/test/api/applications-cancellation.test.js
@@ -34,7 +34,7 @@ describe('Applications cancellation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/me/cancel',
+            path: '/events/' + event.id + '/applications/me/cancel',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { cancelled: true }
@@ -57,7 +57,7 @@ describe('Applications cancellation', () => {
         tk.travel(moment(event.application_period_starts).subtract(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/me/cancel',
+            path: '/events/' + event.id + '/applications/me/cancel',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { cancelled: true }
@@ -74,7 +74,7 @@ describe('Applications cancellation', () => {
         const application = await generator.createApplication({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/cancel',
+            path: '/events/' + event.id + '/applications/' + application.id + '/cancel',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { cancelled: true }
@@ -95,7 +95,7 @@ describe('Applications cancellation', () => {
         const application = await generator.createApplication({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/cancel',
+            path: '/events/' + event.id + '/applications/' + application.id + '/cancel',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { cancelled: true }
@@ -115,7 +115,7 @@ describe('Applications cancellation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/me/cancel',
+            path: '/events/' + event.id + '/applications/me/cancel',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { cancelled: true }
@@ -131,7 +131,7 @@ describe('Applications cancellation', () => {
         const event = await generator.createEvent({ applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/333/cancel',
+            path: '/events/' + event.id + '/applications/333/cancel',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { cancelled: true }
@@ -148,7 +148,7 @@ describe('Applications cancellation', () => {
         const application = await generator.createApplication({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/cancel',
+            path: '/events/' + event.id + '/applications/' + application.id + '/cancel',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { cancelled: 'lalala' }

--- a/statutory/test/api/applications-confirmed.test.js
+++ b/statutory/test/api/applications-confirmed.test.js
@@ -29,7 +29,7 @@ describe('Applications confirmation', () => {
         await generator.createApplication({ user_id: regularUser.id }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/me/confirmed',
+            path: '/events/' + event.id + '/applications/me/confirmed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { confirmed: true }
@@ -46,7 +46,7 @@ describe('Applications confirmation', () => {
         const application = await generator.createApplication({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/confirmed',
+            path: '/events/' + event.id + '/applications/' + application.id + '/confirmed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { confirmed: true }
@@ -65,7 +65,7 @@ describe('Applications confirmation', () => {
         const application = await generator.createApplication({ cancelled: true }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/confirmed',
+            path: '/events/' + event.id + '/applications/' + application.id + '/confirmed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { confirmed: true }
@@ -85,7 +85,7 @@ describe('Applications confirmation', () => {
         const application = await generator.createApplication({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/confirmed',
+            path: '/events/' + event.id + '/applications/' + application.id + '/confirmed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { confirmed: true }
@@ -101,7 +101,7 @@ describe('Applications confirmation', () => {
         const event = await generator.createEvent({ applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/333/confirmed',
+            path: '/events/' + event.id + '/applications/333/confirmed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { confirmed: true }
@@ -118,7 +118,7 @@ describe('Applications confirmation', () => {
         const application = await generator.createApplication({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/confirmed',
+            path: '/events/' + event.id + '/applications/' + application.id + '/confirmed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { confirmed: 'lalala' }
@@ -135,7 +135,7 @@ describe('Applications confirmation', () => {
         const application = await generator.createApplication({ confirmed: true, incoming: true, attended: true }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/confirmed',
+            path: '/events/' + event.id + '/applications/' + application.id + '/confirmed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { confirmed: false }

--- a/statutory/test/api/applications-creation.test.js
+++ b/statutory/test/api/applications-creation.test.js
@@ -33,7 +33,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateApplication({
@@ -61,7 +61,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_ends).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -87,7 +87,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).subtract(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -117,7 +117,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -144,7 +144,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -172,7 +172,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -200,7 +200,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -228,7 +228,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -262,7 +262,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -292,7 +292,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateApplication({
@@ -323,7 +323,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -353,7 +353,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -383,7 +383,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -413,7 +413,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -443,7 +443,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -473,7 +473,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -502,7 +502,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -531,7 +531,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -560,7 +560,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -590,7 +590,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -646,7 +646,7 @@ describe('Applications creation', () => {
             tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/',
+                path: '/events/' + event.id + '/applications/',
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: application
@@ -677,7 +677,7 @@ describe('Applications creation', () => {
             tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/',
+                path: '/events/' + event.id + '/applications/',
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: application
@@ -709,7 +709,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -740,7 +740,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -771,7 +771,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -803,7 +803,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -847,7 +847,7 @@ describe('Applications creation', () => {
             tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/',
+                path: '/events/' + event.id + '/applications/',
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: application
@@ -878,7 +878,7 @@ describe('Applications creation', () => {
             tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/',
+                path: '/events/' + event.id + '/applications/',
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: application
@@ -909,7 +909,7 @@ describe('Applications creation', () => {
             tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/',
+                path: '/events/' + event.id + '/applications/',
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: application
@@ -940,7 +940,7 @@ describe('Applications creation', () => {
             tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/',
+                path: '/events/' + event.id + '/applications/',
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: application
@@ -971,7 +971,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -1003,7 +1003,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -1035,7 +1035,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -1067,7 +1067,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -1099,7 +1099,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -1131,7 +1131,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -1163,7 +1163,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -1195,7 +1195,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -1227,7 +1227,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -1262,7 +1262,7 @@ describe('Applications creation', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -1295,7 +1295,7 @@ describe('Applications creation', () => {
             tk.travel(moment(event.application_period_starts).subtract(5, 'minutes').toDate());
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/',
+                path: '/events/' + event.id + '/applications/',
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: application
@@ -1327,7 +1327,7 @@ describe('Applications creation', () => {
             tk.travel(moment(event.application_period_starts).subtract(5, 'minutes').toDate());
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/',
+                path: '/events/' + event.id + '/applications/',
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: application
@@ -1353,7 +1353,7 @@ describe('Applications creation', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -1384,7 +1384,7 @@ describe('Applications creation', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/',
+            path: '/events/' + event.id + '/applications/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application

--- a/statutory/test/api/applications-departion.test.js
+++ b/statutory/test/api/applications-departion.test.js
@@ -29,7 +29,7 @@ describe('Applications departion', () => {
         await generator.createApplication({ user_id: regularUser.id }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/me/departed',
+            path: '/events/' + event.id + '/applications/me/departed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { departed: true }
@@ -46,7 +46,7 @@ describe('Applications departion', () => {
         const application = await generator.createApplication({ confirmed: true, registered: true }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/departed',
+            path: '/events/' + event.id + '/applications/' + application.id + '/departed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { departed: true }
@@ -65,7 +65,7 @@ describe('Applications departion', () => {
         const application = await generator.createApplication({ confirmed: true, registered: false }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/departed',
+            path: '/events/' + event.id + '/applications/' + application.id + '/departed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { departed: true }
@@ -85,7 +85,7 @@ describe('Applications departion', () => {
         const application = await generator.createApplication({ confirmed: true, incoming: true, attended: true }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/departed',
+            path: '/events/' + event.id + '/applications/' + application.id + '/departed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { departed: true }
@@ -101,7 +101,7 @@ describe('Applications departion', () => {
         const event = await generator.createEvent({ applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/333/departed',
+            path: '/events/' + event.id + '/applications/333/departed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { departed: true }
@@ -118,7 +118,7 @@ describe('Applications departion', () => {
         const application = await generator.createApplication({ confirmed: true, incoming: true, attended: true }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/departed',
+            path: '/events/' + event.id + '/applications/' + application.id + '/departed',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { departed: 'lalala' }

--- a/statutory/test/api/applications-display.test.js
+++ b/statutory/test/api/applications-display.test.js
@@ -28,7 +28,7 @@ describe('Applications displaying', () => {
         await generator.createApplication({ user_id: regularUser.id }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/me',
+            path: '/events/' + event.id + '/applications/me',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -50,7 +50,7 @@ describe('Applications displaying', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -86,7 +86,7 @@ describe('Applications displaying', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -102,7 +102,7 @@ describe('Applications displaying', () => {
         const application = await generator.createApplication({ user_id: userId }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -120,7 +120,7 @@ describe('Applications displaying', () => {
         const application = await generator.createApplication({ user_id: userId }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.statutory_id,
+            path: '/events/' + event.id + '/applications/' + application.statutory_id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -139,7 +139,7 @@ describe('Applications displaying', () => {
         const application = await generator.createApplication({ user_id: 1337 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -154,7 +154,7 @@ describe('Applications displaying', () => {
         const event = await generator.createEvent({ applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/333',
+            path: '/events/' + event.id + '/applications/333',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/applications-editing.test.js
+++ b/statutory/test/api/applications-editing.test.js
@@ -35,7 +35,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/me',
+            path: '/events/' + event.id + '/applications/me',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { body_id: regularUser.bodies[0].id }
@@ -60,7 +60,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).subtract(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { body_id: regularUser.bodies[0].id }
@@ -80,7 +80,7 @@ describe('Applications editing', () => {
 
         // First, change status to accepted with full permissions (from beforeEach mock).
         await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/status',
+            path: '/events/' + event.id + '/applications/' + application.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { status: 'accepted' }
@@ -92,7 +92,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { body_id: regularUser.bodies[0].id }
@@ -111,7 +111,7 @@ describe('Applications editing', () => {
         const application = await generator.createApplication({}, event);
 
         await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/status',
+            path: '/events/' + event.id + '/applications/' + application.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { status: 'accepted' }
@@ -122,7 +122,7 @@ describe('Applications editing', () => {
         mock.mockAll({ mainPermissions: { applyPermissions: true } });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { body_id: regularUser.bodies[0].id }
@@ -143,7 +143,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).subtract(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { body_id: regularUser.bodies[0].id }
@@ -166,7 +166,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { visa_required: 'nope' }
@@ -187,7 +187,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { answers: [] }
@@ -209,7 +209,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { answers: ['Another test answer'] }
@@ -231,7 +231,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/me',
+            path: '/events/' + event.id + '/applications/me',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { body_id: regularUser.bodies[0].id }
@@ -251,7 +251,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/333',
+            path: '/events/' + event.id + '/applications/333',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { body_id: 555 }
@@ -283,7 +283,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: application
@@ -318,7 +318,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { body_id: 1337 }
@@ -355,7 +355,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { body_id: regularUser.bodies[1].id }
@@ -399,7 +399,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { body_id: regularUser.bodies[1].id }
@@ -439,7 +439,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { body_id: regularUser.bodies[1].id }
@@ -465,7 +465,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).subtract(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { body_id: regularUser.bodies[0].id }
@@ -488,7 +488,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).subtract(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { body_id: regularUser.bodies[0].id }
@@ -511,7 +511,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).subtract(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { body_id: regularUser.bodies[0].id }
@@ -534,7 +534,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).subtract(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { visa_required: false }
@@ -560,7 +560,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).subtract(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { visa_required: false }
@@ -586,7 +586,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).subtract(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { visa_required: false }
@@ -612,7 +612,7 @@ describe('Applications editing', () => {
         tk.travel(moment(event.application_period_starts).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { answers: ['Another test answer'] }

--- a/statutory/test/api/applications-is-on-memberslist.test.js
+++ b/statutory/test/api/applications-is-on-memberslist.test.js
@@ -29,7 +29,7 @@ describe('Applications is_on_memberslist', () => {
         await generator.createApplication({ user_id: regularUser.id }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/me/is_on_memberslist',
+            path: '/events/' + event.id + '/applications/me/is_on_memberslist',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { is_on_memberslist: true }
@@ -46,7 +46,7 @@ describe('Applications is_on_memberslist', () => {
         const application = await generator.createApplication({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/is_on_memberslist',
+            path: '/events/' + event.id + '/applications/' + application.id + '/is_on_memberslist',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { is_on_memberslist: true }
@@ -67,7 +67,7 @@ describe('Applications is_on_memberslist', () => {
         const application = await generator.createApplication({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/is_on_memberslist',
+            path: '/events/' + event.id + '/applications/' + application.id + '/is_on_memberslist',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { is_on_memberslist: true }
@@ -83,7 +83,7 @@ describe('Applications is_on_memberslist', () => {
         const event = await generator.createEvent({ applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/333/is_on_memberslist',
+            path: '/events/' + event.id + '/applications/333/is_on_memberslist',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { is_on_memberslist: true }
@@ -100,7 +100,7 @@ describe('Applications is_on_memberslist', () => {
         const application = await generator.createApplication({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/is_on_memberslist',
+            path: '/events/' + event.id + '/applications/' + application.id + '/is_on_memberslist',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { is_on_memberslist: 'lalala' }

--- a/statutory/test/api/applications-listing.test.js
+++ b/statutory/test/api/applications-listing.test.js
@@ -30,7 +30,7 @@ describe('Applications listing', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/all',
+            path: '/events/' + event.id + '/applications/all',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -53,7 +53,7 @@ describe('Applications listing', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/all',
+            path: '/events/' + event.id + '/applications/all',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -70,7 +70,7 @@ describe('Applications listing', () => {
         await generator.createApplication({ status: 'pending' }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/accepted',
+            path: '/events/' + event.id + '/applications/accepted',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -89,7 +89,7 @@ describe('Applications listing', () => {
         tk.travel(moment(event.participants_list_publish_deadline).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/accepted',
+            path: '/events/' + event.id + '/applications/accepted',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -118,7 +118,7 @@ describe('Applications listing', () => {
         tk.travel(moment(event.participants_list_publish_deadline).add(5, 'minutes').toDate());
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/accepted',
+            path: '/events/' + event.id + '/applications/accepted',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -137,7 +137,7 @@ describe('Applications listing', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/juridical',
+            path: '/events/' + event.id + '/applications/juridical',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -155,7 +155,7 @@ describe('Applications listing', () => {
         await generator.createApplication({ user_id: 2 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/juridical',
+            path: '/events/' + event.id + '/applications/juridical',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -179,7 +179,7 @@ describe('Applications listing', () => {
         await generator.createApplication({ status: 'accepted', confirmed: false, cancelled: false, user_id: 2 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/juridical',
+            path: '/events/' + event.id + '/applications/juridical',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -196,7 +196,7 @@ describe('Applications listing', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/incoming',
+            path: '/events/' + event.id + '/applications/incoming',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -214,7 +214,7 @@ describe('Applications listing', () => {
         await generator.createApplication({ user_id: 2 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/incoming',
+            path: '/events/' + event.id + '/applications/incoming',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -240,7 +240,7 @@ describe('Applications listing', () => {
         await generator.createApplication({ status: 'accepted', cancelled: true, user_id: 2 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/incoming',
+            path: '/events/' + event.id + '/applications/incoming',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -257,7 +257,7 @@ describe('Applications listing', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/network',
+            path: '/events/' + event.id + '/applications/network',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -275,7 +275,7 @@ describe('Applications listing', () => {
         await generator.createApplication({ user_id: 2 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/network',
+            path: '/events/' + event.id + '/applications/network',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -297,7 +297,7 @@ describe('Applications listing', () => {
         await generator.createApplication({ status: 'accepted', cancelled: true, user_id: 2 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/network',
+            path: '/events/' + event.id + '/applications/network',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -315,7 +315,7 @@ describe('Applications listing', () => {
             const application = await generator.createApplication({}, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/all',
+                path: '/events/' + event.id + '/applications/all',
                 method: 'GET',
                 headers: { 'X-Auth-Token': 'blablabla' }
             });
@@ -341,7 +341,7 @@ describe('Applications listing', () => {
             }, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/all',
+                path: '/events/' + event.id + '/applications/all',
                 method: 'GET',
                 headers: { 'X-Auth-Token': 'blablabla' }
             });
@@ -367,7 +367,7 @@ describe('Applications listing', () => {
             }, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/all',
+                path: '/events/' + event.id + '/applications/all',
                 method: 'GET',
                 headers: { 'X-Auth-Token': 'blablabla' }
             });
@@ -393,7 +393,7 @@ describe('Applications listing', () => {
             }, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/all',
+                path: '/events/' + event.id + '/applications/all',
                 method: 'GET',
                 headers: { 'X-Auth-Token': 'blablabla' }
             });
@@ -419,7 +419,7 @@ describe('Applications listing', () => {
             }, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/all',
+                path: '/events/' + event.id + '/applications/all',
                 method: 'GET',
                 headers: { 'X-Auth-Token': 'blablabla' }
             });
@@ -442,7 +442,7 @@ describe('Applications listing', () => {
             await generator.createApplication({ user_id: 2, first_name: 'first', last_name: 'last' }, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/all?limit=1',
+                path: '/events/' + event.id + '/applications/all?limit=1',
                 method: 'GET',
                 headers: { 'X-Auth-Token': 'blablabla' }
             });
@@ -460,7 +460,7 @@ describe('Applications listing', () => {
             await generator.createApplication({ user_id: 1, first_name: 'first', last_name: 'last' }, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/all?offset=500',
+                path: '/events/' + event.id + '/applications/all?offset=500',
                 method: 'GET',
                 headers: { 'X-Auth-Token': 'blablabla' }
             });
@@ -481,7 +481,7 @@ describe('Applications listing', () => {
             await generator.createApplication({ user_id: 2, first_name: 'first1' }, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/all?sort[field]=first_name', // ORDER BY first_name DESC
+                path: '/events/' + event.id + '/applications/all?sort[field]=first_name', // ORDER BY first_name DESC
                 method: 'GET',
                 headers: { 'X-Auth-Token': 'blablabla' }
             });
@@ -501,7 +501,7 @@ describe('Applications listing', () => {
             const second = await generator.createApplication({ user_id: 2, first_name: 'first1' }, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/all?sort[order]=asc', // ORDER BY id ASC
+                path: '/events/' + event.id + '/applications/all?sort[order]=asc', // ORDER BY id ASC
                 method: 'GET',
                 headers: { 'X-Auth-Token': 'blablabla' }
             });
@@ -522,7 +522,7 @@ describe('Applications listing', () => {
             await generator.createApplication({ user_id: 1, first_name: 'name name' }, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/all?query=name',
+                path: '/events/' + event.id + '/applications/all?query=name',
                 method: 'GET',
                 headers: { 'X-Auth-Token': 'blablabla' }
             });
@@ -540,7 +540,7 @@ describe('Applications listing', () => {
             await generator.createApplication({ user_id: 1, last_name: 'surname surname' }, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/all?query=surname',
+                path: '/events/' + event.id + '/applications/all?query=surname',
                 method: 'GET',
                 headers: { 'X-Auth-Token': 'blablabla' }
             });
@@ -558,7 +558,7 @@ describe('Applications listing', () => {
             await generator.createApplication({ user_id: 1, email: 'testtest@aegee.eu' }, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/all?query=testtest',
+                path: '/events/' + event.id + '/applications/all?query=testtest',
                 method: 'GET',
                 headers: { 'X-Auth-Token': 'blablabla' }
             });
@@ -576,7 +576,7 @@ describe('Applications listing', () => {
             await generator.createApplication({ cancelled: true }, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/all?displayCancelled=true',
+                path: '/events/' + event.id + '/applications/all?displayCancelled=true',
                 method: 'GET',
                 headers: { 'X-Auth-Token': 'blablabla' }
             });

--- a/statutory/test/api/applications-registration.test.js
+++ b/statutory/test/api/applications-registration.test.js
@@ -29,7 +29,7 @@ describe('Applications registration', () => {
         await generator.createApplication({ user_id: regularUser.id }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/me/registered',
+            path: '/events/' + event.id + '/applications/me/registered',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { registered: true }
@@ -46,7 +46,7 @@ describe('Applications registration', () => {
         const application = await generator.createApplication({ confirmed: true }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/registered',
+            path: '/events/' + event.id + '/applications/' + application.id + '/registered',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { registered: true }
@@ -65,7 +65,7 @@ describe('Applications registration', () => {
         const application = await generator.createApplication({ confirmed: true, registered: true, departed: true }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/registered',
+            path: '/events/' + event.id + '/applications/' + application.id + '/registered',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { registered: false }
@@ -85,7 +85,7 @@ describe('Applications registration', () => {
         const application = await generator.createApplication({ confirmed: true, incoming: true, attended: true }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/registered',
+            path: '/events/' + event.id + '/applications/' + application.id + '/registered',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { registered: true }
@@ -101,7 +101,7 @@ describe('Applications registration', () => {
         const event = await generator.createEvent({ applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/333/registered',
+            path: '/events/' + event.id + '/applications/333/registered',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { registered: true }
@@ -118,7 +118,7 @@ describe('Applications registration', () => {
         const application = await generator.createApplication({ confirmed: true, incoming: true, attended: true }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/registered',
+            path: '/events/' + event.id + '/applications/' + application.id + '/registered',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { registered: 'lalala' }
@@ -135,7 +135,7 @@ describe('Applications registration', () => {
         const application = await generator.createApplication({ confirmed: false }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/registered',
+            path: '/events/' + event.id + '/applications/' + application.id + '/registered',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { registered: true }

--- a/statutory/test/api/applications-status.test.js
+++ b/statutory/test/api/applications-status.test.js
@@ -32,7 +32,7 @@ describe('Applications status', () => {
         await generator.createApplication({ user_id: regularUser.id }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/me/status',
+            path: '/events/' + event.id + '/applications/me/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { status: 'accepted' }
@@ -49,7 +49,7 @@ describe('Applications status', () => {
         const application = await generator.createApplication({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/status',
+            path: '/events/' + event.id + '/applications/' + application.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { status: 'accepted' }
@@ -68,7 +68,7 @@ describe('Applications status', () => {
         const application = await generator.createApplication({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.statutory_id + '/status',
+            path: '/events/' + event.id + '/applications/' + application.statutory_id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { status: 'accepted' }
@@ -89,7 +89,7 @@ describe('Applications status', () => {
         const application = await generator.createApplication({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/status',
+            path: '/events/' + event.id + '/applications/' + application.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { status: 'accepted' }
@@ -105,7 +105,7 @@ describe('Applications status', () => {
         const event = await generator.createEvent({ applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/333/status',
+            path: '/events/' + event.id + '/applications/333/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { status: 'accepted' }
@@ -122,7 +122,7 @@ describe('Applications status', () => {
         const application = await generator.createApplication({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/status',
+            path: '/events/' + event.id + '/applications/' + application.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { status: 'lalala' }
@@ -139,7 +139,7 @@ describe('Applications status', () => {
         const application = await generator.createApplication({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/status',
+            path: '/events/' + event.id + '/applications/' + application.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { status: 'waiting_list' }
@@ -158,7 +158,7 @@ describe('Applications status', () => {
         const application = await generator.createApplication({ user_id: regularUser.id }, event);
 
         await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/status',
+            path: '/events/' + event.id + '/applications/' + application.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { status: 'accepted' }
@@ -167,7 +167,7 @@ describe('Applications status', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -190,7 +190,7 @@ describe('Applications status', () => {
         const application = await generator.createApplication({ user_id: regularUser.id }, event);
 
         await request({
-            uri: '/events/' + event.id + '/applications/' + application.id + '/status',
+            path: '/events/' + event.id + '/applications/' + application.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { status: 'accepted' }
@@ -199,7 +199,7 @@ describe('Applications status', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const beforeRes = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -210,7 +210,7 @@ describe('Applications status', () => {
         mock.mockAll();
 
         const editRes = await request({
-            uri: '/events/' + event.id,
+            path: '/events/' + event.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -226,7 +226,7 @@ describe('Applications status', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const afterRes = await request({
-            uri: '/events/' + event.id + '/applications/' + application.id,
+            path: '/events/' + event.id + '/applications/' + application.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/candidatures-display.test.js
+++ b/statutory/test/api/candidatures-display.test.js
@@ -34,7 +34,7 @@ describe('Candidates displaying', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/1337',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -55,7 +55,7 @@ describe('Candidates displaying', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/false',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/false',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -79,7 +79,7 @@ describe('Candidates displaying', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id,
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -101,7 +101,7 @@ describe('Candidates displaying', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id,
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -125,7 +125,7 @@ describe('Candidates displaying', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id,
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/candidatures-editing.test.js
+++ b/statutory/test/api/candidatures-editing.test.js
@@ -37,7 +37,7 @@ describe('Candidates editing', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id,
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id,
             method: 'PUT',
             body: { first_name: 'Different' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -59,7 +59,7 @@ describe('Candidates editing', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/1337',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/1337',
             method: 'PUT',
             body: { first_name: 'Different' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -81,7 +81,7 @@ describe('Candidates editing', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/false',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/false',
             method: 'PUT',
             body: { first_name: 'Different' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -106,7 +106,7 @@ describe('Candidates editing', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id,
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id,
             method: 'PUT',
             body: { first_name: 'Different', body_id: regularUser.bodies[0].id },
             headers: { 'X-Auth-Token': 'blablabla' }

--- a/statutory/test/api/candidatures-image-upload.test.js
+++ b/statutory/test/api/candidatures-image-upload.test.js
@@ -41,11 +41,13 @@ describe('Candidates image upload', () => {
         await rimraf(config.images_dir);
 
         await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -54,11 +56,13 @@ describe('Candidates image upload', () => {
 
     it('should fail if the uploaded file is not an image (by extension)', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/invalid_image.txt')
+            files: {
+                image: {
+                    path: './test/assets/invalid_image.txt'
+                }
             }
         });
 
@@ -70,15 +74,13 @@ describe('Candidates image upload', () => {
 
     it('should fail if the uploaded file is not an image (by content)', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
+            files: {
                 image: {
-                    value: fs.createReadStream('./test/assets/invalid_image.txt'),
-                    options: {
-                        filename: 'image.jpg'
-                    }
+                    path: './test/assets/invalid_image.txt',
+                    filename: 'image.jpg'
                 }
             }
         });
@@ -91,10 +93,10 @@ describe('Candidates image upload', () => {
 
     it('should fail the \'image\' field is not specified', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {}
+            files: {}
         });
 
         expect(res.statusCode).toEqual(422);
@@ -105,11 +107,13 @@ describe('Candidates image upload', () => {
 
     it('should upload a file if it\'s valid', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/valid_image_2.Png')
+            files: {
+                image: {
+                    path: './test/assets/valid_image_2.Png'
+                }
             }
         });
 
@@ -131,11 +135,13 @@ describe('Candidates image upload', () => {
     it('should remove the old file', async () => {
         // Uploading
         const firstRequest = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -150,11 +156,13 @@ describe('Candidates image upload', () => {
         const oldImgId = firstRequest.body.data.image.id;
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -173,11 +181,13 @@ describe('Candidates image upload', () => {
     it('should fail if no permissions', async () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -190,11 +200,13 @@ describe('Candidates image upload', () => {
     it('should not crash when the file deletion cannot be done', async () => {
         // Uploading
         const firstRequest = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -209,11 +221,13 @@ describe('Candidates image upload', () => {
         await fs.promises.unlink(oldImgPath);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + candidate.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 

--- a/statutory/test/api/candidatures-status.test.js
+++ b/statutory/test/api/candidatures-status.test.js
@@ -37,7 +37,7 @@ describe('Candidates status', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id + '/status',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id + '/status',
             method: 'PUT',
             body: { status: 'approved' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -60,7 +60,7 @@ describe('Candidates status', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id + '/status',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id + '/status',
             method: 'PUT',
             body: { status: false },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -84,7 +84,7 @@ describe('Candidates status', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id + '/status',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates/' + position.candidates[0].id + '/status',
             method: 'PUT',
             body: { status: 'approved' },
             headers: { 'X-Auth-Token': 'blablabla' }

--- a/statutory/test/api/candidatures-submission.test.js
+++ b/statutory/test/api/candidatures-submission.test.js
@@ -36,7 +36,7 @@ describe('Candidates submission', () => {
         const candidate = generator.generateCandidate({ body_id: regularUser.bodies[0].id });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -59,7 +59,7 @@ describe('Candidates submission', () => {
         const candidate = generator.generateCandidate({ body_id: regularUser.bodies[0].id });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -82,7 +82,7 @@ describe('Candidates submission', () => {
         const candidate = generator.generateCandidate({ body_id: regularUser.bodies[0].id });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/1337/candidates',
+            path: '/events/' + event.id + '/positions/1337/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -105,7 +105,7 @@ describe('Candidates submission', () => {
         const candidate = generator.generateCandidate({ body_id: regularUser.bodies[0].id });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/false/candidates',
+            path: '/events/' + event.id + '/positions/false/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -128,7 +128,7 @@ describe('Candidates submission', () => {
         const candidate = generator.generateCandidate({ body_id: 1337 });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -155,7 +155,7 @@ describe('Candidates submission', () => {
         const candidate = generator.generateCandidate({ body_id: regularUser.bodies[0].id });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -179,7 +179,7 @@ describe('Candidates submission', () => {
         const candidate = generator.generateCandidate({ body_id: regularUser.bodies[0].id });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -206,7 +206,7 @@ describe('Candidates submission', () => {
         const candidate = generator.generateCandidate({ body_id: regularUser.bodies[0].id });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -236,7 +236,7 @@ describe('Candidates submission', () => {
         const candidate = generator.generateCandidate({ body_id: regularUser.bodies[0].id, user_id: regularUser.id });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -264,7 +264,7 @@ describe('Candidates submission', () => {
         const candidate = generator.generateCandidate({ body_id: regularUser.bodies[0].id, user_id: regularUser.id });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -312,7 +312,7 @@ describe('Candidates submission', () => {
             candidate[field] = null;
 
             const res = await request({
-                uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+                path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
                 method: 'POST',
                 body: candidate,
                 headers: { 'X-Auth-Token': 'blablabla' }
@@ -344,7 +344,7 @@ describe('Candidates submission', () => {
             candidate[field] = false;
 
             const res = await request({
-                uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+                path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
                 method: 'POST',
                 body: candidate,
                 headers: { 'X-Auth-Token': 'blablabla' }
@@ -369,7 +369,7 @@ describe('Candidates submission', () => {
             candidate[field] = 'test string';
 
             const res = await request({
-                uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+                path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
                 method: 'POST',
                 body: candidate,
                 headers: { 'X-Auth-Token': 'blablabla' }
@@ -397,7 +397,7 @@ describe('Candidates submission', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -424,7 +424,7 @@ describe('Candidates submission', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -451,7 +451,7 @@ describe('Candidates submission', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -478,7 +478,7 @@ describe('Candidates submission', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -505,7 +505,7 @@ describe('Candidates submission', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -532,7 +532,7 @@ describe('Candidates submission', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/candidates',
+            path: '/events/' + event.id + '/positions/' + position.id + '/candidates',
             method: 'POST',
             body: candidate,
             headers: { 'X-Auth-Token': 'blablabla' }

--- a/statutory/test/api/cron-test.test.js
+++ b/statutory/test/api/cron-test.test.js
@@ -64,7 +64,7 @@ describe('Cron testing', () => {
         await cron.registerAllDeadlines();
 
         const res = await request({
-            uri: '/tasks',
+            path: '/tasks',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -137,7 +137,7 @@ describe('Cron testing', () => {
             });
 
             const res = await request({
-                uri: '/events/' + event.id + '/positions/',
+                path: '/events/' + event.id + '/positions/',
                 method: 'POST',
                 body: position,
                 headers: { 'X-Auth-Token': 'blablabla' }
@@ -163,7 +163,7 @@ describe('Cron testing', () => {
             });
 
             const res = await request({
-                uri: '/events/' + event.id + '/positions/',
+                path: '/events/' + event.id + '/positions/',
                 method: 'POST',
                 body: position,
                 headers: { 'X-Auth-Token': 'blablabla' }
@@ -187,7 +187,7 @@ describe('Cron testing', () => {
             });
 
             const res = await request({
-                uri: '/events/' + event.id + '/positions/',
+                path: '/events/' + event.id + '/positions/',
                 method: 'POST',
                 body: position,
                 headers: { 'X-Auth-Token': 'blablabla' }
@@ -209,7 +209,7 @@ describe('Cron testing', () => {
             });
 
             const res = await request({
-                uri: '/events/' + event.id + '/positions/',
+                path: '/events/' + event.id + '/positions/',
                 method: 'POST',
                 body: position,
                 headers: { 'X-Auth-Token': 'blablabla' }
@@ -238,7 +238,7 @@ describe('Cron testing', () => {
             });
 
             const res = await request({
-                uri: '/events/' + event.id + '/positions/',
+                path: '/events/' + event.id + '/positions/',
                 method: 'POST',
                 body: position,
                 headers: { 'X-Auth-Token': 'blablabla' }
@@ -266,7 +266,7 @@ describe('Cron testing', () => {
             const position = await generator.createPosition({}, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/positions/' + position.id,
+                path: '/events/' + event.id + '/positions/' + position.id,
                 method: 'PUT',
                 body: {
                     starts: moment().add(1, 'week').toDate(),
@@ -292,7 +292,7 @@ describe('Cron testing', () => {
             const position = await generator.createPosition({}, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/positions/' + position.id,
+                path: '/events/' + event.id + '/positions/' + position.id,
                 method: 'PUT',
                 body: {
                     starts: moment().subtract(1, 'week').toDate(),
@@ -316,7 +316,7 @@ describe('Cron testing', () => {
             const position = await generator.createPosition({}, event);
 
             const res = await request({
-                uri: '/events/' + event.id + '/positions/' + position.id,
+                path: '/events/' + event.id + '/positions/' + position.id,
                 method: 'PUT',
                 body: {
                     starts: moment().subtract(3, 'week').toDate(),

--- a/statutory/test/api/events-creation-previous-agora.test.js
+++ b/statutory/test/api/events-creation-previous-agora.test.js
@@ -27,7 +27,7 @@ describe('Events previous_agora_id setting', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'bla' },
             method: 'POST',
             body: event
@@ -53,7 +53,7 @@ describe('Events previous_agora_id setting', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'bla' },
             method: 'POST',
             body: event
@@ -78,7 +78,7 @@ describe('Events previous_agora_id setting', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'bla' },
             method: 'POST',
             body: event
@@ -98,7 +98,7 @@ describe('Events previous_agora_id setting', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'bla' },
             method: 'POST',
             body: event

--- a/statutory/test/api/events-creation.test.js
+++ b/statutory/test/api/events-creation.test.js
@@ -27,7 +27,7 @@ describe('Events creation', () => {
     test('should fail if user does not have rights to create events', async () => {
         mock.mockAll({ core: { regularUser: true } });
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { }
@@ -41,7 +41,7 @@ describe('Events creation', () => {
         const event = generator.generateEvent();
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: event
@@ -72,7 +72,7 @@ describe('Events creation', () => {
 
     test('should fail if the event is invalid', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -88,7 +88,7 @@ describe('Events creation', () => {
 
     test('should fail if the event is numbers only', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -110,7 +110,7 @@ describe('Events creation', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -124,7 +124,7 @@ describe('Events creation', () => {
 
     test('should fail if event ends before it starts', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -151,7 +151,7 @@ describe('Events creation', () => {
 
     test('should fail if event application period ends before it starts', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -178,7 +178,7 @@ describe('Events creation', () => {
 
     test('should fail if event starts before application period ends', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -199,7 +199,7 @@ describe('Events creation', () => {
 
     test('should fail if board approve_deadline is before application period ends', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -220,7 +220,7 @@ describe('Events creation', () => {
 
     test('should allow pax list publish deadline before board approve deadline', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -241,7 +241,7 @@ describe('Events creation', () => {
 
     test('should set application status reveal date if publish deadline is already in the past', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -262,7 +262,7 @@ describe('Events creation', () => {
 
     test('should fail if pax list publish deadline is before event starts', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -283,7 +283,7 @@ describe('Events creation', () => {
 
     test('should fail if memberslist_submission_deadline is after event starts', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -310,7 +310,7 @@ describe('Events creation', () => {
 
     test('should fail if memberslist_submission_deadline is not set for Agora', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -338,7 +338,7 @@ describe('Events creation', () => {
 
     test('should not fail if memberslist_submission_deadline is not set for EPM', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -364,7 +364,7 @@ describe('Events creation', () => {
 
     test('should fail if memberslist_submission_deadline is invalid for Agora', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -392,7 +392,7 @@ describe('Events creation', () => {
 
     test('should fail if draft_proposal_deadline is after event starts', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -420,7 +420,7 @@ describe('Events creation', () => {
 
     test('should fail if draft_proposal_deadline is not set for Agora', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -448,7 +448,7 @@ describe('Events creation', () => {
 
     test('should not fail if draft_proposal_deadline is not set for EPM', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -474,7 +474,7 @@ describe('Events creation', () => {
 
     test('should fail if draft_proposal_deadline is invalid for Agora', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -502,7 +502,7 @@ describe('Events creation', () => {
 
     test('should fail if final_proposal_deadline is after event starts', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -529,7 +529,7 @@ describe('Events creation', () => {
 
     test('should fail if final_proposal_deadline is not set for Agora', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -557,7 +557,7 @@ describe('Events creation', () => {
 
     test('should not fail if final_proposal_deadline is not set for EPM', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -583,7 +583,7 @@ describe('Events creation', () => {
 
     test('should fail if final_proposal_deadline is invalid for Agora', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -611,7 +611,7 @@ describe('Events creation', () => {
 
     test('should fail if final_proposal_deadline is before draft_proposal_deadline', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -638,7 +638,7 @@ describe('Events creation', () => {
 
     test('should fail if candidature_deadline is after event starts', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -665,7 +665,7 @@ describe('Events creation', () => {
 
     test('should fail if candidature_deadline is not set for Agora', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -693,7 +693,7 @@ describe('Events creation', () => {
 
     test('should not fail if candidature_deadline is not set for EPM', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -719,7 +719,7 @@ describe('Events creation', () => {
 
     test('should fail if candidature_deadline is invalid for Agora', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -747,7 +747,7 @@ describe('Events creation', () => {
 
     test('should fail if booklet_publication_deadline is after event starts', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -775,7 +775,7 @@ describe('Events creation', () => {
 
     test('should fail if booklet_publication_deadline is not set for Agora', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -803,7 +803,7 @@ describe('Events creation', () => {
 
     test('should not fail if booklet_publication_deadline is not set for EPM', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -829,7 +829,7 @@ describe('Events creation', () => {
 
     test('should fail if booklet_publication_deadline is invalid for Agora', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -857,7 +857,7 @@ describe('Events creation', () => {
 
     test('should fail if updated_booklet_publication_deadline is after event starts', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -884,7 +884,7 @@ describe('Events creation', () => {
 
     test('should fail if updated_booklet_publication_deadline is not set for Agora', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -912,7 +912,7 @@ describe('Events creation', () => {
 
     test('should not fail if updated_booklet_publication_deadline is not set for EPM', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -938,7 +938,7 @@ describe('Events creation', () => {
 
     test('should fail if updated_booklet_publication_deadline is invalid for Agora', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -966,7 +966,7 @@ describe('Events creation', () => {
 
     test('should fail if updated_booklet_publication_deadline is before booklet_publication_deadline', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -993,7 +993,7 @@ describe('Events creation', () => {
 
     test('should fail if questions is empty array', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -1007,7 +1007,7 @@ describe('Events creation', () => {
 
     test('should fail if questions is not an array', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -1022,7 +1022,7 @@ describe('Events creation', () => {
 
     test('should fail if questions are malformed', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -1036,7 +1036,7 @@ describe('Events creation', () => {
 
     test('should fail if question.description is not set', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -1050,7 +1050,7 @@ describe('Events creation', () => {
 
     test('should fail if question.description is not string', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -1064,7 +1064,7 @@ describe('Events creation', () => {
 
     test('should fail if question.required is not set', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -1078,7 +1078,7 @@ describe('Events creation', () => {
 
     test('should fail if question.required is not string', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -1092,7 +1092,7 @@ describe('Events creation', () => {
 
     test('should fail if question.values is not an array when type is select', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -1106,7 +1106,7 @@ describe('Events creation', () => {
 
     test('should fail if question.values.* is invalid when type is select', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -1120,7 +1120,7 @@ describe('Events creation', () => {
 
     test('should fail if question type is not set or invalid', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -1134,7 +1134,7 @@ describe('Events creation', () => {
 
     test('should fail if question type is unknown', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -1148,7 +1148,7 @@ describe('Events creation', () => {
 
     test('should fail if question value is empty', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -1162,7 +1162,7 @@ describe('Events creation', () => {
 
     test('should succeed if type is select and everything is valid', async () => {
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateEvent({
@@ -1178,7 +1178,7 @@ describe('Events creation', () => {
         const event = generator.generateEvent({ locations: false });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1194,7 +1194,7 @@ describe('Events creation', () => {
         const event = generator.generateEvent({ locations: false });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1210,7 +1210,7 @@ describe('Events creation', () => {
         const event = generator.generateEvent({ locations: [false] });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1226,7 +1226,7 @@ describe('Events creation', () => {
         const event = generator.generateEvent({ locations: [{ name: false }] });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1242,7 +1242,7 @@ describe('Events creation', () => {
         const event = generator.generateEvent({ locations: [{ name: '       ' }] });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1258,7 +1258,7 @@ describe('Events creation', () => {
         const event = generator.generateEvent({ locations: [{ name: 'test', position: false }] });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1274,7 +1274,7 @@ describe('Events creation', () => {
         const event = generator.generateEvent({ locations: [{ name: 'test', position: { lat: false, lng: 1 } }] });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1290,7 +1290,7 @@ describe('Events creation', () => {
         const event = generator.generateEvent({ locations: [{ name: 'test', position: { lat: 1, lng: false } }] });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event
@@ -1306,7 +1306,7 @@ describe('Events creation', () => {
         const event = generator.generateEvent({ locations: [{ name: 'test', position: { lat: 1, lng: 1 } }] });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             headers: { 'X-Auth-Token': 'foobar' },
             method: 'POST',
             body: event

--- a/statutory/test/api/events-display.test.js
+++ b/statutory/test/api/events-display.test.js
@@ -25,7 +25,7 @@ describe('Events listing for single', () => {
 
     test('should return 404 if the event is not found', async () => {
         const res = await request({
-            uri: '/events/nonexistant',
+            path: '/events/nonexistant',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -45,7 +45,7 @@ describe('Events listing for single', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id,
+            path: '/events/' + event.id,
             method: 'GET'
         });
 
@@ -57,7 +57,7 @@ describe('Events listing for single', () => {
     test('should find event by url', async () => {
         const event = await generator.createEvent({ url: 'test-slug' });
         const res = await request({
-            uri: '/events/test-slug',
+            path: '/events/test-slug',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -70,7 +70,7 @@ describe('Events listing for single', () => {
     test('should find event by ID', async () => {
         const event = await generator.createEvent();
         const res = await request({
-            uri: '/events/' + event.id,
+            path: '/events/' + event.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -114,7 +114,7 @@ describe('Events listing for single', () => {
         });
 
         const res = await request({
-            uri: '/events/latest',
+            path: '/events/latest',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -161,7 +161,7 @@ describe('Events listing for single', () => {
         });
 
         const res = await request({
-            uri: '/events/latest-agora',
+            path: '/events/latest-agora',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -208,7 +208,7 @@ describe('Events listing for single', () => {
         });
 
         const res = await request({
-            uri: '/events/latest-epm',
+            path: '/events/latest-epm',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -255,7 +255,7 @@ describe('Events listing for single', () => {
         });
 
         const res = await request({
-            uri: '/events/latest-spm',
+            path: '/events/latest-spm',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -284,7 +284,7 @@ describe('Events listing for single', () => {
         });
 
         const res = await request({
-            uri: '/events/latest',
+            path: '/events/latest',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -312,7 +312,7 @@ describe('Events listing for single', () => {
         });
 
         const res = await request({
-            uri: '/events/latest-agora',
+            path: '/events/latest-agora',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -340,7 +340,7 @@ describe('Events listing for single', () => {
         });
 
         const res = await request({
-            uri: '/events/latest-epm',
+            path: '/events/latest-epm',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/events-editing.test.js
+++ b/statutory/test/api/events-editing.test.js
@@ -30,7 +30,7 @@ describe('Events editing', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id,
+            path: '/events/' + event.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -50,7 +50,7 @@ describe('Events editing', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id,
+            path: '/events/' + event.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -69,7 +69,7 @@ describe('Events editing', () => {
 
     test('should return 404 if event is not found', async () => {
         const res = await request({
-            uri: '/events/notexistant',
+            path: '/events/notexistant',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -86,7 +86,7 @@ describe('Events editing', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id,
+            path: '/events/' + event.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -107,7 +107,7 @@ describe('Events editing', () => {
         const event = await generator.createEvent({ type: 'epm' });
 
         const res = await request({
-            uri: '/events/' + event.id,
+            path: '/events/' + event.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -128,7 +128,7 @@ describe('Events editing', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id,
+            path: '/events/' + event.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -151,7 +151,7 @@ describe('Events editing', () => {
         await event.update({ participants_list_publish_deadline: moment().subtract(1, 'day').toDate() });
 
         const res = await request({
-            uri: '/events/' + event.id,
+            path: '/events/' + event.id,
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {

--- a/statutory/test/api/events-fields.test.js
+++ b/statutory/test/api/events-fields.test.js
@@ -24,7 +24,7 @@ describe('Events fields', () => {
     test('should return all applications fields', async () => {
         const event = await generator.createEvent();
         const res = await request({
-            uri: '/events/' + event.id + '/fields/applications/all',
+            path: '/events/' + event.id + '/fields/applications/all',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -36,7 +36,7 @@ describe('Events fields', () => {
     test('should return all incoming fields', async () => {
         const event = await generator.createEvent();
         const res = await request({
-            uri: '/events/' + event.id + '/fields/applications/incoming',
+            path: '/events/' + event.id + '/fields/applications/incoming',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -48,7 +48,7 @@ describe('Events fields', () => {
     test('should return candidates fields', async () => {
         const event = await generator.createEvent();
         const res = await request({
-            uri: '/events/' + event.id + '/fields/candidates',
+            path: '/events/' + event.id + '/fields/candidates',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/events-image-upload.test.js
+++ b/statutory/test/api/events-image-upload.test.js
@@ -36,11 +36,13 @@ describe('Events image upload', () => {
         await rimraf(config.images_dir);
 
         await request({
-            uri: '/events/' + event.id + '/image',
+            path: '/events/' + event.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -49,11 +51,13 @@ describe('Events image upload', () => {
 
     it('should fail if the uploaded file is not an image (by extension)', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/image',
+            path: '/events/' + event.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/invalid_image.txt')
+            files: {
+                image: {
+                    path: './test/assets/invalid_image.txt'
+                }
             }
         });
 
@@ -65,15 +69,13 @@ describe('Events image upload', () => {
 
     it('should fail if the uploaded file is not an image (by content)', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/image',
+            path: '/events/' + event.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
+            files: {
                 image: {
-                    value: fs.createReadStream('./test/assets/invalid_image.txt'),
-                    options: {
-                        filename: 'image.jpg'
-                    }
+                    path: './test/assets/invalid_image.txt',
+                    filename: 'image.jpg'
                 }
             }
         });
@@ -86,10 +88,10 @@ describe('Events image upload', () => {
 
     it('should fail the \'image\' field is not specified', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/image',
+            path: '/events/' + event.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {}
+            files: {}
         });
 
         expect(res.statusCode).toEqual(422);
@@ -100,11 +102,13 @@ describe('Events image upload', () => {
 
     it('should upload a file if it\'s valid', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/image',
+            path: '/events/' + event.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -126,11 +130,13 @@ describe('Events image upload', () => {
     it('should remove the old file', async () => {
         // Uploading
         const firstRequest = await request({
-            uri: '/events/' + event.id + '/image',
+            path: '/events/' + event.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -145,11 +151,13 @@ describe('Events image upload', () => {
         const oldImgId = firstRequest.body.data.image.id;
 
         const res = await request({
-            uri: '/events/' + event.id + '/image',
+            path: '/events/' + event.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -168,11 +176,13 @@ describe('Events image upload', () => {
     it('should fail if no permissions', async () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
         const res = await request({
-            uri: '/events/' + event.id + '/image',
+            path: '/events/' + event.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -185,11 +195,13 @@ describe('Events image upload', () => {
     it('should not crash when the file deletion cannot be done', async () => {
         // Uploading
         const firstRequest = await request({
-            uri: '/events/' + event.id + '/image',
+            path: '/events/' + event.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 
@@ -204,11 +216,13 @@ describe('Events image upload', () => {
         await fs.promises.unlink(oldImgPath);
 
         const res = await request({
-            uri: '/events/' + event.id + '/image',
+            path: '/events/' + event.id + '/image',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
-            formData: {
-                image: fs.createReadStream('./test/assets/valid_image.png')
+            files: {
+                image: {
+                    path: './test/assets/valid_image.png'
+                }
             }
         });
 

--- a/statutory/test/api/events-listing.test.js
+++ b/statutory/test/api/events-listing.test.js
@@ -33,7 +33,7 @@ describe('Events listing', () => {
         const event = await generator.createEvent({ status: 'published' });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET'
         });
 
@@ -50,7 +50,7 @@ describe('Events listing', () => {
         const event = await generator.createEvent({ status: 'published' });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -68,7 +68,7 @@ describe('Events listing', () => {
         const event = await generator.createEvent({ status: 'draft' });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -116,7 +116,7 @@ describe('Events listing', () => {
         });
 
         const res = await request({
-            uri: '/',
+            path: '/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -137,7 +137,7 @@ describe('Events listing', () => {
         await generator.createEvent({ status: 'published', name: 'other', description: 'other' });
 
         const res = await request({
-            uri: '/?search=test',
+            path: '/?search=test',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -187,7 +187,7 @@ describe('Events listing', () => {
         });
 
         const res = await request({
-            uri: '/?starts=' + moment().format('YYYY-MM-DD'),
+            path: '/?starts=' + moment().format('YYYY-MM-DD'),
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -234,7 +234,7 @@ describe('Events listing', () => {
         });
 
         const res = await request({
-            uri: '/?ends=' + moment().format('YYYY-MM-DD'),
+            path: '/?ends=' + moment().format('YYYY-MM-DD'),
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -253,7 +253,7 @@ describe('Events listing', () => {
         await generator.createEvent({ status: 'published', type: 'spm' });
 
         const res = await request({
-            uri: '/?type=agora',
+            path: '/?type=agora',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -272,7 +272,7 @@ describe('Events listing', () => {
         await generator.createEvent({ status: 'published', type: 'spm' });
 
         const res = await request({
-            uri: '/?type[]=agora&type[]=epm',
+            path: '/?type[]=agora&type[]=epm',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -323,7 +323,7 @@ describe('Events listing', () => {
         });
 
         const res = await request({
-            uri: '/recents',
+            path: '/recents',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -372,7 +372,7 @@ describe('Events listing', () => {
         const ends = moment().subtract(10, 'days').toISOString();
 
         const res = await request({
-            uri: '/recents?ends=' + ends,
+            path: '/recents?ends=' + ends,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/events-mine.test.js
+++ b/statutory/test/api/events-mine.test.js
@@ -26,7 +26,7 @@ describe('Events participating', () => {
         const event = await generator.createEvent({ status: 'published' });
 
         const res = await request({
-            uri: '/mine',
+            path: '/mine',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -45,7 +45,7 @@ describe('Events participating', () => {
         await generator.createApplication({ user_id: regularUser.id }, event);
 
         const res = await request({
-            uri: '/mine',
+            path: '/mine',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -72,7 +72,7 @@ describe('Events participating', () => {
         }, event);
 
         const hiddenRes = await request({
-            uri: '/mine',
+            path: '/mine',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -83,7 +83,7 @@ describe('Events participating', () => {
         await event.update({ application_status_revealed_at: new Date() });
 
         const revealedRes = await request({
-            uri: '/mine',
+            path: '/mine',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/events-status-editing.test.js
+++ b/statutory/test/api/events-status-editing.test.js
@@ -28,7 +28,7 @@ describe('Events status editing', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/status',
+            path: '/events/' + event.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -48,7 +48,7 @@ describe('Events status editing', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/events/nonexistant/status',
+            path: '/events/nonexistant/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -65,7 +65,7 @@ describe('Events status editing', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/status',
+            path: '/events/' + event.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {}
@@ -80,7 +80,7 @@ describe('Events status editing', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/status',
+            path: '/events/' + event.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { status: 'not-existant' }
@@ -99,7 +99,7 @@ describe('Events status editing', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/status',
+            path: '/events/' + event.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { status: 'published' }
@@ -117,7 +117,7 @@ describe('Events status editing', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/status',
+            path: '/events/' + event.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { status: 'published' }
@@ -135,7 +135,7 @@ describe('Events status editing', () => {
         const event = await generator.createEvent();
 
         const res = await request({
-            uri: '/events/' + event.id + '/status',
+            path: '/events/' + event.id + '/status',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { status: 'draft' }

--- a/statutory/test/api/export-all.test.js
+++ b/statutory/test/api/export-all.test.js
@@ -38,12 +38,11 @@ describe('Export all', () => {
 
     test('should return nothing if no applications', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/all',
+            path: '/events/' + event.id + '/applications/export/all',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' },
-            qs: { select: Object.keys(helpers.getApplicationFields(event)) }
+            query: { select: Object.keys(helpers.getApplicationFields(event)) }
         });
 
         expect(res.statusCode).toEqual(200);
@@ -63,12 +62,11 @@ describe('Export all', () => {
             answers: [true, 'string']
         }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/all',
+            path: '/events/' + event.id + '/applications/export/all',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' },
-            qs: { select: Object.keys(helpers.getApplicationFields(event)) }
+            query: { select: Object.keys(helpers.getApplicationFields(event)) }
         });
 
         expect(res.statusCode).toEqual(200);
@@ -103,12 +101,11 @@ describe('Export all', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/all',
+            path: '/events/' + event.id + '/applications/export/all',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' },
-            qs: { select: Object.keys(helpers.getApplicationFields(event)) }
+            query: { select: Object.keys(helpers.getApplicationFields(event)) }
         });
 
         expect(res.statusCode).toEqual(200);
@@ -129,12 +126,11 @@ describe('Export all', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/all',
+            path: '/events/' + event.id + '/applications/export/all',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' },
-            qs: { select: Object.keys(helpers.getApplicationFields(event)) }
+            query: { select: Object.keys(helpers.getApplicationFields(event)) }
         });
 
         expect(res.statusCode).toEqual(403);
@@ -142,10 +138,9 @@ describe('Export all', () => {
 
     test('should return 400 if no filter provided', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/all',
+            path: '/events/' + event.id + '/applications/export/all',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' }
         });
 
@@ -160,12 +155,11 @@ describe('Export all', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/all',
+            path: '/events/' + event.id + '/applications/export/all',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' },
-            qs: { select: ['id', 'answers.0'] }
+            query: { select: ['id', 'answers.0'] }
         });
 
         expect(res.statusCode).toEqual(200);
@@ -197,12 +191,11 @@ describe('Export all', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/incoming',
+            path: '/events/' + event.id + '/applications/export/incoming',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' },
-            qs: { select: Object.keys(helpers.getApplicationFields(event)) }
+            query: { select: Object.keys(helpers.getApplicationFields(event)) }
         });
 
         expect(res.statusCode).toEqual(200);
@@ -217,12 +210,11 @@ describe('Export all', () => {
 
     test('should return 400 on invalid prefix', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/invalid',
+            path: '/events/' + event.id + '/applications/export/invalid',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' },
-            qs: { select: Object.keys(helpers.getApplicationFields(event)) }
+            query: { select: Object.keys(helpers.getApplicationFields(event)) }
         });
 
         expect(res.statusCode).toEqual(400);
@@ -248,12 +240,11 @@ describe('Export all', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/all',
+            path: '/events/' + event.id + '/applications/export/all',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' },
-            qs: { select: Object.keys(helpers.getApplicationFields(event)), filter: false }
+            query: { select: Object.keys(helpers.getApplicationFields(event)), filter: false }
         });
 
         expect(res.statusCode).toEqual(200);
@@ -282,12 +273,11 @@ describe('Export all', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/all',
+            path: '/events/' + event.id + '/applications/export/all',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' },
-            qs: {
+            query: {
                 select: Object.keys(helpers.getApplicationFields(event)),
                 filter: { status: 'accepted', confirmed: true }
             }

--- a/statutory/test/api/export-candidates.test.js
+++ b/statutory/test/api/export-candidates.test.js
@@ -37,12 +37,11 @@ describe('Export candidates', () => {
 
     test('should return nothing if no candidates', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/positions/export',
+            path: '/events/' + event.id + '/positions/export',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' },
-            qs: { select: constants.CANDIDATE_FIELDS }
+            query: { select: constants.CANDIDATE_FIELDS }
         });
 
         expect(res.statusCode).toEqual(200);
@@ -63,12 +62,11 @@ describe('Export candidates', () => {
         const candidate = await generator.createCandidate({}, position);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/export',
+            path: '/events/' + event.id + '/positions/export',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' },
-            qs: { select: ['id'] }
+            query: { select: ['id'] }
         });
 
         expect(res.statusCode).toEqual(200);
@@ -85,12 +83,11 @@ describe('Export candidates', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/export',
+            path: '/events/' + event.id + '/positions/export',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' },
-            qs: { select: constants.CANDIDATE_FIELDS }
+            query: { select: constants.CANDIDATE_FIELDS }
         });
 
         expect(res.statusCode).toEqual(403);
@@ -101,12 +98,11 @@ describe('Export candidates', () => {
         const candidate = await generator.createCandidate({ status: 'approved' }, position);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/export',
+            path: '/events/' + event.id + '/positions/export',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' },
-            qs: { select: ['id', 'status'] }
+            query: { select: ['id', 'status'] }
         });
 
         expect(res.statusCode).toEqual(200);
@@ -134,12 +130,11 @@ describe('Export candidates', () => {
         await generator.createCandidate({ status: 'rejected' }, position);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/export',
+            path: '/events/' + event.id + '/positions/export',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' },
-            qs: { select: constants.CANDIDATE_FIELDS, filter: {} }
+            query: { select: constants.CANDIDATE_FIELDS, filter: {} }
         });
 
         expect(res.statusCode).toEqual(200);
@@ -157,12 +152,11 @@ describe('Export candidates', () => {
         await generator.createCandidate({ status: 'rejected' }, position);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/export',
+            path: '/events/' + event.id + '/positions/export',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla', 'Content-Type': 'application/json' },
-            qs: {
+            query: {
                 select: constants.CANDIDATE_FIELDS,
                 filter: { status: 'approved' }
             }

--- a/statutory/test/api/export-delegates-jc.test.js
+++ b/statutory/test/api/export-delegates-jc.test.js
@@ -27,9 +27,9 @@ describe('Export Delegates JC', () => {
 
     test('should return nothing if no applications', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/delegates_jc',
+            path: '/events/' + event.id + '/applications/export/delegates_jc',
             method: 'GET',
-            json: false,
+            responseType: 'text',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 
@@ -44,9 +44,9 @@ describe('Export Delegates JC', () => {
         await generator.createApplication({ cancelled: false, status: 'rejected', user_id: 2 }, event);
         await generator.createApplication({ cancelled: false, status: 'accepted', participant_type: 'visitor', user_id: 3 }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/delegates_jc',
+            path: '/events/' + event.id + '/applications/export/delegates_jc',
             method: 'GET',
-            json: false,
+            responseType: 'text',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 
@@ -59,9 +59,9 @@ describe('Export Delegates JC', () => {
     test('should return the application if it is not cancelled, accepted and a delegate', async () => {
         await generator.createApplication({ user_id: regularUser.id, status: 'accepted', participant_type: 'delegate', body_id: 34 }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/delegates_jc',
+            path: '/events/' + event.id + '/applications/export/delegates_jc',
             method: 'GET',
-            json: false,
+            responseType: 'text',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 
@@ -76,9 +76,9 @@ describe('Export Delegates JC', () => {
         await generator.createApplication({ user_id: regularUser.id }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/delegates_jc',
+            path: '/events/' + event.id + '/applications/export/delegates_jc',
             method: 'GET',
-            json: false,
+            responseType: 'text',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 

--- a/statutory/test/api/export-openslides.test.js
+++ b/statutory/test/api/export-openslides.test.js
@@ -27,9 +27,9 @@ describe('Export OpenSlides', () => {
 
     test('should return nothing if no applications', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/openslides',
+            path: '/events/' + event.id + '/applications/export/openslides',
             method: 'GET',
-            json: false,
+            responseType: 'text',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 
@@ -43,9 +43,9 @@ describe('Export OpenSlides', () => {
         await generator.createApplication({ cancelled: true, status: 'accepted', user_id: 1 }, event);
         await generator.createApplication({ cancelled: false, status: 'rejected', user_id: 2 }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/openslides',
+            path: '/events/' + event.id + '/applications/export/openslides',
             method: 'GET',
-            json: false,
+            responseType: 'text',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 
@@ -58,9 +58,9 @@ describe('Export OpenSlides', () => {
     test('should return the application if there are not cancelled and accepted application', async () => {
         await generator.createApplication({ user_id: regularUser.id, status: 'accepted' }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/openslides',
+            path: '/events/' + event.id + '/applications/export/openslides',
             method: 'GET',
-            json: false,
+            responseType: 'text',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 
@@ -75,9 +75,9 @@ describe('Export OpenSlides', () => {
         await generator.createApplication({ user_id: regularUser.id }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/export/openslides',
+            path: '/events/' + event.id + '/applications/export/openslides',
             method: 'GET',
-            json: false,
+            responseType: 'text',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 

--- a/statutory/test/api/massmailer.test.js
+++ b/statutory/test/api/massmailer.test.js
@@ -57,7 +57,7 @@ describe('Massmailer', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/events/' + event.id + '/massmailer',
+            path: '/events/' + event.id + '/massmailer',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -73,7 +73,7 @@ describe('Massmailer', () => {
 
     test('should send mass mail if everything is okay', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/massmailer',
+            path: '/events/' + event.id + '/massmailer',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -98,7 +98,7 @@ describe('Massmailer', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/massmailer',
+            path: '/events/' + event.id + '/massmailer',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -115,7 +115,7 @@ describe('Massmailer', () => {
 
     test('should fail if body is not set', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/massmailer',
+            path: '/events/' + event.id + '/massmailer',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -130,7 +130,7 @@ describe('Massmailer', () => {
 
     test('should fail if body is empty', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/massmailer',
+            path: '/events/' + event.id + '/massmailer',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -146,7 +146,7 @@ describe('Massmailer', () => {
 
     test('should fail if subject is not set', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/massmailer',
+            path: '/events/' + event.id + '/massmailer',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -161,7 +161,7 @@ describe('Massmailer', () => {
 
     test('should fail if subject is empty', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/massmailer',
+            path: '/events/' + event.id + '/massmailer',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -178,7 +178,7 @@ describe('Massmailer', () => {
     test('should fail if mailer returns net error', async () => {
         mock.mockAll({ mailer: { netError: true } });
         const res = await request({
-            uri: '/events/' + event.id + '/massmailer',
+            path: '/events/' + event.id + '/massmailer',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -195,7 +195,7 @@ describe('Massmailer', () => {
     test('should fail if mailer returns bad response', async () => {
         mock.mockAll({ mailer: { badResponse: true } });
         const res = await request({
-            uri: '/events/' + event.id + '/massmailer',
+            path: '/events/' + event.id + '/massmailer',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -212,7 +212,7 @@ describe('Massmailer', () => {
     test('should fail if mailer returns unsuccessful response', async () => {
         mock.mockAll({ mailer: { unsuccessfulResponse: true } });
         const res = await request({
-            uri: '/events/' + event.id + '/massmailer',
+            path: '/events/' + event.id + '/massmailer',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -228,7 +228,7 @@ describe('Massmailer', () => {
 
     test('should work with filtering', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/massmailer/',
+            path: '/events/' + event.id + '/massmailer/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -246,7 +246,7 @@ describe('Massmailer', () => {
 
     test('should fail if no users match the filter', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/massmailer/',
+            path: '/events/' + event.id + '/massmailer/',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {
@@ -267,7 +267,7 @@ describe('Massmailer', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/massmailer',
+            path: '/events/' + event.id + '/massmailer',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: {

--- a/statutory/test/api/memberslist-fee-paid.test.js
+++ b/statutory/test/api/memberslist-fee-paid.test.js
@@ -34,7 +34,7 @@ describe('Memberslist fee_paid editing', () => {
         });
         await generator.createMembersList({ body_id: regularUser.bodies[0].id }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id + '/fee_paid',
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id + '/fee_paid',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { fee_paid: 300 }
@@ -54,7 +54,7 @@ describe('Memberslist fee_paid editing', () => {
         });
         await generator.createMembersList({ body_id: regularUser.bodies[0].id }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id + '/fee_paid',
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id + '/fee_paid',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { fee_paid: 300 }
@@ -80,7 +80,7 @@ describe('Memberslist fee_paid editing', () => {
             members: [generator.generateMembersListMember({ fee: 16 })]
         }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id + '/fee_paid',
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id + '/fee_paid',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { fee_paid: 1.996 }
@@ -104,7 +104,7 @@ describe('Memberslist fee_paid editing', () => {
             members: [generator.generateMembersListMember({ fee: 16 })]
         }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id + '/fee_paid',
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id + '/fee_paid',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { fee_paid: 2.004 }
@@ -123,7 +123,7 @@ describe('Memberslist fee_paid editing', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/1337/fee_paid',
+            path: '/events/' + event.id + '/memberslists/1337/fee_paid',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { fee_paid: 300 }
@@ -142,7 +142,7 @@ describe('Memberslist fee_paid editing', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/false/fee_paid',
+            path: '/events/' + event.id + '/memberslists/false/fee_paid',
             method: 'PUT',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { fee_paid: 300 }

--- a/statutory/test/api/memberslist-single.test.js
+++ b/statutory/test/api/memberslist-single.test.js
@@ -28,7 +28,7 @@ describe('Memberslist displaying', () => {
         const event = await generator.createEvent({ type: 'agora' });
         await generator.createMembersList({ body_id: regularUser.bodies[0].id }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -45,7 +45,7 @@ describe('Memberslist displaying', () => {
         const event = await generator.createEvent({ type: 'agora' });
         await generator.createMembersList({ body_id: 1337 }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/1337',
+            path: '/events/' + event.id + '/memberslists/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -62,7 +62,7 @@ describe('Memberslist displaying', () => {
         const event = await generator.createEvent({ type: 'agora' });
         await generator.createMembersList({ body_id: regularUser.bodies[0].id }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' },
         });
@@ -78,7 +78,7 @@ describe('Memberslist displaying', () => {
         const event = await generator.createEvent({ type: 'agora' });
         await generator.createMembersList({ body_id: 1337 }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/1337',
+            path: '/events/' + event.id + '/memberslists/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -94,7 +94,7 @@ describe('Memberslist displaying', () => {
         const event = await generator.createEvent({ type: 'agora' });
         await generator.createMembersList({ body_id: regularUser.bodies[0].id }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -110,7 +110,7 @@ describe('Memberslist displaying', () => {
         const event = await generator.createEvent({ type: 'agora' });
         await generator.createMembersList({ body_id: regularUser.bodies[0].id }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -126,7 +126,7 @@ describe('Memberslist displaying', () => {
         const event = await generator.createEvent({ type: 'epm' });
         await generator.createMembersList({ body_id: 1337 }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/1337',
+            path: '/events/' + event.id + '/memberslists/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -139,7 +139,7 @@ describe('Memberslist displaying', () => {
     test('should fail if members list is not uploaded', async () => {
         const event = await generator.createEvent({ type: 'agora' });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/1337',
+            path: '/events/' + event.id + '/memberslists/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -153,7 +153,7 @@ describe('Memberslist displaying', () => {
     test('should fail if body_id is invalid', async () => {
         const event = await generator.createEvent({ type: 'agora' });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/invalid',
+            path: '/events/' + event.id + '/memberslists/invalid',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/memberslist-upload.test.js
+++ b/statutory/test/api/memberslist-upload.test.js
@@ -35,7 +35,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -56,7 +56,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[1].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[1].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -77,7 +77,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/1337',
+            path: '/events/' + event.id + '/memberslists/1337',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -97,7 +97,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/1337',
+            path: '/events/' + event.id + '/memberslists/1337',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -117,7 +117,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -144,7 +144,7 @@ describe('Memberslist uploading', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -164,7 +164,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -184,7 +184,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -209,7 +209,7 @@ describe('Memberslist uploading', () => {
             ends: moment().subtract(1, 'days')
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -241,7 +241,7 @@ describe('Memberslist uploading', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -273,7 +273,7 @@ describe('Memberslist uploading', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -305,7 +305,7 @@ describe('Memberslist uploading', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -337,7 +337,7 @@ describe('Memberslist uploading', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -372,7 +372,7 @@ describe('Memberslist uploading', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -396,7 +396,7 @@ describe('Memberslist uploading', () => {
         body.fee_paid = 1300;
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/1337',
+            path: '/events/' + event.id + '/memberslists/1337',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body
@@ -427,7 +427,7 @@ describe('Memberslist uploading', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/1337',
+            path: '/events/' + event.id + '/memberslists/1337',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body
@@ -458,7 +458,7 @@ describe('Memberslist uploading', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/1337',
+            path: '/events/' + event.id + '/memberslists/1337',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body
@@ -480,7 +480,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(2, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -501,7 +501,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -521,7 +521,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -541,7 +541,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -559,7 +559,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/invalid',
+            path: '/events/' + event.id + '/memberslists/invalid',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -577,7 +577,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ currency: null }, event)
@@ -598,7 +598,7 @@ describe('Memberslist uploading', () => {
         delete membersList.members;
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: membersList
@@ -616,7 +616,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ members: 'test' }, event)
@@ -634,7 +634,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ members: [] }, event)
@@ -652,7 +652,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ members: [
@@ -672,7 +672,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ members: [
@@ -692,7 +692,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ members: [
@@ -712,7 +712,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ members: [
@@ -732,7 +732,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ members: [
@@ -752,7 +752,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ members: [
@@ -772,7 +772,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ members: [
@@ -792,7 +792,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ members: [
@@ -812,7 +812,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ members: [
@@ -832,7 +832,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ members: [
@@ -852,7 +852,7 @@ describe('Memberslist uploading', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ members: [
@@ -878,7 +878,7 @@ describe('Memberslist uploading', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ members: [
@@ -919,7 +919,7 @@ describe('Memberslist uploading', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({}, event)
@@ -943,7 +943,7 @@ describe('Memberslist uploading', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: generator.generateMembersList({ members: [
@@ -971,7 +971,7 @@ describe('Memberslist uploading', () => {
             expect(application.is_on_memberslist).toEqual(false);
 
             const res = await request({
-                uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+                path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: generator.generateMembersList({
@@ -1002,7 +1002,7 @@ describe('Memberslist uploading', () => {
             expect(application.is_on_memberslist).toEqual(false);
 
             const res = await request({
-                uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+                path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: generator.generateMembersList({
@@ -1045,7 +1045,7 @@ describe('Memberslist uploading', () => {
             expect(application.is_on_memberslist).toEqual(true);
 
             const res = await request({
-                uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+                path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: generator.generateMembersList({
@@ -1074,7 +1074,7 @@ describe('Memberslist uploading', () => {
                 application_period_ends: moment().add(1, 'week').toDate()
             });
             const res = await request({
-                uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+                path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: generator.generateMembersList({ currency: 'HU' }, event)
@@ -1097,7 +1097,7 @@ describe('Memberslist uploading', () => {
 
             // EU is BE in the conversion rate API.
             const res = await request({
-                uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+                path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: generator.generateMembersList({ currency: 'EU' }, event)
@@ -1120,7 +1120,7 @@ describe('Memberslist uploading', () => {
 
             // EU is BE in the conversion rate API.
             const res = await request({
-                uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+                path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: generator.generateMembersList({ currency: 'TEST' }, event)
@@ -1143,7 +1143,7 @@ describe('Memberslist uploading', () => {
 
             // EU is BE in the conversion rate API.
             const res = await request({
-                uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+                path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: generator.generateMembersList({ currency: 'HU' }, event)
@@ -1166,7 +1166,7 @@ describe('Memberslist uploading', () => {
 
             // EU is BE in the conversion rate API.
             const res = await request({
-                uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+                path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: generator.generateMembersList({ currency: 'HU' }, event)

--- a/statutory/test/api/memberslists-listing.test.js
+++ b/statutory/test/api/memberslists-listing.test.js
@@ -35,7 +35,7 @@ describe('Memberslist listing', () => {
         await generator.createMembersList({ body_id: regularUser.bodies[0].id }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/',
+            path: '/events/' + event.id + '/memberslists/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -57,7 +57,7 @@ describe('Memberslist listing', () => {
         await generator.createMembersList({ body_id: 1337 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/',
+            path: '/events/' + event.id + '/memberslists/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -85,7 +85,7 @@ describe('Memberslist listing', () => {
         await generator.createMembersList({ body_id: 1337 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/',
+            path: '/events/' + event.id + '/memberslists/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -107,7 +107,7 @@ describe('Memberslist listing', () => {
             application_period_ends: moment().add(1, 'week').toDate()
         });
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/',
+            path: '/events/' + event.id + '/memberslists/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/metrics.test.js
+++ b/statutory/test/api/metrics.test.js
@@ -25,9 +25,9 @@ describe('Metrics requests', () => {
         await generator.createCandidate({ user_id: 3, status: 'approved' }, position);
 
         const res = await request({
-            uri: '/metrics',
+            path: '/metrics',
             method: 'GET',
-            json: false
+            responseType: 'text'
         });
 
         expect(res.statusCode).toEqual(200);
@@ -35,9 +35,9 @@ describe('Metrics requests', () => {
 
     test('should return data correctly on /metrics/requests', async () => {
         const res = await request({
-            uri: '/metrics/requests',
+            path: '/metrics/requests',
             method: 'GET',
-            json: false
+            responseType: 'text'
         });
 
         expect(res.statusCode).toEqual(200);

--- a/statutory/test/api/pax-limits-creation.test.js
+++ b/statutory/test/api/pax-limits-creation.test.js
@@ -24,7 +24,7 @@ describe('Pax limits creation/editing', () => {
     test('should update the limit if exists', async () => {
         const limit = generator.generatePaxLimit();
         const res = await request({
-            uri: '/limits/agora',
+            path: '/limits/agora',
             method: 'POST',
             body: limit,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -41,7 +41,7 @@ describe('Pax limits creation/editing', () => {
         const limit = generator.generatePaxLimit({ body_id: 1, event_type: 'agora' });
 
         const res = await request({
-            uri: '/limits/agora/',
+            path: '/limits/agora/',
             method: 'POST',
             body: limit,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -58,7 +58,7 @@ describe('Pax limits creation/editing', () => {
         const limit = generator.generatePaxLimit({ body_id: 1, event_type: 'agora' });
 
         const res = await request({
-            uri: '/limits/agora/',
+            path: '/limits/agora/',
             method: 'POST',
             body: limit,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -74,7 +74,7 @@ describe('Pax limits creation/editing', () => {
         const limit = generator.generatePaxLimit();
 
         const res = await request({
-            uri: '/limits/invalid/',
+            path: '/limits/invalid/',
             method: 'POST',
             body: limit,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -91,7 +91,7 @@ describe('Pax limits creation/editing', () => {
         const limit = generator.generatePaxLimit();
 
         const res = await request({
-            uri: '/limits/agora/',
+            path: '/limits/agora/',
             method: 'POST',
             body: limit,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -107,7 +107,7 @@ describe('Pax limits creation/editing', () => {
         const limit = generator.generatePaxLimit({ envoy: false });
 
         const res = await request({
-            uri: '/limits/agora/',
+            path: '/limits/agora/',
             method: 'POST',
             body: limit,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -124,7 +124,7 @@ describe('Pax limits creation/editing', () => {
         const limit = generator.generatePaxLimit({ envoy: -1 });
 
         const res = await request({
-            uri: '/limits/agora/',
+            path: '/limits/agora/',
             method: 'POST',
             body: limit,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -141,7 +141,7 @@ describe('Pax limits creation/editing', () => {
         const limit = generator.generatePaxLimit({ envoy: null });
 
         const res = await request({
-            uri: '/limits/agora/',
+            path: '/limits/agora/',
             method: 'POST',
             body: limit,
             headers: { 'X-Auth-Token': 'blablabla' }

--- a/statutory/test/api/pax-limits-default.test.js
+++ b/statutory/test/api/pax-limits-default.test.js
@@ -24,7 +24,7 @@ describe('Pax limits defaults', () => {
 
     test('should display default limits', async () => {
         const res = await request({
-            uri: '/limits/agora/defaults',
+            path: '/limits/agora/defaults',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -41,7 +41,7 @@ describe('Pax limits defaults', () => {
 
     test('should return 404 if defaults receives a body id', async () => {
         const res = await request({
-            uri: '/limits/agora/defaults/' + bodies[0].id,
+            path: '/limits/agora/defaults/' + bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -54,7 +54,7 @@ describe('Pax limits defaults', () => {
 
     test('should return 400 if the event type is invalid', async () => {
         const res = await request({
-            uri: '/limits/invalid/defaults',
+            path: '/limits/invalid/defaults',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -68,7 +68,7 @@ describe('Pax limits defaults', () => {
     test('should return an error if the default request returns net error', async () => {
         mock.mockAll({ bodies: { netError: true } });
         const res = await request({
-            uri: '/limits/agora/defaults',
+            path: '/limits/agora/defaults',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -82,7 +82,7 @@ describe('Pax limits defaults', () => {
     test('should return an error if the default request returns malformed response', async () => {
         mock.mockAll({ bodies: { badResponse: true } });
         const res = await request({
-            uri: '/limits/agora/defaults',
+            path: '/limits/agora/defaults',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -96,7 +96,7 @@ describe('Pax limits defaults', () => {
     test('should return an error if the default request returns unsuccessful response', async () => {
         mock.mockAll({ bodies: { unsuccessfulResponse: true } });
         const res = await request({
-            uri: '/limits/agora/defaults',
+            path: '/limits/agora/defaults',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/pax-limits-listing.test.js
+++ b/statutory/test/api/pax-limits-listing.test.js
@@ -24,7 +24,7 @@ describe('Pax limits listing', () => {
 
     test('should display limits', async () => {
         const res = await request({
-            uri: '/limits/agora',
+            path: '/limits/agora',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -45,7 +45,7 @@ describe('Pax limits listing', () => {
         }
 
         const res = await request({
-            uri: '/limits/agora',
+            path: '/limits/agora',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -62,7 +62,7 @@ describe('Pax limits listing', () => {
 
     test('should return 400 if the event type is invalid', async () => {
         const res = await request({
-            uri: '/limits/invalid',
+            path: '/limits/invalid',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -76,7 +76,7 @@ describe('Pax limits listing', () => {
     test('should return an error if the bodies request returns net error', async () => {
         mock.mockAll({ bodies: { netError: true } });
         const res = await request({
-            uri: '/limits/agora',
+            path: '/limits/agora',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -90,7 +90,7 @@ describe('Pax limits listing', () => {
     test('should return an error if the bodies request returns malformed response', async () => {
         mock.mockAll({ bodies: { badResponse: true } });
         const res = await request({
-            uri: '/limits/agora',
+            path: '/limits/agora',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -104,7 +104,7 @@ describe('Pax limits listing', () => {
     test('should return an error if the bodies request returns unsuccessful response', async () => {
         mock.mockAll({ bodies: { unsuccessfulResponse: true } });
         const res = await request({
-            uri: '/limits/agora',
+            path: '/limits/agora',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/pax-limits-single.test.js
+++ b/statutory/test/api/pax-limits-single.test.js
@@ -24,7 +24,7 @@ describe('Pax limits single', () => {
 
     test('should display limit', async () => {
         const res = await request({
-            uri: '/limits/agora/' + bodies[0].id,
+            path: '/limits/agora/' + bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -41,7 +41,7 @@ describe('Pax limits single', () => {
         await generator.createPaxLimit({ body_id: bodies[0].id, event_type: 'agora' });
 
         const res = await request({
-            uri: '/limits/agora/' + bodies[0].id,
+            path: '/limits/agora/' + bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -56,7 +56,7 @@ describe('Pax limits single', () => {
 
     test('should return 400 if the event type is invalid', async () => {
         const res = await request({
-            uri: '/limits/invalid/' + bodies[0].id,
+            path: '/limits/invalid/' + bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -70,7 +70,7 @@ describe('Pax limits single', () => {
     test('should return an error if the bodies request returns net error', async () => {
         mock.mockAll({ body: { netError: true } });
         const res = await request({
-            uri: '/limits/agora/' + bodies[0].id,
+            path: '/limits/agora/' + bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -84,7 +84,7 @@ describe('Pax limits single', () => {
     test('should return an error if the bodies request returns malformed response', async () => {
         mock.mockAll({ body: { badResponse: true } });
         const res = await request({
-            uri: '/limits/agora/' + bodies[0].id,
+            path: '/limits/agora/' + bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -98,7 +98,7 @@ describe('Pax limits single', () => {
     test('should return an error if the bodies request returns unsuccessful response', async () => {
         mock.mockAll({ body: { unsuccessfulResponse: true } });
         const res = await request({
-            uri: '/limits/agora/' + bodies[0].id,
+            path: '/limits/agora/' + bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/pax_limits-deletion.test.js
+++ b/statutory/test/api/pax_limits-deletion.test.js
@@ -26,7 +26,7 @@ describe('Pax limits deletion', () => {
         await generator.createPaxLimit({ body_id: bodies[0].id, event_type: 'agora' });
 
         const res = await request({
-            uri: '/limits/agora/' + bodies[0].id,
+            path: '/limits/agora/' + bodies[0].id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -39,7 +39,7 @@ describe('Pax limits deletion', () => {
 
     test('should not allow deleting limit when there\'s no limit', async () => {
         const res = await request({
-            uri: '/limits/agora/1337',
+            path: '/limits/agora/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -53,7 +53,7 @@ describe('Pax limits deletion', () => {
         await generator.createPaxLimit({ body_id: bodies[0].id, event_type: 'agora' });
 
         const res = await request({
-            uri: '/limits/invalid/' + bodies[0].id,
+            path: '/limits/invalid/' + bodies[0].id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -66,7 +66,7 @@ describe('Pax limits deletion', () => {
 
     test('should return 400 if the body_id is invalid', async () => {
         const res = await request({
-            uri: '/limits/agora/invalid',
+            path: '/limits/agora/invalid',
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -82,7 +82,7 @@ describe('Pax limits deletion', () => {
         await generator.createPaxLimit({ body_id: bodies[0].id, event_type: 'agora' });
 
         const res = await request({
-            uri: '/limits/agora/' + bodies[0].id,
+            path: '/limits/agora/' + bodies[0].id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/plenaries-creation.test.js
+++ b/statutory/test/api/plenaries-creation.test.js
@@ -28,7 +28,7 @@ describe('Plenaries creation', () => {
         const plenary = generator.generatePlenary({ starts: null });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/',
+            path: '/events/' + event.id + '/plenaries/',
             method: 'POST',
             body: plenary,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -46,7 +46,7 @@ describe('Plenaries creation', () => {
         const plenary = generator.generatePlenary({ ends: null });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/',
+            path: '/events/' + event.id + '/plenaries/',
             method: 'POST',
             body: plenary,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -67,7 +67,7 @@ describe('Plenaries creation', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/',
+            path: '/events/' + event.id + '/plenaries/',
             method: 'POST',
             body: plenary,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -87,7 +87,7 @@ describe('Plenaries creation', () => {
         const plenary = generator.generatePlenary({});
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/',
+            path: '/events/' + event.id + '/plenaries/',
             method: 'POST',
             body: plenary,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -104,7 +104,7 @@ describe('Plenaries creation', () => {
         const plenary = generator.generatePlenary({});
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/',
+            path: '/events/' + event.id + '/plenaries/',
             method: 'POST',
             body: plenary,
             headers: { 'X-Auth-Token': 'blablabla' }

--- a/statutory/test/api/plenaries-edition.test.js
+++ b/statutory/test/api/plenaries-edition.test.js
@@ -28,7 +28,7 @@ describe('Plenaries edition', () => {
         const plenary = await generator.createPlenary({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id,
+            path: '/events/' + event.id + '/plenaries/' + plenary.id,
             method: 'PUT',
             body: { name: 'test' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -46,7 +46,7 @@ describe('Plenaries edition', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/1337',
+            path: '/events/' + event.id + '/plenaries/1337',
             method: 'PUT',
             body: { name: 'test' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -63,7 +63,7 @@ describe('Plenaries edition', () => {
         await generator.createPlenary({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/NaN',
+            path: '/events/' + event.id + '/plenaries/NaN',
             method: 'PUT',
             body: { name: 'test' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -80,7 +80,7 @@ describe('Plenaries edition', () => {
         const plenary = await generator.createPlenary({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id,
+            path: '/events/' + event.id + '/plenaries/' + plenary.id,
             method: 'PUT',
             body: { name: 'test' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -98,7 +98,7 @@ describe('Plenaries edition', () => {
         const plenary = await generator.createPlenary({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id,
+            path: '/events/' + event.id + '/plenaries/' + plenary.id,
             method: 'PUT',
             body: { starts: null },
             headers: { 'X-Auth-Token': 'blablabla' }

--- a/statutory/test/api/plenaries-export-stats.test.js
+++ b/statutory/test/api/plenaries-export-stats.test.js
@@ -31,7 +31,7 @@ describe('Plenaries exports', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/stats',
+            path: '/events/' + event.id + '/plenaries/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -61,10 +61,9 @@ describe('Plenaries exports', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/stats',
+            path: '/events/' + event.id + '/plenaries/stats',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 
@@ -88,10 +87,9 @@ describe('Plenaries exports', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/stats',
+            path: '/events/' + event.id + '/plenaries/stats',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 
@@ -141,10 +139,9 @@ describe('Plenaries exports', () => {
         }, plenary);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/stats',
+            path: '/events/' + event.id + '/plenaries/stats',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 
@@ -190,10 +187,9 @@ describe('Plenaries exports', () => {
         }, plenary);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/stats',
+            path: '/events/' + event.id + '/plenaries/stats',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 
@@ -229,10 +225,9 @@ describe('Plenaries exports', () => {
         }, plenary);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/stats',
+            path: '/events/' + event.id + '/plenaries/stats',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 
@@ -298,10 +293,9 @@ describe('Plenaries exports', () => {
         // total: 1 + 3 + 1 = 5 minutes
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/stats',
+            path: '/events/' + event.id + '/plenaries/stats',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 
@@ -364,10 +358,9 @@ describe('Plenaries exports', () => {
         // total: 66.67%
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/stats',
+            path: '/events/' + event.id + '/plenaries/stats',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 
@@ -457,10 +450,9 @@ describe('Plenaries exports', () => {
         }, thirdPlenary);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/stats',
+            path: '/events/' + event.id + '/plenaries/stats',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 
@@ -492,10 +484,9 @@ describe('Plenaries exports', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/stats',
+            path: '/events/' + event.id + '/plenaries/stats',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 
@@ -516,10 +507,9 @@ describe('Plenaries exports', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/stats',
+            path: '/events/' + event.id + '/plenaries/stats',
             method: 'GET',
-            json: false,
-            encoding: null, // make response body to Buffer.
+            responseType: 'buffer', // make response body to Buffer.
             headers: { 'X-Auth-Token': 'blablabla' }
         });
 

--- a/statutory/test/api/plenaries-list.test.js
+++ b/statutory/test/api/plenaries-list.test.js
@@ -25,7 +25,7 @@ describe('Plenaries listing', () => {
         const event = await generator.createEvent({ type: 'epm', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/',
+            path: '/events/' + event.id + '/plenaries/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -41,7 +41,7 @@ describe('Plenaries listing', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/',
+            path: '/events/' + event.id + '/plenaries/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -60,7 +60,7 @@ describe('Plenaries listing', () => {
         await generator.createPlenary({}, secondEvent);
 
         const res = await request({
-            uri: '/events/' + firstEvent.id + '/plenaries/',
+            path: '/events/' + firstEvent.id + '/plenaries/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -80,7 +80,7 @@ describe('Plenaries listing', () => {
         const secondPlenary = await generator.createPlenary({}, firstEvent);
 
         const res = await request({
-            uri: '/events/' + firstEvent.id + '/plenaries/',
+            path: '/events/' + firstEvent.id + '/plenaries/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/plenaries-mark-attendance.test.js
+++ b/statutory/test/api/plenaries-mark-attendance.test.js
@@ -29,7 +29,7 @@ describe('Plenary attendance marking', () => {
         const plenary = await generator.createPlenary({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
+            path: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { application_id: 1337 }
@@ -52,7 +52,7 @@ describe('Plenary attendance marking', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
+            path: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { application_id: application.id }
@@ -68,7 +68,7 @@ describe('Plenary attendance marking', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/1337/attendance/mark',
+            path: '/events/' + event.id + '/plenaries/1337/attendance/mark',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { application_id: 1337 }
@@ -84,7 +84,7 @@ describe('Plenary attendance marking', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/NaN/attendance/mark',
+            path: '/events/' + event.id + '/plenaries/NaN/attendance/mark',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { application_id: 1337 }
@@ -101,7 +101,7 @@ describe('Plenary attendance marking', () => {
         const plenary = await generator.createPlenary({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
+            path: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { application_id: 1337 }
@@ -122,7 +122,7 @@ describe('Plenary attendance marking', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
+            path: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { application_id: application.id }
@@ -146,7 +146,7 @@ describe('Plenary attendance marking', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
+            path: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { application_id: application.id }
@@ -167,7 +167,7 @@ describe('Plenary attendance marking', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
+            path: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { application_id: application.id }
@@ -202,7 +202,7 @@ describe('Plenary attendance marking', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
+            path: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { application_id: application.id }
@@ -237,7 +237,7 @@ describe('Plenary attendance marking', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
+            path: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { application_id: application.id }
@@ -274,7 +274,7 @@ describe('Plenary attendance marking', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
+            path: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { application_id: application.id }
@@ -296,7 +296,7 @@ describe('Plenary attendance marking', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
+            path: '/events/' + event.id + '/plenaries/' + plenary.id + '/attendance/mark',
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: { application_id: application.statutory_id }

--- a/statutory/test/api/plenaries-single.test.js
+++ b/statutory/test/api/plenaries-single.test.js
@@ -28,7 +28,7 @@ describe('Plenaries displaying', () => {
         const plenary = await generator.createPlenary({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id,
+            path: '/events/' + event.id + '/plenaries/' + plenary.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -46,7 +46,7 @@ describe('Plenaries displaying', () => {
         mock.mockAll({ mainPermissions: { noPermissions: true } });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id,
+            path: '/events/' + event.id + '/plenaries/' + plenary.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -61,7 +61,7 @@ describe('Plenaries displaying', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/1337',
+            path: '/events/' + event.id + '/plenaries/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -76,7 +76,7 @@ describe('Plenaries displaying', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/NaN',
+            path: '/events/' + event.id + '/plenaries/NaN',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -92,7 +92,7 @@ describe('Plenaries displaying', () => {
         const plenary = await generator.createPlenary({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id,
+            path: '/events/' + event.id + '/plenaries/' + plenary.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -117,7 +117,7 @@ describe('Plenaries displaying', () => {
         const thirdAttendance = await generator.createAttendance({ starts: moment().add(3, 'day').toDate(), application_id: secondApplication.id }, plenary);
 
         const res = await request({
-            uri: '/events/' + event.id + '/plenaries/' + plenary.id,
+            path: '/events/' + event.id + '/plenaries/' + plenary.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/positions-creation.test.js
+++ b/statutory/test/api/positions-creation.test.js
@@ -28,7 +28,7 @@ describe('Positions creation', () => {
         const position = generator.generatePosition({ ends: null });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/',
+            path: '/events/' + event.id + '/positions/',
             method: 'POST',
             body: position,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -46,7 +46,7 @@ describe('Positions creation', () => {
         const position = generator.generatePosition({ places: 'string' });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/',
+            path: '/events/' + event.id + '/positions/',
             method: 'POST',
             body: position,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -64,7 +64,7 @@ describe('Positions creation', () => {
         const position = generator.generatePosition({ places: -1 });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/',
+            path: '/events/' + event.id + '/positions/',
             method: 'POST',
             body: position,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -82,7 +82,7 @@ describe('Positions creation', () => {
         const position = generator.generatePosition({ name: null });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/',
+            path: '/events/' + event.id + '/positions/',
             method: 'POST',
             body: position,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -103,7 +103,7 @@ describe('Positions creation', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/',
+            path: '/events/' + event.id + '/positions/',
             method: 'POST',
             body: position,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -123,7 +123,7 @@ describe('Positions creation', () => {
         const position = generator.generatePosition({});
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/',
+            path: '/events/' + event.id + '/positions/',
             method: 'POST',
             body: position,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -140,7 +140,7 @@ describe('Positions creation', () => {
         const position = generator.generatePosition({});
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/',
+            path: '/events/' + event.id + '/positions/',
             method: 'POST',
             body: position,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -164,7 +164,7 @@ describe('Positions creation', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/',
+            path: '/events/' + event.id + '/positions/',
             method: 'POST',
             body: position,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -188,7 +188,7 @@ describe('Positions creation', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/',
+            path: '/events/' + event.id + '/positions/',
             method: 'POST',
             body: position,
             headers: { 'X-Auth-Token': 'blablabla' }

--- a/statutory/test/api/positions-deletion.test.js
+++ b/statutory/test/api/positions-deletion.test.js
@@ -28,7 +28,7 @@ describe('Positions deletion', () => {
         const position = await generator.createPosition({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id,
+            path: '/events/' + event.id + '/positions/' + position.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -45,7 +45,7 @@ describe('Positions deletion', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/1337',
+            path: '/events/' + event.id + '/positions/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -61,7 +61,7 @@ describe('Positions deletion', () => {
         await generator.createPosition({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/NaN',
+            path: '/events/' + event.id + '/positions/NaN',
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -77,7 +77,7 @@ describe('Positions deletion', () => {
         const position = await generator.createPosition({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id,
+            path: '/events/' + event.id + '/positions/' + position.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/positions-edition.test.js
+++ b/statutory/test/api/positions-edition.test.js
@@ -30,7 +30,7 @@ describe('Positions edition', () => {
         const position = await generator.createPosition({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id,
+            path: '/events/' + event.id + '/positions/' + position.id,
             method: 'PUT',
             body: { places: 3 },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -48,7 +48,7 @@ describe('Positions edition', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/1337',
+            path: '/events/' + event.id + '/positions/1337',
             method: 'PUT',
             body: { places: 3 },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -65,7 +65,7 @@ describe('Positions edition', () => {
         await generator.createPosition({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/NaN',
+            path: '/events/' + event.id + '/positions/NaN',
             method: 'PUT',
             body: { places: 3 },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -82,7 +82,7 @@ describe('Positions edition', () => {
         const position = await generator.createPosition({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id,
+            path: '/events/' + event.id + '/positions/' + position.id,
             method: 'PUT',
             body: { places: 3 },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -100,7 +100,7 @@ describe('Positions edition', () => {
         const position = await generator.createPosition({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id,
+            path: '/events/' + event.id + '/positions/' + position.id,
             method: 'PUT',
             body: { places: false },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -121,7 +121,7 @@ describe('Positions edition', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id,
+            path: '/events/' + event.id + '/positions/' + position.id,
             method: 'PUT',
             body: {
                 id: position.id + 1,

--- a/statutory/test/api/positions-list.test.js
+++ b/statutory/test/api/positions-list.test.js
@@ -27,7 +27,7 @@ describe('Positions listing', () => {
         await generator.createPosition({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/',
+            path: '/events/' + event.id + '/positions/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -46,7 +46,7 @@ describe('Positions listing', () => {
         await generator.createPosition({}, secondEvent);
 
         const res = await request({
-            uri: '/events/' + firstEvent.id + '/positions/',
+            path: '/events/' + firstEvent.id + '/positions/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -66,7 +66,7 @@ describe('Positions listing', () => {
         const secondPosition = await generator.createPosition({}, firstEvent);
 
         const res = await request({
-            uri: '/events/' + firstEvent.id + '/positions/',
+            path: '/events/' + firstEvent.id + '/positions/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -88,7 +88,7 @@ describe('Positions listing', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/approved',
+            path: '/events/' + event.id + '/positions/approved',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -113,7 +113,7 @@ describe('Positions listing', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/approved',
+            path: '/events/' + event.id + '/positions/approved',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -136,7 +136,7 @@ describe('Positions listing', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/approved',
+            path: '/events/' + event.id + '/positions/approved',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -155,7 +155,7 @@ describe('Positions listing', () => {
         const secondPosition = await generator.createPosition({}, firstEvent);
 
         const res = await request({
-            uri: '/events/' + firstEvent.id + '/positions/approved',
+            path: '/events/' + firstEvent.id + '/positions/approved',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -177,7 +177,7 @@ describe('Positions listing', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/all',
+            path: '/events/' + event.id + '/positions/all',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -200,7 +200,7 @@ describe('Positions listing', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/all',
+            path: '/events/' + event.id + '/positions/all',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -226,7 +226,7 @@ describe('Positions listing', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/all',
+            path: '/events/' + event.id + '/positions/all',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -243,7 +243,7 @@ describe('Positions listing', () => {
         const secondPosition = await generator.createPosition({}, firstEvent);
 
         const res = await request({
-            uri: '/events/' + firstEvent.id + '/positions/all',
+            path: '/events/' + firstEvent.id + '/positions/all',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -269,7 +269,7 @@ describe('Positions listing', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/candidates/mine',
+            path: '/events/' + event.id + '/positions/candidates/mine',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -289,7 +289,7 @@ describe('Positions listing', () => {
         const thirdCandidate = await generator.createCandidate({ user_id: 3 }, position);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/all',
+            path: '/events/' + event.id + '/positions/all',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -315,7 +315,7 @@ describe('Positions listing', () => {
         const thirdCandidate = await generator.createCandidate({ user_id: 3, status: 'approved' }, position);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/approved',
+            path: '/events/' + event.id + '/positions/approved',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/positions-status.test.js
+++ b/statutory/test/api/positions-status.test.js
@@ -33,7 +33,7 @@ describe('Positions status update', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/status',
+            path: '/events/' + event.id + '/positions/' + position.id + '/status',
             method: 'PUT',
             body: { status: 'closed' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -51,7 +51,7 @@ describe('Positions status update', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/1337/status',
+            path: '/events/' + event.id + '/positions/1337/status',
             method: 'PUT',
             body: { status: 'closed' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -67,7 +67,7 @@ describe('Positions status update', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/NaN/status',
+            path: '/events/' + event.id + '/positions/NaN/status',
             method: 'PUT',
             body: { status: 'closed' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -87,7 +87,7 @@ describe('Positions status update', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/status',
+            path: '/events/' + event.id + '/positions/' + position.id + '/status',
             method: 'PUT',
             body: { status: 'closed' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -108,7 +108,7 @@ describe('Positions status update', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/status',
+            path: '/events/' + event.id + '/positions/' + position.id + '/status',
             method: 'PUT',
             body: {},
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -129,7 +129,7 @@ describe('Positions status update', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/status',
+            path: '/events/' + event.id + '/positions/' + position.id + '/status',
             method: 'PUT',
             body: { status: false },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -151,7 +151,7 @@ describe('Positions status update', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/positions/' + position.id + '/status',
+            path: '/events/' + event.id + '/positions/' + position.id + '/status',
             method: 'PUT',
             body: {
                 places: 5

--- a/statutory/test/api/question-lines-creation.test.js
+++ b/statutory/test/api/question-lines-creation.test.js
@@ -26,7 +26,7 @@ describe('Question line creation', () => {
         const questionLine = generator.generateQuestionLine({ name: null });
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/',
+            path: '/events/' + event.id + '/question-lines/',
             method: 'POST',
             body: questionLine,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -46,7 +46,7 @@ describe('Question line creation', () => {
         const questionLine = generator.generateQuestionLine({});
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/',
+            path: '/events/' + event.id + '/question-lines/',
             method: 'POST',
             body: questionLine,
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -63,7 +63,7 @@ describe('Question line creation', () => {
         const questionLine = generator.generateQuestionLine({});
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/',
+            path: '/events/' + event.id + '/question-lines/',
             method: 'POST',
             body: questionLine,
             headers: { 'X-Auth-Token': 'blablabla' }

--- a/statutory/test/api/question-lines-deletion.test.js
+++ b/statutory/test/api/question-lines-deletion.test.js
@@ -29,7 +29,7 @@ describe('Question line deletion', () => {
         const questionLine = await generator.createQuestionLine({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id,
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -46,7 +46,7 @@ describe('Question line deletion', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/1337',
+            path: '/events/' + event.id + '/question-lines/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -62,7 +62,7 @@ describe('Question line deletion', () => {
         await generator.createQuestionLine({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/NaN',
+            path: '/events/' + event.id + '/question-lines/NaN',
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -83,7 +83,7 @@ describe('Question line deletion', () => {
         await generator.createQuestion({ application_id: application.id }, otherQuestionLine);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id,
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/question-lines-edition.test.js
+++ b/statutory/test/api/question-lines-edition.test.js
@@ -28,7 +28,7 @@ describe('Question line edition', () => {
         const questionLine = await generator.createQuestionLine({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id,
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id,
             method: 'PUT',
             body: { name: 'test' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -46,7 +46,7 @@ describe('Question line edition', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/1337',
+            path: '/events/' + event.id + '/question-lines/1337',
             method: 'PUT',
             body: { name: 'test' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -63,7 +63,7 @@ describe('Question line edition', () => {
         await generator.createQuestionLine({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/NaN',
+            path: '/events/' + event.id + '/question-lines/NaN',
             method: 'PUT',
             body: { name: 'test' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -80,7 +80,7 @@ describe('Question line edition', () => {
         const questionLine = await generator.createQuestionLine({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id,
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id,
             method: 'PUT',
             body: { name: 'test' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -98,7 +98,7 @@ describe('Question line edition', () => {
         const questionLine = await generator.createQuestionLine({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id,
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id,
             method: 'PUT',
             body: { name: null },
             headers: { 'X-Auth-Token': 'blablabla' }

--- a/statutory/test/api/question-lines-listing.test.js
+++ b/statutory/test/api/question-lines-listing.test.js
@@ -30,7 +30,7 @@ describe('Question lines listing', () => {
         await generator.createQuestionLine({}, secondEvent);
 
         const res = await request({
-            uri: '/events/' + firstEvent.id + '/question-lines/',
+            path: '/events/' + firstEvent.id + '/question-lines/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -50,7 +50,7 @@ describe('Question lines listing', () => {
         const secondQuestionLine = await generator.createQuestionLine({}, firstEvent);
 
         const res = await request({
-            uri: '/events/' + firstEvent.id + '/question-lines/',
+            path: '/events/' + firstEvent.id + '/question-lines/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -81,7 +81,7 @@ describe('Question lines listing', () => {
         }, firstEvent);
 
         const res = await request({
-            uri: '/events/' + firstEvent.id + '/question-lines/',
+            path: '/events/' + firstEvent.id + '/question-lines/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -102,7 +102,7 @@ describe('Question lines listing', () => {
         await generator.createQuestionLine({}, secondEvent);
 
         const res = await request({
-            uri: '/events/' + firstEvent.id + '/question-lines/',
+            path: '/events/' + firstEvent.id + '/question-lines/',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/question-lines-status.test.js
+++ b/statutory/test/api/question-lines-status.test.js
@@ -28,7 +28,7 @@ describe('Question lines status update', () => {
         const questionLine = await generator.createQuestionLine({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/status',
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/status',
             method: 'PUT',
             body: { status: 'closed' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -46,7 +46,7 @@ describe('Question lines status update', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/1337/status',
+            path: '/events/' + event.id + '/question-lines/1337/status',
             method: 'PUT',
             body: { status: 'closed' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -62,7 +62,7 @@ describe('Question lines status update', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/NaN/status',
+            path: '/events/' + event.id + '/question-lines/NaN/status',
             method: 'PUT',
             body: { status: 'closed' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -81,7 +81,7 @@ describe('Question lines status update', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/status',
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/status',
             method: 'PUT',
             body: { status: 'closed' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -101,7 +101,7 @@ describe('Question lines status update', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/status',
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/status',
             method: 'PUT',
             body: {},
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -121,7 +121,7 @@ describe('Question lines status update', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/status',
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/status',
             method: 'PUT',
             body: { status: false },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -141,7 +141,7 @@ describe('Question lines status update', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/status',
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/status',
             method: 'PUT',
             body: {
                 name: 'test new'

--- a/statutory/test/api/questions-creation.test.js
+++ b/statutory/test/api/questions-creation.test.js
@@ -31,7 +31,7 @@ describe('Questions creation', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions',
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions',
             method: 'POST',
             body: { text: 'test' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -50,7 +50,7 @@ describe('Questions creation', () => {
         const questionLine = await generator.createQuestionLine({ status: 'open' }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions',
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions',
             method: 'POST',
             body: { text: 'test' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -71,7 +71,7 @@ describe('Questions creation', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions',
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions',
             method: 'POST',
             body: { text: 'test' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -89,7 +89,7 @@ describe('Questions creation', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/1337/questions',
+            path: '/events/' + event.id + '/question-lines/1337/questions',
             method: 'POST',
             body: { text: 'test' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -107,7 +107,7 @@ describe('Questions creation', () => {
         const event = await generator.createEvent({ type: 'agora', applications: [] });
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/false/questions',
+            path: '/events/' + event.id + '/question-lines/false/questions',
             method: 'POST',
             body: { text: 'test' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -130,7 +130,7 @@ describe('Questions creation', () => {
         }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions',
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions',
             method: 'POST',
             body: { text: null },
             headers: { 'X-Auth-Token': 'blablabla' }

--- a/statutory/test/api/questions-deleting.test.js
+++ b/statutory/test/api/questions-deleting.test.js
@@ -29,7 +29,7 @@ describe('Questions deleting', () => {
         const questionLine = await generator.createQuestionLine({ status: 'open' }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/1337',
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/1337',
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -47,7 +47,7 @@ describe('Questions deleting', () => {
         const questionLine = await generator.createQuestionLine({ status: 'open' }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/false',
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/false',
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -71,7 +71,7 @@ describe('Questions deleting', () => {
         const question = await generator.createQuestion({ application_id: application.id }, questionLine);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -92,7 +92,7 @@ describe('Questions deleting', () => {
         const question = await generator.createQuestion({ application_id: application.id }, questionLine);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -116,7 +116,7 @@ describe('Questions deleting', () => {
         const question = await generator.createQuestion({ application_id: application.id }, questionLine);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
             method: 'DELETE',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/questions-displaying.test.js
+++ b/statutory/test/api/questions-displaying.test.js
@@ -29,7 +29,7 @@ describe('Questions displaying', () => {
         const questionLine = await generator.createQuestionLine({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/1337',
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/1337',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -47,7 +47,7 @@ describe('Questions displaying', () => {
         const questionLine = await generator.createQuestionLine({}, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/false',
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/false',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -69,7 +69,7 @@ describe('Questions displaying', () => {
         const question = await generator.createQuestion({ application_id: application.id }, questionLine);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -93,7 +93,7 @@ describe('Questions displaying', () => {
         const question = await generator.createQuestion({ application_id: application.id }, questionLine);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -117,7 +117,7 @@ describe('Questions displaying', () => {
         const question = await generator.createQuestion({ application_id: application.id }, questionLine);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/questions-editing.test.js
+++ b/statutory/test/api/questions-editing.test.js
@@ -35,7 +35,7 @@ describe('Questions editing', () => {
         const question = await generator.createQuestion({ application_id: application.id }, questionLine);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
             method: 'PUT',
             body: { first_name: 'Different' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -54,7 +54,7 @@ describe('Questions editing', () => {
         const questionLine = await generator.createQuestionLine({ status: 'open' }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/1337',
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/1337',
             method: 'PUT',
             body: { first_name: 'Different' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -73,7 +73,7 @@ describe('Questions editing', () => {
         const questionLine = await generator.createQuestionLine({ status: 'open' }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/false',
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/false',
             method: 'PUT',
             body: { text: 'new' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -98,7 +98,7 @@ describe('Questions editing', () => {
         const question = await generator.createQuestion({ application_id: application.id }, questionLine);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
             method: 'PUT',
             body: { text: 'test' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -120,7 +120,7 @@ describe('Questions editing', () => {
         const question = await generator.createQuestion({ application_id: application.id }, questionLine);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
             method: 'PUT',
             body: { text: 'Different' },
             headers: { 'X-Auth-Token': 'blablabla' }
@@ -145,7 +145,7 @@ describe('Questions editing', () => {
         const question = await generator.createQuestion({ application_id: application.id }, questionLine);
 
         const res = await request({
-            uri: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
+            path: '/events/' + event.id + '/question-lines/' + questionLine.id + '/questions/' + question.id,
             method: 'PUT',
             body: { first_name: 'Different' },
             headers: { 'X-Auth-Token': 'blablabla' }

--- a/statutory/test/api/statistics.test.js
+++ b/statutory/test/api/statistics.test.js
@@ -30,7 +30,7 @@ describe('Statistics testing', () => {
 
     test('should return nothing if no applications', async () => {
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -48,7 +48,7 @@ describe('Statistics testing', () => {
     test('should return nothing if all applications are cancelled', async () => {
         await generator.createApplication({ cancelled: true }, event);
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -71,7 +71,7 @@ describe('Statistics testing', () => {
         const secondPax = await generator.createApplication({ user_id: 2, participant_order: 2 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -93,7 +93,7 @@ describe('Statistics testing', () => {
         const secondPax = await generator.createApplication({ user_id: 2, participant_order: 2 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -113,7 +113,7 @@ describe('Statistics testing', () => {
         await generator.createApplication({ user_id: 3, body_id: 2, participant_order: 2 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -133,7 +133,7 @@ describe('Statistics testing', () => {
         await generator.createApplication({ user_id: 3, participant_type: 'visitor', participant_order: 2 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -153,7 +153,7 @@ describe('Statistics testing', () => {
         await generator.createApplication({ user_id: 3, gender: 'female' }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -173,7 +173,7 @@ describe('Statistics testing', () => {
         await generator.createApplication({ user_id: 3, meals: 'Vegetarian' }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -195,7 +195,7 @@ describe('Statistics testing', () => {
         await generator.createApplication({ user_id: 3, number_of_events_visited: 1 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -218,7 +218,7 @@ describe('Statistics testing', () => {
         await generator.createApplication({ user_id: 6, body_id: 3, participant_type: null, participant_order: null }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -243,7 +243,7 @@ describe('Statistics testing', () => {
         await generator.createApplication({ user_id: 6, gender: 'female' }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -268,7 +268,7 @@ describe('Statistics testing', () => {
         await generator.createApplication({ user_id: 6, participant_type: 'visitor', participant_order: 5 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -290,7 +290,7 @@ describe('Statistics testing', () => {
         await generator.createApplication({ user_id: 3, number_of_events_visited: 2 }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -327,7 +327,7 @@ describe('Statistics testing', () => {
         await generator.createApplication({ user_id: 10, status: 'accepted', cancelled: true }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -360,7 +360,7 @@ describe('Statistics testing', () => {
         await generator.createApplication({ user_id: 10, status: 'accepted', cancelled: true }, event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -390,7 +390,7 @@ describe('Statistics testing', () => {
         await event.update({ application_status_revealed_at: new Date() });
 
         const res = await request({
-            uri: '/events/' + event.id + '/applications/stats',
+            path: '/events/' + event.id + '/applications/stats',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/votes-amounts-listing.test.js
+++ b/statutory/test/api/votes-amounts-listing.test.js
@@ -35,7 +35,7 @@ describe('Votes amounts listing', () => {
         await VotesPerAntenna.recalculateVotesForAntenna(regularUser.bodies[0], event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/votes-amounts/antenna',
+            path: '/events/' + event.id + '/votes-amounts/antenna',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -69,7 +69,7 @@ describe('Votes amounts listing', () => {
         await VotesPerAntenna.recalculateVotesForAntenna(regularUser.bodies[0], event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/votes-amounts/delegate',
+            path: '/events/' + event.id + '/votes-amounts/delegate',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -109,7 +109,7 @@ describe('Votes amounts listing', () => {
         await VotesPerAntenna.recalculateVotesForAntenna(regularUser.bodies[0], event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/votes-amounts/nan',
+            path: '/events/' + event.id + '/votes-amounts/nan',
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });
@@ -140,7 +140,7 @@ describe('Votes amounts listing', () => {
         await VotesPerAntenna.recalculateVotesForAntenna(regularUser.bodies[0], event);
 
         const res = await request({
-            uri: '/events/' + event.id + '/votes-amounts/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/votes-amounts/' + regularUser.bodies[0].id,
             method: 'GET',
             headers: { 'X-Auth-Token': 'blablabla' }
         });

--- a/statutory/test/api/votes-per-antenna-calculation.test.js
+++ b/statutory/test/api/votes-per-antenna-calculation.test.js
@@ -65,7 +65,7 @@ describe('Votes per antenna calculation', () => {
             });
 
             const res = await request({
-                uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+                path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: memberslist
@@ -102,7 +102,7 @@ describe('Votes per antenna calculation', () => {
             });
 
             const res = await request({
-                uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+                path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: memberslist
@@ -137,7 +137,7 @@ describe('Votes per antenna calculation', () => {
         });
 
         const res = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: memberslist
@@ -164,7 +164,7 @@ describe('Votes per antenna calculation', () => {
 
         // to recalculate votes amount for antenna
         const secondRes = await request({
-            uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+            path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
             method: 'POST',
             headers: { 'X-Auth-Token': 'blablabla' },
             body: memberslist

--- a/statutory/test/api/votes-recalculation.test.js
+++ b/statutory/test/api/votes-recalculation.test.js
@@ -67,7 +67,7 @@ describe('Votes per antenna/delegate recalculation', () => {
 
             // to recalculate votes amount for antenna
             const res = await request({
-                uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+                path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: memberslist
@@ -107,7 +107,7 @@ describe('Votes per antenna/delegate recalculation', () => {
             expect(votesInDb[0].votes).toEqual(5);
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/' + application.id + '/registered',
+                path: '/events/' + event.id + '/applications/' + application.id + '/registered',
                 method: 'PUT',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: { registered: true }
@@ -153,7 +153,7 @@ describe('Votes per antenna/delegate recalculation', () => {
             expect(votesInDb.length).toEqual(2);
 
             const res = await request({
-                uri: '/events/' + event.id + '/applications/' + application.id + '/departed',
+                path: '/events/' + event.id + '/applications/' + application.id + '/departed',
                 method: 'PUT',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: { departed: true }
@@ -208,7 +208,7 @@ describe('Votes per antenna/delegate recalculation', () => {
 
             // to recalculate votes amount for antenna
             const res = await request({
-                uri: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
+                path: '/events/' + event.id + '/memberslists/' + regularUser.bodies[0].id,
                 method: 'POST',
                 headers: { 'X-Auth-Token': 'blablabla' },
                 body: memberslist

--- a/statutory/test/scripts/helpers.js
+++ b/statutory/test/scripts/helpers.js
@@ -25,28 +25,21 @@ const appendQuery = (url, query) => {
 };
 
 const request = async (options) => {
-    const parseJson = options.json !== false;
+    const responseType = options.responseType || 'json';
     const headers = { ...(options.headers || {}) };
     const fetchOptions = { method: options.method || 'GET', headers };
 
     if (options.body !== undefined) {
-        if (parseJson) {
-            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
-            fetchOptions.body = JSON.stringify(options.body);
-        } else {
-            fetchOptions.body = options.body;
-        }
+        headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+        fetchOptions.body = JSON.stringify(options.body);
     }
 
-    if (options.formData) {
-        const entries = Object.entries(options.formData);
+    if (options.files) {
+        const entries = Object.entries(options.files);
         const formData = new FormData();
         for (const [key, item] of entries) {
-            const value = item && item.value ? item.value : item;
-            const filename = item && item.options && item.options.filename
-                ? item.options.filename
-                : path.basename(value.path);
-            const buffer = fs.readFileSync(value.path);
+            const filename = item.filename || path.basename(item.path);
+            const buffer = fs.readFileSync(item.path);
             formData.append(key, new Blob([buffer]), filename);
         }
         if (entries.length > 0) {
@@ -57,8 +50,8 @@ const request = async (options) => {
         }
     }
 
-    const response = await fetch(appendQuery(new URL(options.uri, baseUrl + '/').toString(), options.qs), fetchOptions);
-    if (options.encoding === null) {
+    const response = await fetch(appendQuery(new URL(options.path, baseUrl + '/').toString(), options.query), fetchOptions);
+    if (responseType === 'buffer') {
         return {
             statusCode: response.status,
             statusMessage: response.statusText,
@@ -70,7 +63,7 @@ const request = async (options) => {
     const text = await response.text();
     let body = text;
 
-    if (parseJson && text) {
+    if (responseType === 'json' && text) {
         try {
             body = JSON.parse(text);
         } catch (err) { // eslint-disable-line no-unused-vars

--- a/statutory/test/scripts/helpers.js
+++ b/statutory/test/scripts/helpers.js
@@ -1,13 +1,89 @@
-const requestPromise = require('request-promise-native');
+const fs = require('fs');
+const path = require('path');
 
 const config = require('../../config');
 
-const request = requestPromise.defaults({
-    json: true,
-    resolveWithFullResponse: true,
-    simple: false,
-    baseUrl: 'http://localhost:' + config.port,
-    qsStringifyOptions: { arrayFormat: 'brackets' }
-});
+const baseUrl = 'http://localhost:' + config.port;
+
+const appendQuery = (url, query) => {
+    if (!query) return url;
+
+    const requestUrl = new URL(url);
+    for (const [key, value] of Object.entries(query)) {
+        if (Array.isArray(value)) {
+            value.forEach((item) => requestUrl.searchParams.append(key, item));
+        } else if (typeof value === 'object' && value !== null) {
+            for (const [nestedKey, nestedValue] of Object.entries(value)) {
+                requestUrl.searchParams.append(`${key}[${nestedKey}]`, nestedValue);
+            }
+        } else {
+            requestUrl.searchParams.append(key, value);
+        }
+    }
+
+    return requestUrl.toString();
+};
+
+const request = async (options) => {
+    const parseJson = options.json !== false;
+    const headers = { ...(options.headers || {}) };
+    const fetchOptions = { method: options.method || 'GET', headers };
+
+    if (options.body !== undefined) {
+        if (parseJson) {
+            headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+            fetchOptions.body = JSON.stringify(options.body);
+        } else {
+            fetchOptions.body = options.body;
+        }
+    }
+
+    if (options.formData) {
+        const entries = Object.entries(options.formData);
+        const formData = new FormData();
+        for (const [key, item] of entries) {
+            const value = item && item.value ? item.value : item;
+            const filename = item && item.options && item.options.filename
+                ? item.options.filename
+                : path.basename(value.path);
+            const buffer = fs.readFileSync(value.path);
+            formData.append(key, new Blob([buffer]), filename);
+        }
+        if (entries.length > 0) {
+            fetchOptions.body = formData;
+        } else {
+            headers['Content-Type'] = 'multipart/form-data; boundary=empty-form';
+            fetchOptions.body = '--empty-form\r\n';
+        }
+    }
+
+    const response = await fetch(appendQuery(new URL(options.uri, baseUrl + '/').toString(), options.qs), fetchOptions);
+    if (options.encoding === null) {
+        return {
+            statusCode: response.status,
+            statusMessage: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body: Buffer.from(await response.arrayBuffer())
+        };
+    }
+
+    const text = await response.text();
+    let body = text;
+
+    if (parseJson && text) {
+        try {
+            body = JSON.parse(text);
+        } catch (err) { // eslint-disable-line no-unused-vars
+            body = text;
+        }
+    }
+
+    return {
+        statusCode: response.status,
+        statusMessage: response.statusText,
+        headers: Object.fromEntries(response.headers.entries()),
+        body
+    };
+};
 
 exports.request = request;

--- a/summeruniversity/lib/core.js
+++ b/summeruniversity/lib/core.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const { request } = require('./http');
 
 const config = require('../config');
 

--- a/summeruniversity/lib/core.js
+++ b/summeruniversity/lib/core.js
@@ -11,9 +11,7 @@ const makeRequest = (options) => {
             'X-Auth-Token': options.token,
             'X-Service': 'summeruniversity'
         },
-        simple: false,
-        json: true,
-        resolveWithFullResponse: options.resolveWithFullResponse || false
+        fullResponse: options.fullResponse || false
     };
 
     if (options.body) {

--- a/summeruniversity/lib/http.js
+++ b/summeruniversity/lib/http.js
@@ -1,9 +1,5 @@
-const parseBody = async (response, parseJson) => {
+const parseBody = async (response) => {
     const text = await response.text();
-
-    if (!parseJson) {
-        return text;
-    }
 
     if (!text) {
         return null;
@@ -38,7 +34,6 @@ const appendQuery = (url, query) => {
 };
 
 module.exports.request = async (options) => {
-    const parseJson = options.json !== false;
     const headers = { ...(options.headers || {}) };
     const fetchOptions = {
         method: options.method || 'GET',
@@ -47,13 +42,13 @@ module.exports.request = async (options) => {
 
     if (options.body !== undefined) {
         headers['Content-Type'] = headers['Content-Type'] || 'application/json';
-        fetchOptions.body = parseJson ? JSON.stringify(options.body) : options.body;
+        fetchOptions.body = JSON.stringify(options.body);
     }
 
     const response = await fetch(appendQuery(options.url, options.qs), fetchOptions);
-    const body = await parseBody(response, parseJson);
+    const body = await parseBody(response);
 
-    if (options.resolveWithFullResponse) {
+    if (options.fullResponse) {
         return {
             statusCode: response.status,
             statusMessage: response.statusText,

--- a/summeruniversity/lib/http.js
+++ b/summeruniversity/lib/http.js
@@ -1,0 +1,66 @@
+const parseBody = async (response, parseJson) => {
+    const text = await response.text();
+
+    if (!parseJson) {
+        return text;
+    }
+
+    if (!text) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch (err) { // eslint-disable-line no-unused-vars
+        return text;
+    }
+};
+
+const appendQuery = (url, query) => {
+    if (!query) {
+        return url;
+    }
+
+    const requestUrl = new URL(url);
+    for (const [key, value] of Object.entries(query)) {
+        if (Array.isArray(value)) {
+            value.forEach((item) => requestUrl.searchParams.append(key, item));
+        } else if (typeof value === 'object' && value !== null) {
+            for (const [nestedKey, nestedValue] of Object.entries(value)) {
+                requestUrl.searchParams.append(`${key}[${nestedKey}]`, nestedValue);
+            }
+        } else {
+            requestUrl.searchParams.append(key, value);
+        }
+    }
+
+    return requestUrl.toString();
+};
+
+module.exports.request = async (options) => {
+    const parseJson = options.json !== false;
+    const headers = { ...(options.headers || {}) };
+    const fetchOptions = {
+        method: options.method || 'GET',
+        headers
+    };
+
+    if (options.body !== undefined) {
+        headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+        fetchOptions.body = parseJson ? JSON.stringify(options.body) : options.body;
+    }
+
+    const response = await fetch(appendQuery(options.url, options.qs), fetchOptions);
+    const body = await parseBody(response, parseJson);
+
+    if (options.resolveWithFullResponse) {
+        return {
+            statusCode: response.status,
+            statusMessage: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body
+        };
+    }
+
+    return body;
+};

--- a/summeruniversity/lib/mailer.js
+++ b/summeruniversity/lib/mailer.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const { request } = require('./http');
 
 const config = require('../config');
 

--- a/summeruniversity/lib/mailer.js
+++ b/summeruniversity/lib/mailer.js
@@ -6,8 +6,6 @@ module.exports.sendMail = async (options) => {
     const mailerBody = await request({
         url: config.mailer.url + ':' + config.mailer.port + '/',
         method: 'POST',
-        simple: false,
-        json: true,
         body: {
             from: options.from,
             to: options.to,

--- a/summeruniversity/lib/middlewares.js
+++ b/summeruniversity/lib/middlewares.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const { request } = require('./http');
 
 const Bugsnag = require('./bugsnag');
 const constants = require('./constants');

--- a/summeruniversity/lib/middlewares.js
+++ b/summeruniversity/lib/middlewares.js
@@ -20,9 +20,7 @@ exports.authenticateUser = async (req, res, next) => {
             'X-Requested-With': 'XMLHttpRequest',
             'X-Auth-Token': req.headers['x-auth-token'],
         },
-        simple: false,
-        json: true,
-        resolveWithFullResponse: true
+        fullResponse: true
     })));
 
     // Fetching permissions for members approval, the list of bodies
@@ -34,13 +32,11 @@ exports.authenticateUser = async (req, res, next) => {
             'X-Requested-With': 'XMLHttpRequest',
             'X-Auth-Token': req.headers['x-auth-token'],
         },
-        simple: false,
-        json: true,
         body: {
             action: 'approve_members',
             object: 'summeruniversity'
         },
-        resolveWithFullResponse: true
+        fullResponse: true
     });
 
     req.userRequest = userBody;

--- a/summeruniversity/package-lock.json
+++ b/summeruniversity/package-lock.json
@@ -29,8 +29,6 @@
         "pg": "^8.20.0",
         "prom-client": "^15.1.3",
         "read-chunk": "^3.2.0",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "sequelize": "^6.37.8",
         "sequelize-cli": "^6.6.3"
       },
@@ -2015,6 +2013,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2248,24 +2247,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2275,12 +2256,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2306,21 +2281,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "license": "MIT"
     },
     "node_modules/babel-jest": {
       "version": "30.3.0",
@@ -2477,15 +2437,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "node_modules/bintrees": {
       "version": "1.0.2",
@@ -2744,12 +2695,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2987,18 +2932,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -3091,12 +3024,6 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "license": "MIT"
-    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -3138,18 +3065,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/data-view-buffer": {
@@ -3291,15 +3206,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3382,16 +3288,6 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/editorconfig": {
       "version": "1.0.7",
@@ -4289,31 +4185,18 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -4514,29 +4397,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/forwarded": {
@@ -4754,15 +4614,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -4878,29 +4729,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -5019,21 +4847,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/human-signals": {
@@ -5600,12 +5413,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -5670,12 +5477,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6447,12 +6248,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6480,16 +6275,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -6503,6 +6293,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -6528,21 +6319,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/keyv": {
@@ -7429,15 +7205,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7821,12 +7588,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT"
-    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
@@ -8161,18 +7922,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -8187,6 +7936,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8377,90 +8127,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "license": "ISC",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "license": "ISC",
-      "dependencies": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
-      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-directory": {
@@ -9319,31 +8985,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stack-generator": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
@@ -9389,15 +9030,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -9820,19 +9452,6 @@
       "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==",
       "license": "MIT"
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -9876,24 +9495,6 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10179,6 +9780,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -10240,20 +9842,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/walker": {

--- a/summeruniversity/package.json
+++ b/summeruniversity/package.json
@@ -63,8 +63,6 @@
     "pg": "^8.20.0",
     "prom-client": "^15.1.3",
     "read-chunk": "^3.2.0",
-    "request": "^2.88.2",
-    "request-promise-native": "^1.0.9",
     "sequelize": "^6.37.8",
     "sequelize-cli": "^6.6.3"
   },


### PR DESCRIPTION
## Summary
- Replace backend `request` / `request-promise-native` call sites with native `fetch` adapters.
- Update backend API test helpers to preserve full-response, querystring, binary export, and multipart upload behavior.
- Remove direct `request` and `request-promise-native` dependencies from backend module manifests and lockfiles.

## Validation
- `npm run lint` in core, discounts, events, knowledge, network, statutory, summeruniversity.
- `USERNAME=postgres PG_PASSWORD=5ecr3t npm test` in discounts, events, knowledge, network.
- `USERNAME=postgres PG_PASSWORD=5ecr3t npm test` in core initially had one empty multipart compatibility failure; focused rerun passed after helper fix: `NODE_ENV=test npx jest test/api/users-image-upload.test.js --runInBand --forceExit`.
- Statutory full run exposed helper compatibility failures; focused rerun passed after helper fix: `NODE_ENV=test npx jest test/api/candidatures-image-upload.test.js test/api/events-image-upload.test.js test/api/export-all.test.js test/api/export-candidates.test.js test/api/plenaries-export-stats.test.js --runInBand --forceExit`.
- Summeruniversity test script currently exits with no matching `test/api/*.js` files.
- `npm audit --workspaces=false --audit-level=moderate` is clean for discounts, knowledge, network; remaining core/events/statutory/summeruniversity audit findings are unrelated `file-type`/`tar` issues.

## Notes
- Frontend Vue CLI 4 still pulls `request` transitively via `@vue/cli-shared-utils`; upgrading Vue CLI to v5 is a separate frontend tooling migration.