### PR TITLE
fix(ci): install mailer runtime without interactive prompts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1181,7 +1181,7 @@ jobs:
           working_directory: ~/project/mailer
           command: |
             sudo apt-get update
-            sudo apt-get install elixir erlang
+            sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y elixir erlang
       - run:
           name: Setup mailer hex and rebar
           working_directory: ~/project/mailer


### PR DESCRIPTION
The `mailer-test` job times out while installing Elixir and Erlang because Ubuntu's `needrestart` asks which services to restart. Run this installation with noninteractive debconf, automatic service restarts, and apt's `-y` confirmation so the job can reach the tests unattended. The environment overrides apply after `sudo` and only to this install command.

Validation: parsed the full CircleCI YAML, checked the extracted command with `bash -n`, verified the intended arguments, confirmed every other parsed configuration value is unchanged, and passed `git diff --check`. Live [CircleCI mailer-test job 45182](https://app.circleci.com/pipelines/github/AEGEE/MyAEGEE/jobs/45182) passed: installation completed unattended and the existing suite reports **41 tests, 0 failures**, with 71.1% total mailer coverage.

Based on `stable`; independent of the quorum changes in #2158.
