### PR TITLE
Update join request guidance and notifications

### DIFF
--- a/core/middlewares/join-requests.js
+++ b/core/middlewares/join-requests.js
@@ -39,6 +39,8 @@ exports.createJoinRequest = async (req, res) => {
             motivation: req.body.motivation
         }, { transaction: t });
 
+        const recipients = [req.currentBody.email];
+
         // Fetching a permission.
         const permission = await Permission.findOne({
             where: {
@@ -49,30 +51,29 @@ exports.createJoinRequest = async (req, res) => {
         });
 
         if (!permission) {
-            logger.warn('No local:process:join_request permission, not sending mails to board.');
-            return;
-        }
+            logger.warn('No local:process:join_request permission, only sending mail to body email.');
+        } else {
+            const circles = await req.permissions.fetchPermissionCircles(permission);
+            const localCircles = circles.filter((circle) => circle.body_id === req.currentBody.id);
 
-        const circles = await req.permissions.fetchPermissionCircles(permission);
-        const localCircles = circles.filter((circle) => circle.body_id === req.currentBody.id);
+            if (!localCircles.length) {
+                logger.debug('No local circles, only sending mail to body email.');
+            } else {
+                const members = await User.findAll({
+                    where: { '$circle_memberships.circle_id$': { [Sequelize.Op.in]: localCircles.map((circle) => circle.id) } },
+                    include: [CircleMembership]
+                });
 
-        if (!localCircles.length) {
-            logger.debug('No local circles, not sending mails to user.');
-            return;
-        }
+                if (!members.length) {
+                    logger.debug('No members with local:process:join_request permission, only sending mail to body email.');
+                }
 
-        const members = await User.findAll({
-            where: { '$circle_memberships.circle_id$': { [Sequelize.Op.in]: localCircles.map((circle) => circle.id) } },
-            include: [CircleMembership]
-        });
-
-        if (!members.length) {
-            logger.debug('No members with local:process:join_request permission, not sending mails to board.');
-            return;
+                recipients.push(...members.map((member) => member.notification_email));
+            }
         }
 
         await mailer.sendMail({
-            to: members.map((member) => member.notification_email),
+            to: recipients,
             subject: constants.MAIL_SUBJECTS.NEW_JOIN_REQUEST,
             template: 'member_joined.html',
             parameters: {

--- a/core/test/api/join-requests-creating.test.js
+++ b/core/test/api/join-requests-creating.test.js
@@ -90,13 +90,17 @@ describe('Join request creating', () => {
         expect(res.body).toHaveProperty('message');
     });
 
-    test('should not send anything if no permission', async () => {
-        const requestMock = mock.mockAll();
-
+    test('should send mail to body email if no permission', async () => {
         const user = await generator.createUser({ username: 'test', mail_confirmed_at: new Date() });
         const token = await generator.createAccessToken(user);
 
         const body = await generator.createBody();
+
+        const requestMock = mock.mockAll({
+            mailer: {
+                body: (b) => b.to.length === 1 && b.to[0] === body.email.toLowerCase()
+            }
+        });
 
         const res = await request({
             path: '/bodies/' + body.id + '/join-requests',
@@ -110,16 +114,20 @@ describe('Join request creating', () => {
         expect(res.body).not.toHaveProperty('errors');
         expect(res.body).toHaveProperty('data');
 
-        expect(requestMock.mailer.isDone()).toEqual(false);
+        expect(requestMock.mailer.isDone()).toEqual(true);
     });
 
-    test('should not send anything if no circles', async () => {
-        const requestMock = mock.mockAll();
-
+    test('should send mail to body email if no circles', async () => {
         const user = await generator.createUser({ username: 'test', mail_confirmed_at: new Date() });
         const token = await generator.createAccessToken(user);
 
         const body = await generator.createBody();
+
+        const requestMock = mock.mockAll({
+            mailer: {
+                body: (b) => b.to.length === 1 && b.to[0] === body.email.toLowerCase()
+            }
+        });
 
         const otherUser = await generator.createUser();
         await generator.createPermission({ scope: 'local', action: 'process', object: 'join_request' });
@@ -137,16 +145,20 @@ describe('Join request creating', () => {
         expect(res.body).not.toHaveProperty('errors');
         expect(res.body).toHaveProperty('data');
 
-        expect(requestMock.mailer.isDone()).toEqual(false);
+        expect(requestMock.mailer.isDone()).toEqual(true);
     });
 
-    test('should not send anything if no members', async () => {
-        const requestMock = mock.mockAll();
-
+    test('should send mail to body email if no members', async () => {
         const user = await generator.createUser({ username: 'test', mail_confirmed_at: new Date() });
         const token = await generator.createAccessToken(user);
 
         const body = await generator.createBody();
+
+        const requestMock = mock.mockAll({
+            mailer: {
+                body: (b) => b.to.length === 1 && b.to[0] === body.email.toLowerCase()
+            }
+        });
 
         const otherUser = await generator.createUser();
         const permission = await generator.createPermission({ scope: 'local', action: 'process', object: 'join_request' });
@@ -166,7 +178,7 @@ describe('Join request creating', () => {
         expect(res.body).not.toHaveProperty('errors');
         expect(res.body).toHaveProperty('data');
 
-        expect(requestMock.mailer.isDone()).toEqual(false);
+        expect(requestMock.mailer.isDone()).toEqual(true);
     });
 
     test('should send mails if there are members', async () => {
@@ -184,7 +196,9 @@ describe('Join request creating', () => {
 
         const requestMock = mock.mockAll({
             mailer: {
-                body: (b) => b.to.length === 1 && b.to[0] === otherUser.email.toLowerCase()
+                body: (b) => b.to.length === 2
+                    && b.to.includes(body.email.toLowerCase())
+                    && b.to.includes(otherUser.email.toLowerCase())
             }
         });
 

--- a/frontend/src/views/core/bodies/Single.vue
+++ b/frontend/src/views/core/bodies/Single.vue
@@ -447,7 +447,8 @@ export default {
       }
 
       this.$buefy.dialog.prompt({
-        message: 'Join body',
+        title: 'Join body',
+        message: this.getJoinRequestMessage(),
         inputAttrs: {
           placeholder: 'Motivation',
           required: false
@@ -474,6 +475,22 @@ export default {
             this.$root.showError('Could not sent join request', err)
           }
         })
+    },
+    getJoinRequestMessage () {
+      const contactDetails = [
+        'Local email: ' + this.escapeHtml(this.body.email),
+        this.body.website ? 'Website: ' + this.escapeHtml(this.body.website) : null
+      ].filter(Boolean).join('<br>')
+
+      return 'To help the Local process your join request more efficiently, we strongly encourage you to also contact the Local board directly by email after submitting your request. Introducing yourself and expressing your motivation to join can help the Local get to know you, support the onboarding process, and avoid delays in communication.<br><br>' + contactDetails
+    },
+    escapeHtml (value) {
+      return String(value || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;')
     },
     askLeaveBody () {
       this.$buefy.dialog.confirm({

--- a/frontend/src/views/core/members/UpdateProfile.vue
+++ b/frontend/src/views/core/members/UpdateProfile.vue
@@ -216,8 +216,11 @@ export default {
         })
     },
     askToJoinBody (bodyId) {
+      const selectedBody = this.bodies.find((body) => body.id === bodyId)
+
       this.$buefy.dialog.prompt({
-        message: 'Join body',
+        title: 'Join body',
+        message: this.getJoinRequestMessage(selectedBody),
         inputAttrs: {
           placeholder: 'Motivation',
           required: false
@@ -246,6 +249,24 @@ export default {
             this.$root.showError('Could not sent join request', err)
           }
         })
+    },
+    getJoinRequestMessage (body) {
+      const contactDetails = body
+        ? [
+          'Local email: ' + this.escapeHtml(body.email),
+          body.website ? 'Website: ' + this.escapeHtml(body.website) : null
+        ].filter(Boolean).join('<br>')
+        : 'Local email: automatically filled after selecting a Local'
+
+      return 'To help the Local process your join request more efficiently, we strongly encourage you to also contact the Local board directly by email after submitting your request. Introducing yourself and expressing your motivation to join can help the Local get to know you, support the onboarding process, and avoid delays in communication.<br><br>' + contactDetails
+    },
+    escapeHtml (value) {
+      return String(value || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;')
     },
     changeEmail (newEmail) {
       if (RESTRICTED_EMAILS.some((domain) => newEmail.includes(domain))) {


### PR DESCRIPTION
## Summary
- add Local email and website guidance to join request prompts
- send new join request notifications to the body profile email as well as board members
- update join request notification tests for the new body email recipient

## Verification
- npx eslint src/views/core/members/UpdateProfile.vue src/views/core/bodies/Single.vue
- npx eslint middlewares/join-requests.js test/api/join-requests-creating.test.js
- NODE_ENV=test USERNAME=postgres PG_PASSWORD=5ecr3t npm run db:setup && NODE_ENV=test USERNAME=postgres PG_PASSWORD=5ecr3t npx jest test/api/join-requests-creating.test.js --runInBand --forceExit