### PR TITLE
feat(core): add member lookup permission

### DIFF
--- a/core/lib/server.js
+++ b/core/lib/server.js
@@ -104,6 +104,7 @@ MemberRouter.put('/primary-body', members.setPrimaryBody);
 MemberRouter.put('/email', members.triggerEmailChange);
 MemberRouter.put('/password', members.setUserPassword);
 MemberRouter.post('/listserv', members.subscribeListserv);
+MemberRouter.get('/lookup', members.lookupUser);
 MemberRouter.get('/', members.getUser);
 MemberRouter.put('/', members.updateUser);
 MemberRouter.delete('/', members.deleteUser);

--- a/core/middlewares/members.js
+++ b/core/middlewares/members.js
@@ -128,6 +128,27 @@ exports.getUser = async (req, res) => {
     });
 };
 
+exports.lookupUser = async (req, res) => {
+    if (!req.permissions.hasPermission('lookup:member')
+        && !req.permissions.hasPermission('view:member')
+        && req.user.id !== req.currentUser.id) {
+        return errors.makeForbiddenError(res, 'Permission lookup:member is required, but not present.');
+    }
+
+    return res.json({
+        success: true,
+        data: {
+            id: req.currentUser.id,
+            first_name: req.currentUser.first_name,
+            last_name: req.currentUser.last_name,
+            username: req.currentUser.username,
+            email: req.currentUser.email,
+            gsuite_id: req.currentUser.gsuite_id,
+            notification_email: req.currentUser.notification_email
+        }
+    });
+};
+
 exports.getUsersEmail = async (req, res) => {
     const correctQuery = req.query.query && typeof req.query.query === 'string' && req.query.query.trim().length > 0 && req.query.query.match(/^\d+(?:,\d+)*$/g);
 

--- a/core/scripts/seed.js
+++ b/core/scripts/seed.js
@@ -247,6 +247,12 @@ async function createPermissions() {
         scope: 'global',
         description: 'View all members in the system. Assign this role to trusted persons only to avoid disclosure. For local scope, use view_members:body'
     });
+    permissions.lookupMember = await Permission.create({
+        action: 'lookup',
+        object: 'member',
+        scope: 'global',
+        description: 'Lookup limited member identity and contact routing data, including notification email.'
+    });
     permissions.addMemberCircle = await Permission.create({
         action: 'add_member',
         object: 'circle',
@@ -803,7 +809,7 @@ async function createPermissions() {
         description: ' Manage and delete LTCs. '
     }], { individualHooks: true, validate: true });
 
-    permissions.eqac = [...eqacPermissions, permissions.viewMember, permissions.approveEventNwm];
+    permissions.eqac = [...eqacPermissions, permissions.lookupMember, permissions.approveEventNwm];
 
     const chairPermissions = await Permission.bulkCreate([{
         action: 'mail',

--- a/core/test/api/users-details.test.js
+++ b/core/test/api/users-details.test.js
@@ -212,4 +212,86 @@ describe('User details', () => {
         expect(res.body).toHaveProperty('message');
         expect(res.body).not.toHaveProperty('data');
     });
+
+    test('should fail with search permission on regular member details', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
+        const otherUser = await generator.createUser();
+
+        const res = await request({
+            path: '/members/' + otherUser.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).toHaveProperty('message');
+        expect(res.body).not.toHaveProperty('data');
+    });
+
+    test('should fail member lookup data with only search permission', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
+        const otherUser = await generator.createUser();
+
+        const res = await request({
+            path: '/members/' + otherUser.id + '/lookup',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).toHaveProperty('message');
+        expect(res.body).not.toHaveProperty('data');
+    });
+
+    test('should return limited member lookup data with lookup permission', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'lookup', object: 'member' });
+        const otherUser = await generator.createUser({ gsuite_id: 'organizer@aegee.eu' });
+
+        const res = await request({
+            path: '/members/' + otherUser.id + '/lookup',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body.data).toEqual({
+            id: otherUser.id,
+            first_name: otherUser.first_name,
+            last_name: otherUser.last_name,
+            username: otherUser.username,
+            email: otherUser.email,
+            gsuite_id: otherUser.gsuite_id,
+            notification_email: otherUser.notification_email
+        });
+    });
+
+    test('should fail member lookup data without lookup permission', async () => {
+        const user = await generator.createUser();
+        const token = await generator.createAccessToken(user);
+
+        const otherUser = await generator.createUser();
+
+        const res = await request({
+            path: '/members/' + otherUser.id + '/lookup',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).toHaveProperty('message');
+        expect(res.body).not.toHaveProperty('data');
+    });
 });

