### PR TITLE
fix(frontend): improve Resources colours and add new financial links

### DIFF
--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -44,7 +44,12 @@ $link: $blue;
 $family-primary: $family-sans-serif;
 
 :root {
+	--blue-light: #{$blue-light};
+	--red-light: #{$red-light};
+	--green-light: #{$green-light};
 	--purple-light: #{$purple-light};
+	--white-ter: #fafafa;
+	--yellow-light: #{$yellow-light};
 }
 
 $fa-font-path: "../fonts" !default;

--- a/frontend/src/views/static/Resources.vue
+++ b/frontend/src/views/static/Resources.vue
@@ -10,7 +10,7 @@
             <a :href="resource.url" target="_blank" rel="noopener noreferrer">
               <div class="card">
                 <header role="tab" class="card-header">
-                  <div class="card-header-title" :style="{ 'background-color': resource.color }">
+                  <div class="card-header-title" :style="{ 'background-color': 'var(--' + resource.color + '-light)' }">
                     <span>{{ resource.title }}</span>
                   </div>
                 </header>
@@ -35,7 +35,7 @@
   height: 150px;
 }
 .resources .resources-item .card:hover .card-content {
-  background-color: #fafafa;
+  background-color: var(--white-ter);
 }
 .resources .resources-item .card {
   height: 100%;
@@ -67,19 +67,19 @@ export default {
             url: 'https://aegee.org',
             title: 'AEGEE Website',
             description: 'Official website',
-            color: '#4CA0FF'
+            color: 'blue'
           },
           {
             url: 'https://aegee.us7.list-manage.com/subscribe?u=7a170c64e0d3990f3f6629d21&id=fc8908d780',
             title: 'External Newsletter',
             description: 'Bi-monthly newsletter for Partners & Supporters',
-            color: '#4CA0FF'
+            color: 'blue'
           },
           {
             url: 'https://drive.google.com/drive/folders/1kU6DQd0v5rsGMwdjnhYUerYcJMH7af0_',
             title: 'Key to Europe',
             description: 'Yearbook - the annual report publication',
-            color: '#4CA0FF'
+            color: 'blue'
           }
         ],
         'Members': [
@@ -87,61 +87,75 @@ export default {
             url: '/pages/mailing-lists',
             title: 'Mailing Lists',
             description: 'AEGEE mailing lists',
-            color: '#FFDB4C'
+            color: 'yellow'
           },
           {
             url: 'https://drive.google.com/drive/folders/1TSLKDPKUFe7k3POjlW1XzJdxgz5mfhrQ',
             title: 'Strategic Plans & Action Agendas',
             description: 'Strategic Plans and their Action Agendas',
-            color: '#FFDB4C'
+            color: 'yellow'
           },
           {
             url: 'https://www.facebook.com/groups/aegeeans/',
             title: 'Facebook Group',
             description: 'AEGEE\'s official group on Facebook',
-            color: '#FFDB4C'
+            color: 'yellow'
           },
           {
             url: 'https://www.zeus.aegee.org/magazine/',
             title: 'The AEGEEan Magazine',
             description: 'AEGEE\'s online Magazine',
-            color: '#FFDB4C'
+            color: 'yellow'
           },
           {
             url: 'https://forms.gle/DhfVStza9xhn1jRT6',
             title: 'AEGEE-Academy',
             description: 'Request a trainer for your training events',
-            color: '#FFDB4C'
+            color: 'yellow'
           },
           {
             url: 'https://forms.gle/s8vE6b9wrEHqV1xe9',
             title: 'AEGEE House Guest Request',
             description: 'Visiting the AEGEE house',
-            color: '#FFDB4C'
-          },
-          {
-            url: 'https://form.jotform.com/261133028599056',
-            title: 'ASRF Application Form',
-            description: 'Apply for the AEGEE Social Responsibility Fund',
-            color: '#FFDB4C'
+            color: 'yellow'
           },
           {
             url: 'https://www.aegee.org/code-of-conduct/',
             title: 'Code of Conduct',
             description: 'Read AEGEE\'s Code of Conduct',
-            color: '#FFDB4C'
+            color: 'yellow'
           },
           {
             url: 'https://forms.gle/EcaDkdyQfSb65Jdh8',
             title: 'Safe Person Committee',
             description: 'Request a Safe Person or workshop for your event',
-            color: '#FFDB4C'
+            color: 'yellow'
           },
           {
             url: 'https://docs.google.com/forms/d/e/1FAIpQLSf0OmluW11nce72VEuWOybQ1n83gMK6UcE9QvfJ5gIBETUwpA/viewform',
             title: 'Sexual Harassment Report',
             description: 'Report a case of sexual harassment',
-            color: '#FFDB4C'
+            color: 'yellow'
+          }
+        ],
+        'Financial': [
+          {
+            url: 'https://form.jotform.com/261133028599056',
+            title: 'ASRF Application Form',
+            description: 'Apply for the AEGEE Social Responsibility Fund',
+            color: 'blue'
+          },
+          {
+            url: 'https://form.jotform.com/92653241656965',
+            title: 'Reimbursement Form',
+            description: "Request a reimbursement for AEGEE-Europe's expenses",
+            color: 'blue'
+          },
+          {
+            url: 'https://form.jotform.com/261146144461047',
+            title: 'Travel Plan of European Bodies',
+            description: 'Request travel plan approval on behalf of your European Body',
+            color: 'blue'
           }
         ],
         'Network': [
@@ -149,25 +163,25 @@ export default {
             url: 'https://docs.google.com/forms/d/e/1FAIpQLSd2u-r1jFGyNwYCwsSnMf9-dApH7ZGeGltZusxqWqkB_VQ0zg/viewform',
             title: 'AEGEE Contact in your City',
             description: 'Leave your contact details behind to start the process of founding an AEGEE Contact in your city',
-            color: '#C2DE5D'
+            color: 'green'
           },
           {
             url: 'https://docs.google.com/forms/d/e/1FAIpQLSfmbGAjG_us00KMuV-pMeasja_gfjLXVwhaqRK9y5rbTSb0xw/viewform',
             title: 'Suggest a City for a Potential Contact',
             description: 'Provide a suggestion for where AEGEE should have a Contact',
-            color: '#C2DE5D'
+            color: 'green'
           },
           {
             url: 'https://docs.google.com/document/d/1rQRddt8H3J1RUYMpdxRxuhNqyV3BcP8mV8ykNLNup3o/edit',
             title: 'Set up your own Contact',
             description: 'Find out how to set up a Contact in this step by step guide',
-            color: '#C2DE5D'
+            color: 'green'
           },
           {
             url: 'https://docs.google.com/document/d/1e0jdTLvn7-JdwOlxMXcf55I5mcNwEmI_loN0djj0U2c/edit',
             title: 'Develop your Contact',
             description: 'Find out how to develop your Contact with tips and tricks in this toolkit',
-            color: '#C2DE5D'
+            color: 'green'
           }
         ],
         'Statutory': [
@@ -175,13 +189,13 @@ export default {
             url: 'https://www.zeus.aegee.org/statutoryvote/jc/',
             title: 'Online Voting',
             description: 'Online Voting for Agorae/General Assembly',
-            color: '#C44BC2'
+            color: 'purple'
           },
           {
             url: 'https://drive.google.com/drive/folders/1GKd6jWeolMDRw7EXZO-ROXupBQUzAgk2',
             title: 'CIA',
             description: 'Statutes, regulation, working formats and motions',
-            color: '#C44BC2'
+            color: 'purple'
           }
         ],
         'Useful guides': [
@@ -189,7 +203,7 @@ export default {
             url: 'https://myaegee.atlassian.net/wiki/spaces/KMS/pages/2238152708/Public+Relations',
             title: 'Visual Identity',
             description: 'Manual, logos, PR materials and more',
-            color: '#FF5543'
+            color: 'red'
           }
         ]
       }


### PR DESCRIPTION
## Summary
- replace hard-coded resource card colors with named palette values
- expose the needed light palette colors as CSS variables
- add a Financial resources category
- Fixes HELP-2962

## Verification
- npm run lint