### PR TITLE
fix(statutory): count accepted delegates after publication

### DIFF
--- a/frontend/src/views/statutory/Stats.vue
+++ b/frontend/src/views/statutory/Stats.vue
@@ -84,7 +84,7 @@
         <div class="subtitle">Quorum</div>
         <p>
           {{ quorum.present }} of {{ quorum.total }} antennae represented by
-          {{ stats.quorum.accepted_only ? 'accepted non-cancelled applications' : 'non-cancelled applications' }}.
+          {{ stats.quorum.accepted_only ? 'accepted non-cancelled delegate applications' : 'non-cancelled applications' }}.
           Required: {{ quorum.required }} (50%).
         </p>
         <pie-chart class="chart" :chart-data="byQuorumData" :options="byQuorumOptions" />

--- a/statutory/lib/quorum.js
+++ b/statutory/lib/quorum.js
@@ -3,7 +3,7 @@
 module.exports = (applications, event, now = Date.now()) => {
     const acceptedOnly = now >= new Date(event.participants_list_publish_deadline).getTime();
     const represented = applications.filter((application) => !application.cancelled
-        && (!acceptedOnly || application.status === 'accepted'));
+        && (!acceptedOnly || (application.status === 'accepted' && application.participant_type === 'delegate')));
 
     return {
         accepted_only: acceptedOnly,

--- a/statutory/test/unit/quorum.test.js
+++ b/statutory/test/unit/quorum.test.js
@@ -4,21 +4,25 @@ describe('Quorum representation', () => {
     const deadline = Date.parse('2026-09-10T12:00:00Z');
     const event = { participants_list_publish_deadline: '2026-09-10T14:00:00+02:00' };
     const applications = [
-        { body_id: 1, status: 'accepted', cancelled: false },
-        { body_id: 1, status: 'accepted', cancelled: false },
-        { body_id: 2, status: 'pending', cancelled: false },
-        { body_id: 3, status: 'rejected', cancelled: false },
-        { body_id: 4, status: 'waiting_list', cancelled: false },
-        { body_id: 5, status: 'accepted', cancelled: true }
+        { body_id: 1, status: 'accepted', cancelled: false, participant_type: 'delegate' },
+        { body_id: 1, status: 'accepted', cancelled: false, participant_type: 'delegate' },
+        { body_id: 2, status: 'pending', cancelled: false, participant_type: 'delegate' },
+        { body_id: 3, status: 'rejected', cancelled: false, participant_type: 'delegate' },
+        { body_id: 4, status: 'waiting_list', cancelled: false, participant_type: 'delegate' },
+        { body_id: 5, status: 'accepted', cancelled: true, participant_type: 'delegate' },
+        { body_id: 6, status: 'accepted', cancelled: false, participant_type: 'observer' },
+        { body_id: 7, status: 'accepted', cancelled: false, participant_type: 'envoy' },
+        { body_id: 8, status: 'accepted', cancelled: false, participant_type: 'visitor' },
+        { body_id: 9, status: 'accepted', cancelled: false, participant_type: null }
     ];
 
     test('counts each body with non-cancelled applications once before publication', () => {
         expect(getQuorumStats(applications, event, deadline - 1)).toEqual({
-            accepted_only: false, body_ids: [1, 2, 3, 4]
+            accepted_only: false, body_ids: [1, 2, 3, 4, 6, 7, 8, 9]
         });
     });
 
-    test.each([0, 1])('counts only accepted non-cancelled applications at/after publication (%i ms)', (offset) => {
+    test.each([0, 1])('counts only accepted non-cancelled delegates at/after publication (%i ms)', (offset) => {
         expect(getQuorumStats(applications, event, deadline + offset)).toEqual({
             accepted_only: true, body_ids: [1]
         });


### PR DESCRIPTION
After the participant-list publication deadline, quorum representation previously counted any accepted, non-cancelled applicant. Require participant_type = delegate as well, so accepted observers, envoys, visitors, and applications with no participant type do not represent an antenna.

Before the deadline, continue counting all non-cancelled applications. The exact publication timestamp starts the delegate-only rule. Update the statistics label to describe the new basis; antenna-only counting, the 50% requirement, and omission of a quorum verdict remain unchanged.

Validation: all 8 quorum tests passed, covering participant types, cancellation, deduplication, publication boundaries, default server time, and empty results. The quorum helper has full statement, function, and branch coverage. ESLint passed for the changed backend/test and Vue files; git diff --check passed. Full API/browser tests were not run locally.