--- a/events/lib/core.js
+++ b/events/lib/core.js
@@ -23,7 +23,7 @@ const makeRequest = (options) => {
 
 const fetchUser = async (user, token) => {
     const userRequest = await makeRequest({
-        url: config.core.url + ':' + config.core.port + '/members/' + user.user_id,
+        url: config.core.url + ':' + config.core.port + '/members/' + user.user_id + '/lookup',
         token
     });
 

--- a/frontend/src/views/events/Edit.vue
+++ b/frontend/src/views/events/Edit.vue
@@ -314,7 +314,7 @@
           <div class="content">
             <p>The user creating the event automatically becomes the organiser.</p>
             <p>People who are not listed as organisers won't be able to see and manage event manage applications, even if they are the board members.</p>
-            <p v-if="!can.viewAllMembers">
+            <p v-if="!can.searchAllMembers">
               <strong>You can only add people from your bodies.</strong>
               If a person from another body needs to be added as an organiser, you can temporarily join this body to get the permissions
               to see members of this body, add required people, then leave it.
@@ -705,7 +705,7 @@ export default {
       },
       can: {
         edit_application_status: false,
-        viewAllMembers: false
+        searchAllMembers: false
       },
       errors: {},
       isLoading: false,
@@ -722,10 +722,10 @@ export default {
       if (this.token) this.token.cancel()
       this.token = this.axios.CancelToken.source()
 
-      // If user has global permission, fetching global members list.
+      // If user has global permission, searching the global members list.
       // Otherwise, fetch all of the members of the bodies this user is a member of.
-      const endpoints = this.can.viewAllMembers
-        ? [this.services['core'] + '/members']
+      const endpoints = this.can.searchAllMembers
+        ? [this.services['core'] + '/members_search']
         : this.loginUser.bodies.map(body => this.services['core'] + '/bodies/' + body.id + '/members')
 
       // Ignoring the requests that failed (because of 403 most likely)
@@ -742,7 +742,7 @@ export default {
       Promise.all(endpoints.map(fetchEndpoint)).then((responses) => {
         this.autoComplete.members.values = responses
           .reduce((acc, val) => acc.concat(val), [])
-          .map(value => (this.can.viewAllMembers ? value : value.user))
+          .map(value => (this.can.searchAllMembers ? value : value.user))
           .filter((elt, index, array) => array.findIndex(e => e.id === elt.id) === index)
 
         this.autoComplete.members.loading = false
@@ -961,7 +961,7 @@ export default {
 
       return this.axios.get(this.services['core'] + '/my_permissions/')
     }).then((response) => {
-      this.can.viewAllMembers = response.data.data.some(permission => permission.combined.endsWith('global:view:member'))
+      this.can.searchAllMembers = response.data.data.some(permission => permission.combined.endsWith('global:search:member'))
 
       if (!this.$route.params.id) {
         this.isLoading = false
@@ -978,7 +978,7 @@ export default {
       return this.axios.get(this.services['events'] + '/single/' + this.$route.params.id).then((eventsResponse) => {
         this.event = eventsResponse.data.data
         this.can = eventsResponse.data.permissions
-        this.can.viewAllMembers = response.data.data.some(permission => permission.combined.endsWith('global:view:member')) // override it
+        this.can.searchAllMembers = response.data.data.some(permission => permission.combined.endsWith('global:search:member')) // override it
 
         this.dates.starts = this.event.starts = new Date(this.event.starts)
         this.dates.ends = this.event.starts = new Date(this.event.ends)


### PR DESCRIPTION
## Summary
- add a generic member lookup endpoint guarded by `lookup:member`
- use the lookup endpoint when resolving event organisers
- switch event organiser autocomplete to `members_search` / `global:search:member`
- seed EQAC with `lookup:member` instead of `view:member`

## Verification
- `NODE_ENV=test USERNAME=postgres PG_PASSWORD=5ecr3t npx jest test/api/users-details.test.js --runInBand --forceExit`
- `npx eslint middlewares/members.js lib/server.js scripts/seed.js ../events/lib/core.js test/api/users-details.test.js`
- `npx eslint src/views/events/Edit.vue`