### PR TITLE
fix(docker): use numeric users and exec-form healthcheck

### DIFF
--- a/core/docker/core/Dockerfile
+++ b/core/docker/core/Dockerfile
@@ -18,7 +18,7 @@ ARG PACKAGE_VERSION
 # Rebuilds that only change source code will skip the npm ci step.
 COPY --chown=node:node package.json package-lock.json ./
 
-USER node
+USER 1000
 
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
  && npm ci --legacy-peer-deps --omit=dev

--- a/discounts/docker/discounts/Dockerfile
+++ b/discounts/docker/discounts/Dockerfile
@@ -18,7 +18,7 @@ ARG PACKAGE_VERSION
 # Rebuilds that only change source code will skip the npm ci step.
 COPY --chown=node:node package.json package-lock.json ./
 
-USER node
+USER 1000
 
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
  && npm ci --legacy-peer-deps --omit=dev

--- a/dispatcher/docker/Dockerfile
+++ b/dispatcher/docker/Dockerfile
@@ -9,14 +9,14 @@ COPY ./templates /usr/app/templates
 COPY ./dispatcher/main.py /usr/app/src/main.py
 COPY ./dispatcher/notify.py /usr/app/src/notify.py
 
-RUN useradd -s /bin/bash python
-USER python
+RUN useradd -u 1000 -s /bin/bash python
+USER 1000
 
 # Checks that the RabbitMQ AMQP port is reachable from this container's network namespace.
 # If rabbit becomes unavailable the container is marked unhealthy, making the degradation
 # visible to Docker and any monitoring stack watching container health.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD python -c "import socket; socket.create_connection(('rabbit', 5672), 3)"
+  CMD ["python", "-c", "import socket; socket.create_connection(('rabbit', 5672), 3)"]
 
 ENTRYPOINT [ "python", "-u" ]
 CMD ["main.py"]

--- a/events/docker/events/Dockerfile
+++ b/events/docker/events/Dockerfile
@@ -18,7 +18,7 @@ ARG PACKAGE_VERSION
 # Rebuilds that only change source code will skip the npm ci step.
 COPY --chown=node:node package.json package-lock.json ./
 
-USER node
+USER 1000
 
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
  && npm ci --legacy-peer-deps --omit=dev

--- a/knowledge/docker/knowledge/Dockerfile
+++ b/knowledge/docker/knowledge/Dockerfile
@@ -18,7 +18,7 @@ ARG PACKAGE_VERSION
 # Rebuilds that only change source code will skip the npm ci step.
 COPY --chown=node:node package.json package-lock.json ./
 
-USER node
+USER 1000
 
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
  && npm ci --legacy-peer-deps --omit=dev

--- a/network/docker/network/Dockerfile
+++ b/network/docker/network/Dockerfile
@@ -18,7 +18,7 @@ ARG PACKAGE_VERSION
 # Rebuilds that only change source code will skip the npm ci step.
 COPY --chown=node:node package.json package-lock.json ./
 
-USER node
+USER 1000
 
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
  && npm ci --legacy-peer-deps --omit=dev

--- a/statutory/docker/statutory/Dockerfile
+++ b/statutory/docker/statutory/Dockerfile
@@ -18,7 +18,7 @@ ARG PACKAGE_VERSION
 # Rebuilds that only change source code will skip the npm ci step.
 COPY --chown=node:node package.json package-lock.json ./
 
-USER node
+USER 1000
 
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
  && npm ci --legacy-peer-deps --omit=dev

--- a/summeruniversity/docker/summeruniversity/Dockerfile
+++ b/summeruniversity/docker/summeruniversity/Dockerfile
@@ -18,7 +18,7 @@ ARG PACKAGE_VERSION
 # Rebuilds that only change source code will skip the npm ci step.
 COPY --chown=node:node package.json package-lock.json ./
 
-USER node
+USER 1000
 
 RUN if [ -n "$PACKAGE_VERSION" ]; then npm version "$PACKAGE_VERSION" --no-git-tag-version --allow-same-version; fi \
  && npm ci --legacy-peer-deps --omit=dev


### PR DESCRIPTION
The Dockerfile lint job now runs hadolint 2.15.1, which rejects eight named `USER` directives (DL3066) and the dispatcher's shell-form healthcheck (DL3025).

Use UID 1000 for the seven Node services, retaining their existing `node` account, group lookup, home directory, and named COPY/chown ownership. Explicitly create the dispatcher's `python` account with UID 1000 and select that numeric UID. Convert its existing RabbitMQ TCP healthcheck to exec form, preserving the Python code and all healthcheck timing settings.

Validation:
- Reproduced all nine diagnostics with the freshly pulled CI image, `hadolint/hadolint:latest-alpine` (2.15.1), then passed the full CI-equivalent Dockerfile lint command.
- Built the changed dispatcher image; verified its non-root UID/GID and source/template readability.
- Ran the actual dispatcher image's healthcheck command against an available TCP listener and an unavailable port: exit zero and nonzero respectively.
- Compared named-user versus UID-1000 execution in all seven existing Node service images: identical UID, primary/supplementary groups, HOME, and write access to source, media, and scripts directories. These are runtime identity checks on existing images; the full Node image builds remain covered by CI.
- `git diff --check` passed.

This is a separate Docker-only change based on `stable`; it contains no quorum changes from #2158.
