### PR TITLE
fix(frontend): guard event ban checks for guests

### DIFF
--- a/frontend/src/views/events/Single.vue
+++ b/frontend/src/views/events/Single.vue
@@ -580,13 +580,13 @@ export default {
       services: 'services'
     }),
     isOrganizer () {
-      return this.event.organizers.some((org) => org.user_id === this.loginUser.id)
+      return this.loginUser && this.event.organizers.some((org) => org.user_id === this.loginUser.id)
     },
     isOnlineEvent () {
       return this.event.method === 'online'
     },
     activeEventApplicationBan () {
-      return this.loginUser.event_application_ban && new Date(this.loginUser.event_application_ban.ban_until) > new Date()
+      return this.loginUser && this.loginUser.event_application_ban && new Date(this.loginUser.event_application_ban.ban_until) > new Date()
     }
   }
 }

--- a/frontend/src/views/statutory/Single.vue
+++ b/frontend/src/views/statutory/Single.vue
@@ -625,7 +625,7 @@ export default {
       )
     },
     activeEventApplicationBan () {
-      return this.loginUser.event_application_ban && new Date(this.loginUser.event_application_ban.ban_until) > new Date()
+      return this.loginUser && this.loginUser.event_application_ban && new Date(this.loginUser.event_application_ban.ban_until) > new Date()
     }
   }
 }

--- a/frontend/src/views/summeruniversity/Single.vue
+++ b/frontend/src/views/summeruniversity/Single.vue
@@ -792,10 +792,10 @@ export default {
       services: 'services'
     }),
     isOrganizer () {
-      return this.event.organizers.some((org) => org.user_id === this.loginUser.id)
+      return this.loginUser && this.event.organizers.some((org) => org.user_id === this.loginUser.id)
     },
     activeEventApplicationBan () {
-      return this.loginUser.event_application_ban && new Date(this.loginUser.event_application_ban.ban_until) > new Date()
+      return this.loginUser && this.loginUser.event_application_ban && new Date(this.loginUser.event_application_ban.ban_until) > new Date()
     }
   }
 }


### PR DESCRIPTION
## Summary
- Guard event application ban checks when public single-event pages render without a logged-in user
- Guard organizer checks on public event and Summer University single pages

## Testing
- npm run lint