### PR TITLE
fix(statutory): base antenna quorum on publication and acceptance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
           name: Run core tests
           working_directory: ~/project/core
           command: |
-            TEST=$(circleci tests glob test/**/*.js | circleci tests split --split-by=timings)
+            TEST=$(circleci tests glob "test/**/*.js" | circleci tests split --split-by=timings)
             JEST_JUNIT_OUTPUT_DIR=$HOME/reports/jest npm run test:ci $TEST -- --reporters=default --reporters=jest-junit
       - codecov/upload
       - store_test_results:
@@ -316,7 +316,7 @@ jobs:
           name: Run discounts tests
           working_directory: ~/project/discounts
           command: |
-            TEST=$(circleci tests glob test/api/*.js | circleci tests split --split-by=timings)
+            TEST=$(circleci tests glob "test/**/*.js" | circleci tests split --split-by=timings)
             JEST_JUNIT_OUTPUT_DIR=$HOME/reports/jest npm run test:ci $TEST -- --reporters=default --reporters=jest-junit
       - codecov/upload
       - store_test_results:
@@ -535,7 +535,7 @@ jobs:
           name: Run events tests
           working_directory: ~/project/events
           command: |
-            TEST=$(circleci tests glob test/**/*.js | circleci tests split --split-by=timings)
+            TEST=$(circleci tests glob "test/**/*.js" | circleci tests split --split-by=timings)
             JEST_JUNIT_OUTPUT_DIR=$HOME/reports/jest npm run test:ci $TEST -- --reporters=default --reporters=jest-junit
       - codecov/upload
       - store_test_results:
@@ -964,7 +964,7 @@ jobs:
           name: Run knowledge tests
           working_directory: ~/project/knowledge
           command: |
-            TEST=$(circleci tests glob test/api/*.js | circleci tests split --split-by=timings)
+            TEST=$(circleci tests glob "test/**/*.js" | circleci tests split --split-by=timings)
             JEST_JUNIT_OUTPUT_DIR=$HOME/reports/jest npm run test:ci $TEST -- --reporters=default --reporters=jest-junit
       - codecov/upload
       - store_test_results:
@@ -1462,7 +1462,7 @@ jobs:
           name: Run network tests
           working_directory: ~/project/network
           command: |
-            TEST=$(circleci tests glob test/**/*.js | circleci tests split --split-by=timings)
+            TEST=$(circleci tests glob "test/**/*.js" | circleci tests split --split-by=timings)
             JEST_JUNIT_OUTPUT_DIR=$HOME/reports/jest npm run test:ci $TEST -- --reporters=default --reporters=jest-junit
       - codecov/upload
       - store_test_results:
@@ -1681,7 +1681,7 @@ jobs:
           name: Run statutory tests
           working_directory: ~/project/statutory
           command: |
-            TEST=$(circleci tests glob test/api/*.js | circleci tests split --split-by=timings)
+            TEST=$(circleci tests glob "test/**/*.js" | circleci tests split --split-by=timings)
             JEST_JUNIT_OUTPUT_DIR=$HOME/reports/jest npm run test:ci $TEST -- --reporters=default --reporters=jest-junit
       - codecov/upload
       - store_test_results:

--- a/frontend/src/views/statutory/Stats.vue
+++ b/frontend/src/views/statutory/Stats.vue
@@ -83,7 +83,8 @@
 
         <div class="subtitle">Quorum</div>
         <p>
-          {{ quorum.present }} of {{ quorum.total }} antennae represented by non-cancelled applications.
+          {{ quorum.present }} of {{ quorum.total }} antennae represented by
+          {{ stats.quorum.accepted_only ? 'accepted non-cancelled applications' : 'non-cancelled applications' }}.
           Required: {{ quorum.required }} (50%).
         </p>
         <pie-chart class="chart" :chart-data="byQuorumData" :options="byQuorumOptions" />
@@ -132,6 +133,7 @@ export default {
       },
       bodies: [],
       stats: {
+        quorum: { accepted_only: false, body_ids: [] },
         by_date: [],
         by_date_cumulative: [],
         by_body: [],
@@ -316,8 +318,8 @@ export default {
       }
 
       const total = Object.keys(localsMap).length
-      const present = this.stats.by_body
-        .filter((body) => body.type in localsMap)
+      const present = this.stats.quorum.body_ids
+        .filter((bodyId) => bodyId in localsMap)
         .length
 
       const required = Math.ceil(total / 2)

--- a/frontend/src/views/statutory/Stats.vue
+++ b/frontend/src/views/statutory/Stats.vue
@@ -82,6 +82,10 @@
         <pie-chart class="chart" :chart-data="byNumOfEventsData()" :options="byNumOfEventsOptions" />
 
         <div class="subtitle">Quorum</div>
+        <p>
+          {{ quorum.present }} of {{ quorum.total }} antennae represented by non-cancelled applications.
+          Required: {{ quorum.required }} (50%).
+        </p>
         <pie-chart class="chart" :chart-data="byQuorumData" :options="byQuorumOptions" />
       </div>
     </div>
@@ -303,10 +307,10 @@ export default {
         }
       }
     },
-    byQuorumData () {
+    quorum () {
       const localsMap = {}
       for (const body of this.bodies) {
-        if (['antenna', 'contact antenna', 'partner'].includes(body.type)) {
+        if (body.type === 'antenna') {
           localsMap[body.id] = true
         }
       }
@@ -316,9 +320,14 @@ export default {
         .filter((body) => body.type in localsMap)
         .length
 
-      const quorum = present * 100 / total
+      const required = Math.ceil(total / 2)
+      return { total, present, required }
+    },
+    byQuorumData () {
+      const { total, present } = this.quorum
+      const percentage = total > 0 ? present * 100 / total : 0
       return {
-        labels: [`Present (${quorum.toFixed(2)}%)`, `Not present (${(100 - quorum).toFixed(2)}%)`],
+        labels: [`Represented (${percentage.toFixed(2)}%)`, `Not represented (${(total > 0 ? 100 - percentage : 0).toFixed(2)}%)`],
         datasets: [{
           label: 'Quorum',
           backgroundColor: ['#C2DE5D', '#C45850'],

--- a/statutory/README.md
+++ b/statutory/README.md
@@ -24,6 +24,20 @@ The main developer of this module is Sergey Peshkov (AEGEE-Voronezh, github.com/
 
 You can specify the microservice configuration by editing the `lib/index.js` file. Check out the example at `lib/index.js.example` and the comments in `lib/index.js` for more information.
 
+## Quorum statistics
+
+`GET /events/:event_id/applications/stats` includes `data.quorum` with
+`accepted_only` (boolean) and `body_ids` (distinct represented body IDs).
+Before `participants_list_publish_deadline`, representation includes all
+non-cancelled applications. At and after that timestamp, it includes only
+accepted non-cancelled applications. The cutoff uses server time, regardless
+of staff permissions or early application-status publication. Other statistics,
+including `by_body`, retain their existing meaning.
+
+The frontend restricts these IDs to antennae and displays a 50% requirement,
+rounded up. These statistics do not determine whether statutory quorum is met.
+Deploy the updated statutory service before the updated frontend.
+
 ## LICENSE
 
 Copyright 2018 Sergey Peshkov (AEGEE-Europe) and contributors.

--- a/statutory/README.md
+++ b/statutory/README.md
@@ -24,20 +24,6 @@ The main developer of this module is Sergey Peshkov (AEGEE-Voronezh, github.com/
 
 You can specify the microservice configuration by editing the `lib/index.js` file. Check out the example at `lib/index.js.example` and the comments in `lib/index.js` for more information.
 
-## Quorum statistics
-
-`GET /events/:event_id/applications/stats` includes `data.quorum` with
-`accepted_only` (boolean) and `body_ids` (distinct represented body IDs).
-Before `participants_list_publish_deadline`, representation includes all
-non-cancelled applications. At and after that timestamp, it includes only
-accepted non-cancelled applications. The cutoff uses server time, regardless
-of staff permissions or early application-status publication. Other statistics,
-including `by_body`, retain their existing meaning.
-
-The frontend restricts these IDs to antennae and displays a 50% requirement,
-rounded up. These statistics do not determine whether statutory quorum is met.
-Deploy the updated statutory service before the updated frontend.
-
 ## LICENSE
 
 Copyright 2018 Sergey Peshkov (AEGEE-Europe) and contributors.

--- a/statutory/lib/applications.js
+++ b/statutory/lib/applications.js
@@ -8,6 +8,7 @@ const mailer = require('./mailer');
 const { Application, VotesPerAntenna, PaxLimit, Event } = require('../models');
 const constants = require('./constants');
 const helpers = require('./helpers');
+const getQuorumStats = require('./quorum');
 const { sequelize, Sequelize } = require('./sequelize');
 const logger = require('./logger');
 
@@ -250,6 +251,7 @@ exports.getStats = async (req, res) => {
 
     // Filtering out cancelled applications.
     const notCancelledApplications = applications.filter((app) => !app.cancelled);
+    statsObject.quorum = getQuorumStats(applications, req.event);
 
     // By date
     const dates = notCancelledApplications.map((app) => moment(app.created_at).format('YYYY-MM-DD'))

--- a/statutory/lib/quorum.js
+++ b/statutory/lib/quorum.js
@@ -1,5 +1,5 @@
 // Quorum representation follows the scheduled publication time, regardless of
-// staff permissions or an early application-status reveal.
+// permissions or an early application-status reveal.
 module.exports = (applications, event, now = Date.now()) => {
     const acceptedOnly = now >= new Date(event.participants_list_publish_deadline).getTime();
     const represented = applications.filter((application) => !application.cancelled

--- a/statutory/lib/quorum.js
+++ b/statutory/lib/quorum.js
@@ -1,0 +1,12 @@
+// Quorum representation follows the scheduled publication time, regardless of
+// staff permissions or an early application-status reveal.
+module.exports = (applications, event, now = Date.now()) => {
+    const acceptedOnly = now >= new Date(event.participants_list_publish_deadline).getTime();
+    const represented = applications.filter((application) => !application.cancelled
+        && (!acceptedOnly || application.status === 'accepted'));
+
+    return {
+        accepted_only: acceptedOnly,
+        body_ids: [...new Set(represented.map((application) => application.body_id))]
+    };
+};

--- a/statutory/test/unit/quorum.test.js
+++ b/statutory/test/unit/quorum.test.js
@@ -1,0 +1,37 @@
+const getQuorumStats = require('../../lib/quorum');
+
+describe('Quorum representation', () => {
+    const deadline = Date.parse('2026-09-10T12:00:00Z');
+    const event = { participants_list_publish_deadline: '2026-09-10T14:00:00+02:00' };
+    const applications = [
+        { body_id: 1, status: 'accepted', cancelled: false },
+        { body_id: 1, status: 'accepted', cancelled: false },
+        { body_id: 2, status: 'pending', cancelled: false },
+        { body_id: 3, status: 'rejected', cancelled: false },
+        { body_id: 4, status: 'waiting_list', cancelled: false },
+        { body_id: 5, status: 'accepted', cancelled: true }
+    ];
+
+    test('counts each body with non-cancelled applications once before publication', () => {
+        expect(getQuorumStats(applications, event, deadline - 1)).toEqual({
+            accepted_only: false, body_ids: [1, 2, 3, 4]
+        });
+    });
+
+    test.each([0, 1])('counts only accepted non-cancelled applications at/after publication (%i ms)', (offset) => {
+        expect(getQuorumStats(applications, event, deadline + offset)).toEqual({
+            accepted_only: true, body_ids: [1]
+        });
+    });
+
+    test('an early status reveal does not move the quorum cutoff', () => {
+        expect(getQuorumStats(applications, {
+            ...event, application_status_revealed_at: '2026-09-01T00:00:00Z'
+        }, deadline - 1).accepted_only).toBe(false);
+    });
+
+    test.each([deadline - 1, deadline])('handles no applications at %i', (now) => {
+        expect(getQuorumStats([], event, now).body_ids).toEqual([]);
+        expect(getQuorumStats(applications.filter((app) => app.cancelled), event, now).body_ids).toEqual([]);
+    });
+});

--- a/statutory/test/unit/quorum.test.js
+++ b/statutory/test/unit/quorum.test.js
@@ -24,6 +24,15 @@ describe('Quorum representation', () => {
         });
     });
 
+    test.each([deadline - 1, deadline])('uses server time by default at %i', (now) => {
+        const clock = jest.spyOn(Date, 'now').mockReturnValue(now);
+        try {
+            expect(getQuorumStats(applications, event)).toEqual(getQuorumStats(applications, event, now));
+        } finally {
+            clock.mockRestore();
+        }
+    });
+
     test('an early status reveal does not move the quorum cutoff', () => {
         expect(getQuorumStats(applications, {
             ...event, application_status_revealed_at: '2026-09-01T00:00:00Z'


### PR DESCRIPTION
Statutory quorum statistics now count antennae only and display the 50% requirement, rounded up. Previously the chart also included contact antennae and partners.

Before the participant-list publish time, count antennae with any non-cancelled application. At and after that time, count antennae with an accepted non-cancelled application. The server uses participants_list_publish_deadline, regardless of staff permissions or early status reveal, and returns the filtered body IDs plus the basis used. Other application statistics retain their existing meaning.

The UI labels the current basis and does not state whether quorum is reached, since other determining factors are not represented in the system. Empty antenna lists produce valid percentages.

CI now discovers test/**/*.js recursively across all six Jest service jobs, including unit tests previously excluded by API-only globs. The glob is quoted so CircleCI performs recursive expansion.

Validation: 8 Jest unit tests passed, covering the publication boundary, time-zone offsets, duplicate bodies, cancelled applications, early status reveal, default server time, and empty results. The quorum helper has 100% statement, function, and branch coverage. Recursive discovery matches all 240 suites found by unrestricted Jest discovery across the six services. YAML and shell syntax checks passed. Four additional server-to-chart calculation scenarios passed. ESLint passed for all changed JavaScript/Vue files, and git diff --check passed. Full database/API and browser tests were not run.

Deployment: deploy the statutory service before the frontend, which consumes the new quorum response field.
